### PR TITLE
Fixed spilled loot performance when rocks die

### DIFF
--- a/map_gen/Diggy/Feature/DiggyHole.lua
+++ b/map_gen/Diggy/Feature/DiggyHole.lua
@@ -81,7 +81,24 @@ end
 ]]
 function DiggyHole.register(config)
     Event.add(defines.events.on_entity_died, function (event)
-        diggy_hole(event.entity)
+        local entity = event.entity
+        diggy_hole(entity)
+
+        local position = entity.position
+        local surface = entity.surface
+
+        -- fixes massive frame drops when too much stone is spilled
+        local stones = surface.find_entities_filtered({
+            area = {{position.x - 1, position.y - 1}, {position.x + 1, position.y + 1}},
+            limit = 20,
+            type = 'item-entity',
+            name = 'item-on-ground',
+        })
+        for _, stone in ipairs(stones) do
+            if (stone.stack.name == 'stone') then
+                stone.destroy()
+            end
+        end
     end)
 
     Event.add(defines.events.on_player_mined_entity, function (event)


### PR DESCRIPTION
Fixes it by deleting all stone around it up to 20. Only triggers on death of a rock as mining doesn't really suffer from it and can be easily avoided. Reduces the costs of lookups per tick.

See #229 