### PR TITLE
Increase feedback for commands, overhaul print_admins

### DIFF
--- a/features/gui/popup.lua
+++ b/features/gui/popup.lua
@@ -67,6 +67,7 @@ Gui.on_click(
     end
 )
 
+-- Creates a popup dialog for all players
 local function popup(cmd)
     local player = game.player
     if player and not player.admin then
@@ -85,8 +86,13 @@ local function popup(cmd)
     for _, p in ipairs(game.connected_players) do
         show_popup(p, message)
     end
+
+    player.print('Popup sent')
+    Utils.print_admins(player.name .. ' sent a popup to all players', false)
+    Utils.log_command(game.player.name, cmd.name, cmd.parameter)
 end
 
+-- Creates a popup dialog for all players, specifically for the server upgrading factorio versions
 local function popup_update(cmd)
     local player = game.player
     if player and not player.admin then
@@ -99,8 +105,13 @@ local function popup_update(cmd)
     for _, p in ipairs(game.connected_players) do
         show_popup(p, message)
     end
+
+    player.print('Popup sent')
+    Utils.print_admins(player.name .. ' sent a popup to all players', false)
+    Utils.log_command(game.player.name, cmd.name, message)
 end
 
+-- Creates a popup dialog for the specifically targetted player
 local function popup_player(cmd)
     local player = game.player
     if player and not player.admin then
@@ -130,6 +141,9 @@ local function popup_player(cmd)
     message = message:sub(end_index, #message):gsub('\\n', '\n')
 
     show_popup(target, message)
+
+    player.print('Popup sent')
+    Utils.log_command(game.player.name, cmd.name, cmd.parameter)
 end
 
 commands.add_command('popup', '<message> - Shows a popup to all connected players (Admins only)', popup)

--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -1,39 +1,43 @@
 local Event = require "utils.event"
 local UserGroups = require "features.user_groups"
 local Utils = require "utils.utils"
-local Game = require 'utils.game'
+local Game = require "utils.game"
 
 local function allowed_to_nuke(player)
-  if type(player) == "table" then
-  return player.admin or UserGroups.is_regular(player.name) or ((player.online_time / 216000) > global.scenario.config.nuke_control.nuke_min_time_hours)
-  elseif type(player) == "number" then
-    return allowed_to_nuke(Game.get_player_by_index(player))
-  end
+    if type(player) == "table" then
+        return player.admin or UserGroups.is_regular(player.name) or ((player.online_time / 216000) > global.scenario.config.nuke_control.nuke_min_time_hours)
+    elseif type(player) == "number" then
+        return allowed_to_nuke(Game.get_player_by_index(player))
+    end
 end
 
 local function ammo_changed(event)
-  local player = Game.get_player_by_index(event.player_index)
-    if allowed_to_nuke(player) then return end
-  local nukes = player.remove_item({name="atomic-bomb", count=1000})
-  if nukes > 0 then
-    game.print(player.name .. " tried to use a nuke, but instead dropped it on his foot.")
-
-    local character = player.character
-    if character and character.valid then
-      for _,p in ipairs(game.connected_players) do
-        if p ~= player then
-          p.add_custom_alert(character, {type = 'item', name = 'atomic-bomb'}, player.name, true)
-        end
-      end
+    local player = Game.get_player_by_index(event.player_index)
+    if allowed_to_nuke(player) then
+        return
     end
-    player.character.health = 0
-  end
+    local nukes = player.remove_item({name = "atomic-bomb", count = 1000})
+    if nukes > 0 then
+        game.print(player.name .. " tried to use a nuke, but instead dropped it on his foot.")
+
+        local character = player.character
+        if character and character.valid then
+            for _, p in ipairs(game.connected_players) do
+                if p ~= player then
+                    p.add_custom_alert(character, {type = "item", name = "atomic-bomb"}, player.name, true)
+                end
+            end
+        end
+        player.character.health = 0
+    end
 end
 
 local function on_player_deconstructed_area(event)
-  local player = Game.get_player_by_index(event.player_index)
-    if allowed_to_nuke(player) then return end
-    player.remove_item({name="deconstruction-planner", count=1000})
+    local player = Game.get_player_by_index(event.player_index)
+    if allowed_to_nuke(player) then
+        return
+    end
+    player.remove_item({name = "deconstruction-planner", count = 1000})
 
     --Make them think they arent noticed
     Utils.print_except(player.name .. " tried to deconstruct something, but instead deconstructed themself.", player)
@@ -41,113 +45,111 @@ local function on_player_deconstructed_area(event)
 
     local character = player.character
     if character and character.valid then
-      for _,p in ipairs(game.connected_players) do
-        if p ~= player then
-          p.add_custom_alert(character, {type = 'item', name = 'deconstruction-planner'}, player.name, true)
+        for _, p in ipairs(game.connected_players) do
+            if p ~= player then
+                p.add_custom_alert(character, {type = "item", name = "deconstruction-planner"}, player.name, true)
+            end
         end
-      end
     end
     character.health = 0
 
     local area = event.area
     local left_top, right_bottom = area.left_top, area.right_bottom
     if left_top.x == right_bottom.x and left_top.y == right_bottom.y then
-      return
+        return
     end
 
-    local entities = player.surface.find_entities_filtered{area = area, force = player.force}
+    local entities = player.surface.find_entities_filtered {area = area, force = player.force}
     if #entities > 1000 then
-      Utils.print_admins("Warning! " .. player.name .. " just tried to deconstruct " .. tostring(#entities) .. " entities!")
+        Utils.print_admins("Warning! " .. player.name .. " just tried to deconstruct " .. tostring(#entities) .. " entities!", false)
     end
-    for _,entity in pairs(entities) do
-      if entity.valid and entity.to_be_deconstructed(Game.get_player_by_index(event.player_index).force) then
-        entity.cancel_deconstruction(Game.get_player_by_index(event.player_index).force)
-      end
+    for _, entity in pairs(entities) do
+        if entity.valid and entity.to_be_deconstructed(Game.get_player_by_index(event.player_index).force) then
+            entity.cancel_deconstruction(Game.get_player_by_index(event.player_index).force)
+        end
     end
 end
 
 local function item_not_sanctioned(item)
-  local name = item.name
-  return (
-    name:find("capsule") or
-    name == "cliff-explosives" or
-    name == "raw-fish" or
-    name == "discharge-defense-remote"
-  )
+    local name = item.name
+    return (name:find("capsule") or name == "cliff-explosives" or name == "raw-fish" or name == "discharge-defense-remote")
 end
 
 global.entities_allowed_to_bomb = {
-  ["stone-wall"] = true,
-  ["transport-belt"] = true,
-  ["fast-transport-belt"] = true,
-  ["express-transport-belt"] = true,
-  ["construction-robot"] = true,
-  ["player"] = true,
-  ["gun-turret"] = true,
-  ["laser-turret"] = true,
-  ["flamethrower-turret"] = true,
-  ["rail"] = true,
-  ["rail-chain-signal"] = true,
-  ["rail-signal"] = true,
-  ["tile-ghost"] = true,
-  ["entity-ghost"] = true,
-  ["gate"] = true,
-  ["electric-pole"] = true,
-  ["small-electric-pole"] = true,
-  ["medium-electric-pole"] = true,
-  ["big-electric-pole"] = true,
-  ["logistic-robot"] = true,
-  ["defender"] = true,
-  ["destroyer"] = true,
-  ["distractor"] = true
+    ["stone-wall"] = true,
+    ["transport-belt"] = true,
+    ["fast-transport-belt"] = true,
+    ["express-transport-belt"] = true,
+    ["construction-robot"] = true,
+    ["player"] = true,
+    ["gun-turret"] = true,
+    ["laser-turret"] = true,
+    ["flamethrower-turret"] = true,
+    ["rail"] = true,
+    ["rail-chain-signal"] = true,
+    ["rail-signal"] = true,
+    ["tile-ghost"] = true,
+    ["entity-ghost"] = true,
+    ["gate"] = true,
+    ["electric-pole"] = true,
+    ["small-electric-pole"] = true,
+    ["medium-electric-pole"] = true,
+    ["big-electric-pole"] = true,
+    ["logistic-robot"] = true,
+    ["defender"] = true,
+    ["destroyer"] = true,
+    ["distractor"] = true
 }
 
 local function entity_allowed_to_bomb(entity)
-  return global.entities_allowed_to_bomb[entity.name]
+    return global.entities_allowed_to_bomb[entity.name]
 end
 global.players_warned = {}
 local function on_capsule_used(event)
-  local item = event.item
-  local player = Game.get_player_by_index(event.player_index)
+    local item = event.item
+    local player = Game.get_player_by_index(event.player_index)
 
-  if not player or not player.valid or
-    (global.scenario.config.nuke_control.enable_autokick and global.scenario.config.nuke_control.enable_autoban) then
-    return
-  end
-
-  if item.name == 'artillery-targeting-remote' then
-    player.surface.create_entity{name = 'flying-text', text = player.name, color = player.color, position = event.position}
-  end
-
-  if item_not_sanctioned(item) then return end
-
-  if (not allowed_to_nuke(player)) then
-    local area = {{event.position.x-5, event.position.y-5}, {event.position.x+5, event.position.y+5}}
-    local count = 0
-    local entities = player.surface.find_entities_filtered{force=player.force, area=area}
-    for _,e in pairs(entities) do
-      if not entity_allowed_to_bomb(e) then count = count + 1 end
+    if not player or not player.valid or (global.scenario.config.nuke_control.enable_autokick and global.scenario.config.nuke_control.enable_autoban) then
+        return
     end
-    if count > 8 then
-      if global.players_warned[event.player_index] then
-        if global.scenario.config.nuke_control.enable_autokick then
-          game.ban_player(player, string.format("Damaged %i entities with %s. This action was performed automatically. If you want to contest this ban please visit redmew.com/discord.", count, event.item.name))
-        end
-      else
-        global.players_warned[event.player_index] = true
-        if global.scenario.config.nuke_control.enable_autoban then
-          game.print(player, string.format("Damaged %i entities with %s -Antigrief", count, event.item.name))
-        end
-      end
+
+    if item.name == "artillery-targeting-remote" then
+        player.surface.create_entity {name = "flying-text", text = player.name, color = player.color, position = event.position}
     end
-  end
+
+    if item_not_sanctioned(item) then
+        return
+    end
+
+    if (not allowed_to_nuke(player)) then
+        local area = {{event.position.x - 5, event.position.y - 5}, {event.position.x + 5, event.position.y + 5}}
+        local count = 0
+        local entities = player.surface.find_entities_filtered {force = player.force, area = area}
+        for _, e in pairs(entities) do
+            if not entity_allowed_to_bomb(e) then
+                count = count + 1
+            end
+        end
+        if count > 8 then
+            if global.players_warned[event.player_index] then
+                if global.scenario.config.nuke_control.enable_autokick then
+                    game.ban_player(player, string.format("Damaged %i entities with %s. This action was performed automatically. If you want to contest this ban please visit redmew.com/discord.", count, event.item.name))
+                end
+            else
+                global.players_warned[event.player_index] = true
+                if global.scenario.config.nuke_control.enable_autoban then
+                    game.print(player, string.format("Damaged %i entities with %s -Antigrief", count, event.item.name))
+                end
+            end
+        end
+    end
 end
 
 local function on_player_joined(event)
-  local player = game.players[event.player_index]
-  if string.match(player.name,"^[Ili1|]+$") then
-    game.ban_player(player) --No reason given, to not give them any hints to change their name
-  end
+    local player = game.players[event.player_index]
+    if string.match(player.name, "^[Ili1|]+$") then
+        game.ban_player(player) --No reason given, to not give them any hints to change their name
+    end
 end
 
 Event.add(defines.events.on_player_ammo_inventory_changed, ammo_changed)

--- a/utils/utils.lua
+++ b/utils/utils.lua
@@ -1,5 +1,6 @@
 local Module = {}
 local Game = require 'utils.game'
+local prefix = '## - '
 
 Module.distance = function(pos1, pos2)
     local dx = pos2.x - pos1.x
@@ -15,10 +16,25 @@ Module.print_except = function(msg, player)
     end
 end
 
-Module.print_admins = function(msg)
-    for _, p in pairs(game.players) do
-        if p.connected and p.admin then
-            p.print(msg)
+-- Takes a LuaPlayer or string as source
+Module.print_admins = function(msg, source)
+    local source_name
+    local chat_color
+    if source then
+        if type(source) == 'string' then
+            source_name = source
+            chat_colot = game.players[source].chat_color
+        else
+            source_name = source.name
+            chat_color = source.chat_color
+        end
+    else
+        source_name = "Server"
+        chat_color = {r=255, g=255, b=255}
+    end
+    for _, p in pairs(game.connected_players) do
+        if p.admin then
+            p.print(string.format('%s(ADMIN) %s: %s', prefix, source_name, msg), chat_color)
         end
     end
 end
@@ -115,6 +131,22 @@ end
 
 Module.cant_run = function(name)
     Game.player_print("Can't run command (" .. name .. ') - insufficient permission.')
+end
+
+Module.log_command = function(user, command, parameters)
+    local name
+
+    -- We can use a LuaPlayer or a string (ex. "Server").
+    if type(user) == 'string' then
+        name = user
+    else
+        name = user.name
+    end
+    local action = table.concat {'[Admin-Command] ', name, ' used: ', command}
+    if parameters then
+        action = table.concat {'[Admin-Command] ', name, ' used: ', command, ' ', parameters}
+    end
+    log(action)
 end
 
 Module.comma_value = function(n) -- credit http://richard.warburton.it


### PR DESCRIPTION
Overhaul and make use of print_admins. Previously only nuke_control used the function and it remains compatible with no changes needed (I just prefer to explicitly send a nil).
Generate more feedback for admins and into the logs from report.lua, popup.lua and custom_commands.lua
Add comments for custom commands functions
Add comments for a few report functions
Add comments for popup
Remove whitespaces in report.lua
Use more straightforward method to stop jailed shooters
Reformat nuke_control since I had it open already