### PR TITLE
Add scenario info for crashsite

### DIFF
--- a/map_gen/presets/crash_site.lua
+++ b/map_gen/presets/crash_site.lua
@@ -8,6 +8,12 @@ local Random = require 'map_gen.shared.random'
 local OutpostBuilder = require 'map_gen.presets.crash_site.outpost_builder'
 local math = require "utils.math"
 local degrees = math.degrees
+local ScenarioInfo = require 'info'
+
+-- Comment out this block if you're getting scenario info from another source.
+ScenarioInfo.set_map_name('Crashsite')
+ScenarioInfo.set_map_description('Capture outposts and defend against the biters.')
+ScenarioInfo.set_map_extra_info('- Outposts have enemy turrets defending them.\n- Outposts have loot and provide a steady stream of resources.\n- Outpost markets with different resources and at prices.\n- Capturing outposts increases evolution.\n- Reduced damage by all player weapons, turrets, and ammo.\n- Biters have more health and deal more damage.')
 
 -- leave seeds nil to have them filled in based on teh map seed.
 local outpost_seed = nil --91000


### PR DESCRIPTION
Crash site has a lot of unique mechanics and features, having those featured listed automatically would be especially helpful since we can go through multiple maps daily when the players wipe.