### PR TITLE
Added scrolling text popups and UX for market chests

### DIFF
--- a/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
+++ b/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
@@ -10,6 +10,7 @@ local Debug = require 'map_gen.Diggy.Debug'
 local Task = require 'utils.Task'
 local Token = require 'utils.global_token'
 local Global = require 'utils.global'
+local Game = require 'utils.game'
 local insert = table.insert
 local random = math.random
 local floor = math.floor
@@ -308,18 +309,19 @@ function DiggyCaveCollapse.register(cfg)
 
     Event.add(defines.events.on_marked_for_deconstruction, function (event)
         if (nil ~= support_beam_entities[event.entity.name]) then
-            event.entity.cancel_deconstruction(game.players[event.player_index].force)
+            event.entity.cancel_deconstruction(Game.get_player_by_index(event.player_index).force)
         end
     end)
 
     Event.add(defines.events.on_pre_player_mined_item, function(event)
-        if (nil ~= deconstruction_alert_message_shown[event.player_index]) then
+        local player_index = event.player_index
+        if (nil ~= deconstruction_alert_message_shown[player_index]) then
             return
         end
 
         if (nil ~= support_beam_entities[event.entity.name]) then
             require 'popup'.player(
-                game.players[event.player_index],[[
+                Game.get_player_by_index(player_index),[[
 Mining entities such as walls, stone paths, concrete
 and rocks, can cause a cave-in, be careful miner!
 
@@ -328,7 +330,7 @@ prevent a cave-in. Use stone paths and concrete
 to reinforce it further.
 ]]
             )
-            deconstruction_alert_message_shown[event.player_index] = true
+            deconstruction_alert_message_shown[player_index] = true
         end
     end)
 

--- a/map_gen/Diggy/Feature/SetupPlayer.lua
+++ b/map_gen/Diggy/Feature/SetupPlayer.lua
@@ -5,6 +5,7 @@
 -- dependencies
 local Event = require 'utils.event'
 local Debug = require 'map_gen.Diggy.Debug'
+local Game = require 'utils.game'
 
 -- this
 local SetupPlayer = {}
@@ -13,13 +14,12 @@ global.SetupPlayer = {
     first_player_spawned = false,
 }
 
-
 --[[--
     Registers all event handlers.
 ]]
 function SetupPlayer.register(config)
     Event.add(defines.events.on_player_created, function (event)
-        local player = game.players[event.player_index]
+        local player = Game.get_player_by_index(event.player_index)
         local position = {0, 0}
         local surface = player.surface
 

--- a/utils/game.lua
+++ b/utils/game.lua
@@ -1,4 +1,5 @@
 local Global = require 'utils.global'
+local random = math.random
 
 local Game = {}
 
@@ -37,6 +38,45 @@ function Game.get_player_by_index(index)
             return v
         end
     end
+end
+
+--[[
+    @param Position String to display at
+    @param text String to display
+    @param color table in {r = 0~1, g = 0~1, b = 0~1}, defaults to white.
+    @param surface LuaSurface
+
+    @return the created entity
+]]
+function Game.print_floating_text(surface, position, text, color)
+    color = color or {r = 1, g = 1, b = 1}
+
+    return surface.create_entity {
+        name = 'tutorial-flying-text',
+        color = color,
+        text = text,
+        position = position,
+    }
+end
+
+--[[
+    Creates a floating text entity at the player location with the specified color in {r, g, b} format.
+
+    Example: "+10 iron" or "-10 coins"
+
+    @param text String to display
+    @param color table in {r = 0~1, g = 0~1, b = 0~1}, defaults to white.
+
+    @return the created entity
+]]
+function Game.print_player_floating_text(player_index, text, color)
+    local player = Game.get_player_by_index(player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    local position = player.position
+    return Game.print_floating_text(player.surface, {x = position.x, y = position.y - 1.5}, text, color)
 end
 
 return Game


### PR DESCRIPTION
When no stone will be send to the surface (when no stones have been handed in yet), nothing will be displayed, otherwise this will start appearing
![image](https://user-images.githubusercontent.com/1754678/48092374-c822aa00-e20c-11e8-88fe-5876f9b2b62b.png)

If there's no stone in the market, this message will appear
![image](https://user-images.githubusercontent.com/1754678/48092381-cbb63100-e20c-11e8-8b23-863805cbdb05.png)

If stone is sent, this message will appear
![image](https://user-images.githubusercontent.com/1754678/48092385-cf49b800-e20c-11e8-9019-f9ecb15cc03f.png)

This message appears when the player sends stone to the surface via the market
![image](https://user-images.githubusercontent.com/1754678/48092390-d244a880-e20c-11e8-91ed-18ead238d89d.png)
