### PR TITLE
Increase cost of landmines in the market

### DIFF
--- a/resources/market_items.lua
+++ b/resources/market_items.lua
@@ -22,7 +22,7 @@ return {
     {price = {{market_item, 3}}, offer = {type = 'give-item', item = 'decider-combinator'}},
     {price = {{market_item, 3}}, offer = {type = 'give-item', item = 'arithmetic-combinator'}},
     {price = {{market_item, 3}}, offer = {type = 'give-item', item = 'constant-combinator'}},
-    {price = {{market_item, 7}}, offer = {type = 'give-item', item = 'programmable-speaker'}},    
+    {price = {{market_item, 7}}, offer = {type = 'give-item', item = 'programmable-speaker'}},
     {price = {{market_item, 15}}, offer = {type = 'give-item', item = 'steel-axe'}},
     {price = {{market_item, 15}}, offer = {type = 'give-item', item = 'submachine-gun'}},
     {price = {{market_item, 15}}, offer = {type = 'give-item', item = 'shotgun'}},
@@ -48,7 +48,7 @@ return {
     {price = {{market_item, 30}}, offer = {type = 'give-item', item = 'explosive-cannon-shell'}},
     {price = {{market_item, 75}}, offer = {type = 'give-item', item = 'explosive-uranium-cannon-shell'}},
     {price = {{market_item, 100}}, offer = {type = 'give-item', item = 'artillery-shell'}},
-    {price = {{market_item, 1}}, offer = {type = 'give-item', item = 'land-mine'}},
+    {price = {{market_item, 3}}, offer = {type = 'give-item', item = 'land-mine'}},
     {price = {{market_item, 5}}, offer = {type = 'give-item', item = 'grenade'}},
     {price = {{market_item, 35}}, offer = {type = 'give-item', item = 'cluster-grenade'}},
     {price = {{market_item, 5}}, offer = {type = 'give-item', item = 'defender-capsule'}},
@@ -82,7 +82,7 @@ return {
     {price = {{market_item, 20}}, offer = {type = 'give-item', item = 'production-science-pack'}},
     {price = {{market_item, 25}}, offer = {type = 'give-item', item = 'high-tech-science-pack'}}, ]]
 
-    
+
     --[[ {price = {{market_item, 3}}, offer = {type = 'give-item', item = 'piercing-rounds-magazine'}},
     {price = {{market_item, 2}}, offer = {type = 'give-item', item = 'grenade'}},
     {price = {{market_item, 1}}, offer = {type = 'give-item', item = 'land-mine'}},


### PR DESCRIPTION
As it turns out, landmines in the early game are supremely powerful. One player picked up 10k coins in the first couple hours of maltease cross using them.