### PR TITLE
Make the language we use a little more mature/professional

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -38,7 +38,7 @@ local function player_created(event)
     player.insert {name = 'coin', count = 10}
     player.insert {name = 'iron-gear-wheel', count = 8}
     player.insert {name = 'iron-plate', count = 16}
-    player.print('Welcome to our Server. You can join our Discord at: redmew.com/discord')
+    player.print('Welcome to our Server. You can join our Discord at: redmew.com/discord or check out our patreon at patron.com/redmew')
     player.print('And remember.. Keep Calm And Spaghetti!')
 
     local gui = player.gui
@@ -131,9 +131,13 @@ local function hodor(event)
         return
     end
 
-    if message:match('discord') then
+    if message:match('discord') and not game.player.admin then
         player.print('Did you ask about our discord server?')
         player.print('You can find it here: redmew.com/discord')
+    end
+    if message:match('patreon') and not game.player.admin then
+        player.print('Did you ask about our patreon?')
+        player.print('You can find it here: patreon.com/redmew')
     end
 
     if global.naughty_words_enabled then

--- a/control.lua
+++ b/control.lua
@@ -131,6 +131,16 @@ local function hodor(event)
         return
     end
 
+    -- Remove next 2 blocks August 17th, 2018
+    if message:match('discord') and game.player.admin then
+        player.print('Did you ask about our discord server?')
+        player.print('You can find it here: redmew.com/discord (This message will no longer print for admins after August 17th)')
+    end
+    if message:match('discord') and game.player.admin then
+        player.print('Did you ask about our discord server?')
+        player.print('You can find it here: redmew.com/discord (This message will no longer print for admins after August 17th)')
+    end
+    
     if message:match('discord') and not game.player.admin then
         player.print('Did you ask about our discord server?')
         player.print('You can find it here: redmew.com/discord')

--- a/info.lua
+++ b/info.lua
@@ -26,12 +26,13 @@ Hi stranger, I'm a fish..
 And this is what you ought to know:
 
 - Please be nice and don't grief. Or else.. ;)
-- Admins: Don't abuse. Don't fight other Admins.
+- If you suspect griefing, whisper an admin.
 - Don't argue with other players for silly things.
+- If arguing, do not make the arguments personal.
 - No political, racist, or hateful content.
 - If you suspect you desync, restart the game.
-- Join our growing community on redmew.com/discord
-- Contribute to our Hookers & Blow fund at:
+- Join our discord at redmew.com/discord
+- Supporting the server costs:
   Patreon: patreon.com/redmew
   Paypal: paypal.me/jsuesse
 ]===]


### PR DESCRIPTION
We don't want to lose the quirk/silliness we have, but if we want patrons/donations it might be better to not call it a hooker+blow fund.

Instructing admins not to cheat or in-fight implies a problem so big that it needs to be addressed publicly. (Which might be the case, but our users don't need to know that)

Make admins immune to the patreon/discord spam. More just quality of life for admins since we talk about discord a lot without actually needing the link ourselves.