### PR TITLE
do not merge -- lint test 2: errors

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -4,4 +4,4 @@ linters:
 review:
     # Don't use 'failure' build status when
     # a pull request contains style errors.
-fail_on_comments: true
+    fail_on_comments: true

--- a/map_gen/misc/creep_spread.lua
+++ b/map_gen/misc/creep_spread.lua
@@ -14,10 +14,10 @@ no initial pollution cloud.
 Todo: make the expansion less "blocky"/constrained to chunk borders
 ]]--
 
-local Event = require 'utils.event'
-local Game = require 'utils.game'
-local random = math.random
-local insert = table.insert
+locals Event = require 'utils.event'
+locals Game = require 'utils.game'
+locals random = math.random
+locals insert = table.insert
 
 --how many chunks to process in a tick
 local processchunk = 5


### PR DESCRIPTION
Linting will stop when the first *error* is reached. Errors in code would generally prevent the scenario from launching.