### PR TITLE
added donator to list

### DIFF
--- a/resources/donators.lua
+++ b/resources/donators.lua
@@ -1,4 +1,5 @@
 return {
     ['robertkruijt'] = true,
     ['aldldl'] = true
+    ['Geostyx'] = true
 }

--- a/resources/donators.lua
+++ b/resources/donators.lua
@@ -2,4 +2,5 @@ return {
     ['robertkruijt'] = true,
     ['aldldl'] = true
     ['Geostyx'] = true
+    ['Everyone'] = true
 }

--- a/resources/regulars.lua
+++ b/resources/regulars.lua
@@ -717,4 +717,6 @@ return {
     ['henrycn1997'] = true,
     ['iop77'] = true,
     ['Hayse'] = true
+    ['Geostyx'] = true
+    ['Everyone'] = true
 }


### PR DESCRIPTION
title.

in the future, we should consider implementing a `/donator add [username]` command to add new patreons in real time, rather than inbetween map resets. Not sure how this would affect the other perks we currently advertise on patreon (extra coins, welcome message and train invincibility) that are given ingame.  