### PR TITLE
Dev diggy stress colors

### DIFF
--- a/map_gen/Diggy/Debug.lua
+++ b/map_gen/Diggy/Debug.lua
@@ -175,6 +175,16 @@ function Debug.print_colored_grid_value(value, surface, position, scale, offset,
     local u_color = under_bound or color
     local o_color = over_bound or color
     
+    if (color_value < 0) then
+        color = u_color
+    elseif (color_value > 1) then
+        color = o_color
+    else
+        color = { r = color.r + color_value * d_color.r,
+                  g = color.g + color_value * d_color.g,
+                  b = color.b + color_value * d_color.b }
+    end
+    
     text = value
 
     if type(immutable) ~= 'boolean' then
@@ -184,16 +194,6 @@ function Debug.print_colored_grid_value(value, surface, position, scale, offset,
     if not is_string then
         offset = offset or 0
         position = {x = position.x + offset, y = position.y + offset}
-        
-        if (color_value < 0) then
-            color = u_color
-        elseif (color_value > 1) then
-            color = o_color
-        else
-            color = { r = color.r + color_value * delta_color.r,
-                      g = color.g + color_value * delta_color.g,
-                      b = color.b + color_value * delta_color.b }
-        end
 
         -- round at precision of 2
         text = floor(100 * value) * 0.01

--- a/map_gen/Diggy/Debug.lua
+++ b/map_gen/Diggy/Debug.lua
@@ -97,30 +97,103 @@ function Debug.print_grid_value(value, surface, position, scale, offset, immutab
     if type(immutable) ~= 'boolean' then
         immutable = false
     end
-
+    
     if not is_string then
         scale = scale or 1
         offset = offset or 0
         position = {x = position.x + offset, y = position.y + offset}
-		local collapse_stress = 3.57
-		local collapse_amount = value / collapse_stress
+        local r = max(1, value) / scale
+        local g = 1 - abs(value) / scale
+        local b = min(1, value) / scale
 
-        local r = 0
-        local g = 1
-        local b = 0
-		
-		if (collapse_amount > 0) then
-			r = collapse_amount
-			g = 1 - collapse_amount
-		end
-		
-		if (collapse_amount >= 1) then
-			r = 1
-			g = 1
-			b = 1
-		end
+        if (r > 0) then
+            r = 0
+        end
+
+        if (b < 0) then
+            b = 0
+        end
+
+        if (g < 0) then
+            g = 0
+        end
+
+        r = abs(r)
 
         color = { r = r, g = g, b = b}
+
+        -- round at precision of 2
+        text = floor(100 * value) * 0.01
+
+        if (0 == text) then
+            text = '0.00'
+        end
+    end
+
+    if not immutable then
+        local text_entity = surface.find_entity('flying-text', position)
+
+        if text_entity then
+            text_entity.text = text
+            text_entity.color = color
+            return
+        end
+    end
+
+    surface.create_entity{
+        name = 'flying-text',
+        color = color,
+        text = text,
+        position = position
+    }.active = false
+end
+
+--[[--
+    Prints a colored value on a location. When given a color_value and a delta_color,
+    will change the color of the text from the base to base + value * delta. This will
+    make the color of the text range from 'base_color' to 'base_color + delta_color'
+    as the color_value ranges from 0 to 1
+
+    @param value of number to be displayed
+    @param surface LuaSurface
+    @param position Position {x, y}
+    @param scale float
+    @param offset float position offset
+    @param immutable bool if immutable, only set, never do a surface lookup, values never change
+    @param color_value float How far along the range of values of colors the value is to be displayed
+    @param base_color {r,g,b} The color for the text to be if color_value is 0
+    @param delta_color {r,g,b} The amount to correct the base_color if color_value is 1
+    @param under_bound {r,g,b} The color to be used if color_value < 0
+    @param over_bound {r,g,b} The color to be used if color_value > 1
+]]
+function Debug.print_colored_grid_value(value, surface, position, scale, offset, immutable,
+        color_value, base_color, delta_color, under_bound, over_bound)
+    local is_string = type(value) == 'string'
+    -- default values:
+    local color = base_color or {r = 1, g = 1, b = 1}
+    local d_color = delta_color or {r = 0, g = 0, b = 0}
+    local u_color = under_bound or color
+    local o_color = over_bound or color
+    
+    text = value
+
+    if type(immutable) ~= 'boolean' then
+        immutable = false
+    end
+
+    if not is_string then
+        offset = offset or 0
+        position = {x = position.x + offset, y = position.y + offset}
+        
+        if (color_value < 0) then
+            color = u_color
+        elseif (color_value > 1) then
+            color = o_color
+        else
+            color = { r = color.r + color_value * delta_color.r,
+                      g = color.g + color_value * delta_color.g,
+                      b = color.b + color_value * delta_color.b }
+        end
 
         -- round at precision of 2
         text = floor(100 * value) * 0.01

--- a/map_gen/Diggy/Debug.lua
+++ b/map_gen/Diggy/Debug.lua
@@ -102,23 +102,23 @@ function Debug.print_grid_value(value, surface, position, scale, offset, immutab
         scale = scale or 1
         offset = offset or 0
         position = {x = position.x + offset, y = position.y + offset}
-        local r = max(1, value) / scale
-        local g = 1 - abs(value) / scale
-        local b = min(1, value) / scale
+		local collapse_stress = 3.57
+		local collapse_amount = value / collapse_stress
 
-        if (r > 0) then
-            r = 0
-        end
-
-        if (b < 0) then
-            b = 0
-        end
-
-        if (g < 0) then
-            g = 0
-        end
-
-        r = abs(r)
+        local r = 0
+        local g = 1
+        local b = 0
+		
+		if (collapse_amount > 0) then
+			r = collapse_amount
+			g = 1 - collapse_amount
+		end
+		
+		if (collapse_amount > 1) then
+			r = 1
+			g = 1
+			b = 1
+		end
 
         color = { r = r, g = g, b = b}
 

--- a/map_gen/Diggy/Debug.lua
+++ b/map_gen/Diggy/Debug.lua
@@ -114,7 +114,7 @@ function Debug.print_grid_value(value, surface, position, scale, offset, immutab
 			g = 1 - collapse_amount
 		end
 		
-		if (collapse_amount > 1) then
+		if (collapse_amount >= 1) then
 			r = 1
 			g = 1
 			b = 1

--- a/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
+++ b/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
@@ -467,7 +467,9 @@ local function add_fraction(stress_map, x, y, fraction)
     end
     if (enable_stress_grid) then
         local surface = game.surfaces[stress_map.surface_index]
-        Debug.print_grid_value(value, surface, {x = x, y = y}, 4, 0.5)
+        Debug.print_colored_grid_value(value, surface, {x = x, y = y}, 4, 0.5, false,
+            value / stress_threshold_causing_collapse,  {r = 0, g = 1, b = 0}, {r = 1, g = -1, b = 0},
+            {r = 0, g = 1, b = 0}, {r = 1, g = 1, b = 1})
     end
     return value
 end


### PR DESCRIPTION
Makes the stress grid much clearer to interpret, the colors go from green (at <= 0) to red (at 3.57), then turn to white when a collapse is about to occur.