### PR TITLE
Force diggy biters to spawn, even if there's no space

### DIFF
--- a/map_gen/Diggy/Feature/AlienSpawner.lua
+++ b/map_gen/Diggy/Feature/AlienSpawner.lua
@@ -28,7 +28,7 @@ local function spawn_alien(surface, x, y)
         insert(units, {name = name, position = position, force = enemy_force, amount = amount})
     end
 
-    Template.units(surface, units, 3)
+    Template.units(surface, units, 1.5, 'small-biter')
 end
 
 --[[--

--- a/map_gen/Diggy/Template.lua
+++ b/map_gen/Diggy/Template.lua
@@ -148,19 +148,26 @@ end
     @param surface LuaSurface to put the tiles and entities on
     @param units table of entities as required by create_entity
     @param non_colliding_distance int amount of tiles to scan around original position in case it's already taken
+    @param generic_unit_name_for_spawn_size String allows setting a custom unit name for spawn size, will overwrite the actual
 ]]
-function Template.units(surface, units, non_colliding_distance)
+function Template.units(surface, units, non_colliding_distance, generic_unit_name_for_spawn_size)
     non_colliding_distance = non_colliding_distance or 1
+    generic_unit_name_for_spawn_size = generic_unit_name_for_spawn_size or 'player'
+
     local create_entity = surface.create_entity
-    local find_non_colliding_position = surface.find_non_colliding_position
+    local position
 
     for _, entity in pairs(units) do
-        local position = find_non_colliding_position(entity.name, entity.position, non_colliding_distance, 1)
+        position = position or surface.find_non_colliding_position(
+            generic_unit_name_for_spawn_size,
+            entity.position, non_colliding_distance,
+            0.5
+        )
 
         if (nil ~= position) then
             entity.position = position
             create_entity(entity)
-        else
+        elseif (nil == create_entity(entity)) then
             Debug.print_position(entity.position, "Failed to spawn '" .. entity.name .. "'")
         end
     end


### PR DESCRIPTION
Should increase performance a bit and ensure biters/spitters are spawned inside rocks if there's no space. It's not perfect because they don't automatically start digging their way out, but this is something we can tackle at a later stage, it works decently in most scenarios and forces player action due to high level spitters.

Fixes #302 