### PR TITLE
Night time and solar panel popup

### DIFF
--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -18,6 +18,11 @@ local Config = {
             -- initial starting position size, higher values are not recommended
             starting_size = 8,
         },
+        
+        -- controls the Daylight (Default diggy: enabled = true)
+        NightTime = {
+            enabled = true, -- true = No Daylight, false = Day/night circle (Solar panels work)
+        },
 
         -- controls setting up the players
         SetupPlayer = {

--- a/map_gen/Diggy/Feature/NightTime.lua
+++ b/map_gen/Diggy/Feature/NightTime.lua
@@ -27,13 +27,13 @@ satellites
 end
 
 local function on_research_finished(event)
-    local force = game.forces.player
+    local force = event.research.force
     force.recipes["solar-panel-equipment"].enabled=false
 end
 
 function NightTime.register(config)
-        Event.add(defines.events.on_built_entity, on_built_entity)
-        Event.add(defines.events.on_research_finished, on_research_finished)
+    Event.add(defines.events.on_built_entity, on_built_entity)
+    Event.add(defines.events.on_research_finished, on_research_finished)
 end
 
 function NightTime.on_init()

--- a/map_gen/Diggy/Feature/NightTime.lua
+++ b/map_gen/Diggy/Feature/NightTime.lua
@@ -1,0 +1,46 @@
+--[[-- info
+    Provides the ability to inform players that solar panels doesn't work underground
+]]
+
+-- dependencies
+local Event = require 'utils.event'
+local Game = require 'utils.game'
+
+-- this
+local NightTime = {}
+
+local function on_built_entity(event)
+    local player = Game.get_player_by_index(event.player_index)
+    local entity = event.created_entity
+    if (entity.name == 'solar-panel') then
+        require 'popup'.player(
+            player,[[
+Placing solar panels underground does not seem
+to have an effect on power production!
+Studies show, that the same applies to the portable version!
+
+Foreman's advice: Solar Panels are only useful in crafting
+satellites
+]]
+        )
+    end
+end
+
+local function on_research_finished(event)
+    local force = game.forces.player
+    force.recipes["solar-panel-equipment"].enabled=false
+end
+
+function NightTime.register(config)
+        Event.add(defines.events.on_built_entity, on_built_entity)
+        Event.add(defines.events.on_research_finished, on_research_finished)
+end
+
+function NightTime.on_init()
+    local surface = game.surfaces.nauvis
+    
+    surface.daytime = 0.5
+    surface.freeze_daytime = 1
+end
+
+return NightTime

--- a/map_gen/Diggy/Feature/StartingZone.lua
+++ b/map_gen/Diggy/Feature/StartingZone.lua
@@ -77,12 +77,5 @@ function StartingZone.register(config)
     Event.add_removable(defines.events.on_chunk_generated, callback_token)
 end
 
-function StartingZone.on_init()
-    local surface = game.surfaces.nauvis
-
-    surface.daytime = 0.5
-    surface.freeze_daytime = 1
-end
-
 
 return StartingZone


### PR DESCRIPTION
Split the time assignment into a new file NightTime.lua allowing for it to be disabled. (Restore normal day/night cycle)

Also added a popup when a player places a solar panel informing that they are purely cosmetic

Removed the recipe for portable solar panels because they are useless, but the technology is needed.

The popup is shown every time a solar panel is placed. <--- (Up for discussion)

No desyncs with toggle-heavy-mode

closes #284 