### PR TITLE
Redraw stone sent to surface GUI on stone sent

### DIFF
--- a/map_gen/Diggy/Feature/MarketExchange.lua
+++ b/map_gen/Diggy/Feature/MarketExchange.lua
@@ -149,7 +149,9 @@ local function update_market_contents(market)
             })
         end
     end
-    
+
+    MarketExchange.update_gui()
+
     if (old_level < stone_tracker.current_level) then
         for _, buffs in pairs(config.buffs) do
             if (buffs.prototype.name == 'mining_speed') then
@@ -502,7 +504,7 @@ local function toggle(event)
     redraw_buff(data)
 
     Gui.set_data(frame, data)
-    
+
 end
 
 local function on_player_created(event)
@@ -517,6 +519,18 @@ Gui.on_click('Diggy.MarketExchange.Button', toggle)
 Gui.on_custom_close('Diggy.MarketExchange.Frame', function (event)
     event.element.destroy()
 end)
+
+function MarketExchange.update_gui()
+    for _, p in ipairs(game.connected_players) do
+        local frame = p.gui.left['Diggy.MarketExchange.Frame']
+
+        if frame and frame.valid then
+            local data = {player = p}
+            toggle(data)
+            toggle(data)
+        end
+    end
+end
 
 function MarketExchange.on_init()
     Task.set_timeout_in_ticks(50, on_market_timeout_finished, {

--- a/map_gen/Diggy/Feature/MarketExchange.lua
+++ b/map_gen/Diggy/Feature/MarketExchange.lua
@@ -463,15 +463,15 @@ end
 
 local function toggle(event)
     local player = event.player
-    local center = player.gui.center
-    local frame = center['Diggy.MarketExchange.Frame']
+    local left = player.gui.left
+    local frame = left['Diggy.MarketExchange.Frame']
 
     if (frame) then
         Gui.destroy(frame)
         return
     end
 
-    frame = center.add({name = 'Diggy.MarketExchange.Frame', type = 'frame', direction = 'vertical'})
+    frame = left.add({name = 'Diggy.MarketExchange.Frame', type = 'frame', direction = 'vertical'})
 
     local market_progressbars = frame.add({type = 'flow', direction = 'vertical'})
     local market_list_heading = frame.add({type = 'flow', direction = 'horizontal'})
@@ -502,8 +502,7 @@ local function toggle(event)
     redraw_buff(data)
 
     Gui.set_data(frame, data)
-
-    player.opened = frame
+    
 end
 
 local function on_player_created(event)


### PR DESCRIPTION
~~Work in progress~~ 
Redraw stone sent to surface gui when stone sent (On market_update_content())

GUI moved to top left to allow sending stone from the market while having it open:
![image](https://user-images.githubusercontent.com/44922798/48507479-579f0d00-e84c-11e8-8d07-d6695eed7309.png)


~~Partial solution for~~
closes #285 