### PR TITLE
Reduced biter spawn cache footprint and digging increases evo

### DIFF
--- a/map_gen/Diggy/AlienEvolutionProgress.lua
+++ b/map_gen/Diggy/AlienEvolutionProgress.lua
@@ -6,13 +6,20 @@
 -- dependencies
 local Global = require 'utils.global'
 local random = math.random
+local round = math.round
 
 -- this
 local AlienEvolutionProgress = {}
 
 local alien_cache = {
-    biters = {},
-    spitters = {},
+    biters = {
+        evolution = -1,
+        cache = {},
+    },
+    spitters = {
+        evolution = -1,
+        cache = {},
+    },
 }
 
 Global.register({
@@ -96,23 +103,25 @@ local function get_name_by_random(collection)
 end
 
 function AlienEvolutionProgress.getBiterValues(evolution)
-    local evolution_cache_key = evolution * 100
+    local evolution_value = round(evolution * 100)
 
-    if (nil == alien_cache.biters[evolution_cache_key]) then
-        alien_cache.biters[evolution_cache_key] = get_values(biters, evolution)
+    if (alien_cache.biters.evolution < evolution_value) then
+        alien_cache.biters.evolution = evolution_value
+        alien_cache.biters.cache = get_values(biters, evolution)
     end
 
-    return alien_cache.biters[evolution_cache_key]
+    return alien_cache.biters.cache
 end
 
 function AlienEvolutionProgress.getSpitterValues(evolution)
-    local evolution_cache_key = evolution * 100
+    local evolution_value = round(evolution * 100)
 
-    if (nil == alien_cache.spitters[evolution_cache_key]) then
-        alien_cache.spitters[evolution_cache_key] = get_values(spitters, evolution)
+    if (alien_cache.spitters.evolution < evolution_value) then
+        alien_cache.spitters.evolution = evolution_value
+        alien_cache.spitters.cache = get_values(spitters, evolution)
     end
 
-    return alien_cache.spitters[evolution_cache_key]
+    return alien_cache.spitters.cache
 end
 
 function AlienEvolutionProgress.getBitersByEvolution(total_biters, evolution)

--- a/map_gen/Diggy/Feature/AlienSpawner.lua
+++ b/map_gen/Diggy/Feature/AlienSpawner.lua
@@ -38,6 +38,8 @@ function AlienSpawner.register(config)
     local alien_minimum_distance_square = config.alien_minimum_distance ^ 2
 
     Event.add(Template.events.on_void_removed, function(event)
+        game.forces.enemy.evolution_factor = game.forces.enemy.evolution_factor + 0.0000008
+
         local x = event.old_tile.position.x
         local y = event.old_tile.position.y
 


### PR DESCRIPTION
Opening 100x100 tiles would mean 0.8% evolution increase. Is this a correct value? I feel like this would scale a lot less aggressive than the settings we had for the first open run.

I've also fixed the cache to only store the last evolution factor, but this only works if evolution increases, never decreases. This should fix a "memory leak" when spawning biters as evolution values were a float but never rounded. This meant that it was stored uniquely anyway.

See #229