### PR TITLE
Reduce cave opening frame drops

### DIFF
--- a/map_gen/Diggy/Feature/DiggyHole.lua
+++ b/map_gen/Diggy/Feature/DiggyHole.lua
@@ -76,8 +76,8 @@ function DiggyHole.register(config)
 
         -- fixes massive frame drops when too much stone is spilled
         local stones = surface.find_entities_filtered({
-            area = {{position.x - 1, position.y - 1}, {position.x + 1, position.y + 1}},
-            limit = 20,
+            area = {{position.x - 2, position.y - 2}, {position.x + 2, position.y + 2}},
+            limit = 60,
             type = 'item-entity',
             name = 'item-on-ground',
         })


### PR DESCRIPTION
By increase the size, the amount of stones is greatly reduced and there is most likely _always_ space, meaning that opening a cave automatically wouldn't cause massive frame drops anymore. Performance isn't really impacted by the lookup as it happens spread over ticks.

![image](https://user-images.githubusercontent.com/1754678/48084500-2d1fd500-e1f8-11e8-96c4-16d2dea5b517.png)
