### PR TITLE
Balance changes and fixes based on the second play

### DIFF
--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -26,10 +26,14 @@ local Config = {
             cheats = {
                 manual_mining_speed_modifier = 1000,
                 character_inventory_slots_bonus = 1000,
+                character_running_speed_modifier = 2,
             },
         },
         DiggyHole = {
             enabled = true,
+
+            -- enables commands like /clear-void
+            enable_debug_commands = false,
         },
         DiggyCaveCollapse = {
             enabled = true,
@@ -71,6 +75,7 @@ local Config = {
             cracking_sounds = {
               'CRACK',
               'KRRRR',
+              'R U N',
             }
         },
         RefreshMap = {
@@ -102,25 +107,25 @@ local Config = {
 
             -- defines the increased chance of spawning resources
             -- calculated_probability = resource_probability + ((distance / distance_probability_modifier) / 100)
-            distance_probability_modifier = 1.5,
+            distance_probability_modifier = 10,
 
             -- increases the amount of oil * oil_value_modifier
             oil_value_modifier = 750,
 
-            -- percentage of chance that resources will spawn after mining
-            resource_probability = 0.1,
+            -- min percentage of chance that resources will spawn after mining
+            resource_probability = 0.01,
 
             -- max chance of spawning resources based on resource_probability + calculated distance_probability_modifier
-            max_resource_probability = 0.4,
+            max_resource_probability = 0.30,
 
             -- chances per resource of spawning, sum must be 1.00
             resource_chances = {
-                ['coal']        = 0.171,
-                ['copper-ore']  = 0.221,
-                ['iron-ore']    = 0.381,
-                ['stone']       = 0.201,
+                ['coal']        = 0.16,
+                ['copper-ore']  = 0.215,
+                ['iron-ore']    = 0.389,
+                ['stone']       = 0.212,
                 ['uranium-ore'] = 0.021,
-                ['crude-oil']   = 0.005,
+                ['crude-oil']   = 0.003,
             },
 
             -- minimum distance from the spawn point required before it spawns
@@ -135,12 +140,12 @@ local Config = {
 
             -- defines the chance of which resource_richness_value to spawn, sum must be 1.00
             resource_richness_probability = {
-                ['scarce']     = 0.40,
-                ['low']        = 0.28,
-                ['sufficient'] = 0.16,
-                ['good']       = 0.10,
-                ['plenty']     = 0.04,
-                ['jackpot']    = 0.02,
+                ['scarce']     = 0.44,
+                ['low']        = 0.35,
+                ['sufficient'] = 0.164,
+                ['good']       = 0.03,
+                ['plenty']     = 0.01,
+                ['jackpot']    = 0.006,
             },
 
             -- defines the min and max range of ores to spawn
@@ -166,7 +171,7 @@ local Config = {
             enabled = true,
 
             -- percentage * mining productivity level gets added to mining speed
-            mining_speed_productivity_multiplier = 10,
+            mining_speed_productivity_multiplier = 5,
 
             -- market config
             market_spawn_position = {x = 0, y = 3},
@@ -200,7 +205,9 @@ local Config = {
                 {stone = 450, type = 'buff', prototype = {name = 'inventory_slot', value = 2}},
                 {stone = 450, type = 'buff', prototype = {name = 'stone_automation', value = 5}},
                 {stone = 450, type = 'market', prototype = {price = 850, name = 'submachine-gun'}},
+                {stone = 450, type = 'market', prototype = {price = 850, name = 'shotgun'}},
                 {stone = 450, type = 'market', prototype = {price = 50, name = 'firearm-magazine'}},
+                {stone = 450, type = 'market', prototype = {price = 50, name = 'shotgun-shell'}},
                 {stone = 450, type = 'market', prototype = {price = 500, name = 'light-armor'}},
 
                 {stone = 750, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
@@ -236,110 +243,156 @@ local Config = {
                 {stone = 10000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
                 {stone = 10000, type = 'market', prototype = {price = 750, name = 'heavy-armor'}},
 
-                {stone = 15000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 15000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 15000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
-                {stone = 25000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 25000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 25000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
                 {stone = 25000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 35000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 35000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 35000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 35000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
                 {stone = 35000, type = 'market', prototype = {price = 100, name = 'piercing-rounds-magazine'}},
+                {stone = 35000, type = 'market', prototype = {price = 100, name = 'piercing-shotgun-shell'}},
                 {stone = 35000, type = 'market', prototype = {price = 1500, name = 'modular-armor'}},
 
-                {stone = 50000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 50000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 50000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 50000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 75000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 75000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 75000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 75000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 100000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 100000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 100000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 100000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 125000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 125000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 125000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 125000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 150000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 150000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 150000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 150000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 175000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 175000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 175000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 175000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 200000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 200000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 200000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 200000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 225000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 225000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 225000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 225000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 250000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 250000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 250000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 250000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 275000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 275000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 275000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 275000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 300000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 300000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 300000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 300000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 350000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 350000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 350000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
-                {stone = 2500, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 350000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 400000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 400000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 400000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 400000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 500000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 500000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 500000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 500000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 600000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 600000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 600000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 600000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 700000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 700000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 700000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 700000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
 
-                {stone = 800000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 800000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 800000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
                 {stone = 800000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
                 {stone = 800000, type = 'market', prototype = {price = 250, name = 'uranium-rounds-magazine'}},
+                {stone = 800000, type = 'market', prototype = {price = 1000, name = 'combat-shotgun'}},
 
-                {stone = 900000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 900000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 900000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 900000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 1000000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 1000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 1000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 1000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 1250000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 1250000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 1250000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 1250000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 1500000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 1500000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 1500000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 1500000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 1750000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 1750000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 1750000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 1750000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 2000000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 2000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 2000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 2000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 2500000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 2500000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 2500000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 2500000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
 
-                {stone = 3000000, type = 'buff', prototype = {name = 'mining_speed', value = 2}},
+                {stone = 3000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
                 {stone = 3000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 3000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 3500000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 3500000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 3500000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 4000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 4000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 4000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 4500000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 4500000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 4500000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 5000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 5000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 5000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 6000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 6000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 6000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 7000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 7000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 7000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 8000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 8000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 8000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 9000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 9000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 9000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
+
+                {stone = 10000000, type = 'buff', prototype = {name = 'mining_speed', value = 5}},
+                {stone = 10000000, type = 'buff', prototype = {name = 'stone_automation', value = 2}},
+                {stone = 10000000, type = 'buff', prototype = {name = 'inventory_slot', value = 1}},
             },
         },
     },

--- a/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
+++ b/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
@@ -148,15 +148,17 @@ local function spawn_cracking_sound_text(surface, position)
         b = 0
     }
 
+    local create_entity = surface.create_entity
+
     for i = 1, #text do
         local x_offset = (i - #text / 2 - 1) / 3
         local char = text:sub(i, i)
-        surface.create_entity {
-                name = 'flying-text',
-                color = color,
-                text = char,
-                position = {x = position.x + x_offset, y = position.y - ((i + 1) % 2) / 4}
-            }.active = true
+        create_entity {
+            name = 'flying-text',
+            color = color,
+            text = char,
+            position = {x = position.x + x_offset, y = position.y - ((i + 1) % 2) / 4}
+        }.active = true
     end
 end
 
@@ -184,7 +186,6 @@ end
 
 local function on_built_tile(surface, new_tile, tiles)
     local new_tile_strength = support_beam_entities[new_tile.name]
-
 
     for _, tile in pairs(tiles) do
         if new_tile_strength then
@@ -414,7 +415,7 @@ end
 
     @return number sum of old fraction + new fraction
 ]]
-function add_fraction(stress_map, x, y, fraction)
+local function add_fraction(stress_map, x, y, fraction)
     x = 2 * floor(x / 2)
     y = 2 * floor(y / 2)
 

--- a/map_gen/Diggy/Feature/MarketExchange.lua
+++ b/map_gen/Diggy/Feature/MarketExchange.lua
@@ -343,7 +343,7 @@ function MarketExchange.register(cfg)
     Event.on_nth_tick(config.void_chest_frequency, function ()
         local send_to_surface = 0
         local find_entities_filtered = game.surfaces.nauvis.find_entities_filtered
-        local chests = find_entities_filtered({area = area, type = {'container', 'logistics-container'}})
+        local chests = find_entities_filtered({area = area, type = {'container', 'logistic-container'}})
         local to_fetch = stone_collecting.active_modifier
 
         for _, chest in pairs(chests) do

--- a/map_gen/Diggy/Feature/ScatteredResources.lua
+++ b/map_gen/Diggy/Feature/ScatteredResources.lua
@@ -76,7 +76,7 @@ function ScatteredResources.register(config)
 
         local distance = floor(sqrt(x^2 + y^2))
         local calculated_probability = config.resource_probability + ((distance / config.distance_probability_modifier) / 100)
-        local probability = 0.7
+        local probability = config.max_resource_probability
 
         if (calculated_probability < probability) then
             probability = calculated_probability

--- a/map_gen/Diggy/Feature/SetupPlayer.lua
+++ b/map_gen/Diggy/Feature/SetupPlayer.lua
@@ -39,6 +39,7 @@ function SetupPlayer.register(config)
         Debug.cheat(function()
             player.force.manual_mining_speed_modifier = config.cheats.manual_mining_speed_modifier
             player.force.character_inventory_slots_bonus = config.cheats.character_inventory_slots_bonus
+            player.character_running_speed_modifier = config.cheats.character_running_speed_modifier
         end)
     end)
 end

--- a/map_gen/Diggy/Feature/StartingZone.lua
+++ b/map_gen/Diggy/Feature/StartingZone.lua
@@ -24,6 +24,7 @@ function StartingZone.register(config)
 
     local function on_chunk_generated(event)
         local start_point_area = {{-0.9, -0.9}, {0.9, 0.9}}
+        local start_point_cleanup = {{-0.9, -0.9}, {1.9, 1.9}}
         local surface = event.surface
 
         -- hack to figure out whether the important chunks are generated via Diggy.Feature.RefreshMap.
@@ -32,7 +33,7 @@ function StartingZone.register(config)
         end
 
         -- ensure a clean starting point
-        for _, entity in pairs(surface.find_entities_filtered({area = start_point_area, type = 'resource'})) do
+        for _, entity in pairs(surface.find_entities_filtered({area = start_point_cleanup, type = 'resource'})) do
             entity.destroy()
         end
 
@@ -81,6 +82,8 @@ function StartingZone.on_init()
 
     surface.daytime = 0.5
     surface.freeze_daytime = 1
+    -- base factorio =                pollution_factor = 0.000015
+    game.map_settings.enemy_evolution.pollution_factor = 0.000002
 end
 
 


### PR DESCRIPTION
This contains a list of small fixes based on the previous run. The bigger things I will create a new issue for.

Changelog
 - Speed modifier in cheats
 - `/clear-void` command to open a big portion of void
 - Fixed a bug causing 70% instead of intended max resource density
 - Greatly reduced min and max ore density
 - Overall lowered resource spawn
 - Added a shotgun in the market
 - Added more market rewards
 - Fixed a bug causing the log to fill with errors, removed the offending dead code
 - Mining speed from the market is now 5 instead of 2 for the majority
 - Mining speed from mining productivity is now 5 per level instead of 10
 - Reduced pollution evolution factor by x15
 - Fixed the bug causing only 1/4th of the starting position to be cleared of resources
