### PR TITLE
bug fixes

### DIFF
--- a/report.lua
+++ b/report.lua
@@ -20,10 +20,7 @@ local function draw_report(parent, report_id)
     local time_ago = Utils.format_time(game.tick - report.tick)
 
     local message = report.message
-    for _,child in pairs(parent.children) do
-        Gui.remove_data_recursivly(child)
-        child.destroy() 
-    end
+    Gui.clear(parent)
 
     parent.add {type="label", caption="Offender: " .. reported_player_name} 
     local msg_label_pane = parent.add {type="scroll-pane", vertical_scroll_policy = "auto-and-reserve-space", horizontal_scroll_policy="never"}
@@ -38,11 +35,7 @@ end
 local function show_reports(player)
     local reports = global.reports or {}
 
-    local center = player.gui.center
-    if player.opened then --Destroy whatever is open
-        Gui.remove_data_recursivly(player.opened)
-        player.opened.destroy()
-    end
+    local center = player.gui.center    
   
     local report_frame = center.add {
         type = 'frame',
@@ -68,7 +61,9 @@ local function show_reports(player)
     local report_body = report_frame.add {type = "scroll-pane", name = report_body_name, horizontal_scroll_policy = "never", vertical_scroll_policy="never"}
     report_frame.add {type = 'button', name = report_close_button_name, caption = 'Close'}
 
-    draw_report(report_body, #reports)
+    if #reports > 0 then
+        draw_report(report_body, #reports)
+    end
 end
 
 local function report(reporting_player, reported_player, message)
@@ -125,11 +120,7 @@ local reporting_input_name = Gui.uid_name()
 
 Module.spawn_reporting_popup = function(player, reported_player)
 
-    local center = player.gui.center
-    if player.opened then --Destroy whatever is open
-        Gui.remove_data_recursivly(player.opened)
-        player.opened.destroy()
-    end
+    local center = player.gui.center    
   
     local reporting_popup = center.add {
         type = 'frame',


### PR DESCRIPTION
Not a bug fix but
```lua
for _,child in pairs(parent.children) do
        Gui.remove_data_recursivly(child)
        child.destroy() 
end
```
is the same functionality as `Gui.Clear(parent)`

line 64 - 66
Missing check for when /showreports is called but there are no reports to show

Removed lines 42 - 45
```lua
if player.opened then --Destroy whatever is open
    Gui.remove_data_recursivly(player.opened)
    player.opened.destroy()
end
```
This throws an error if you have an entity opened (e.g looking inside a chest).
I get what you are trying to do, close an open guiElement if one is already opened. But `player.opened` can return an entity, equipment or element, so you you would have to check the type first using `player.opened_gui_type`. 
However, you don't need to explicitly close opened elements like this, when `player.opened` is changed to something else the `on_gui_closed` event is called with the old element. For native game elements they are obviously closed correctly, for custom elements you have to close them explicitly. As long as all custom elements do that, which I find best done in `Gui.on_custom_close` (like the reports elements do) then all is good. 
So short version you should just remove this code. When `player.opened = report_frame` is called a few lines down whatever element used to be opened will be closed correctly.

Removed lines 129-132
Same reason as above