### PR TITLE
Added a new command wrapper to reduce boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Internal
 - [Core] Added a new command wrapper #443
 - [Core] Overhaul utils and add minor functionality #464
+- [Core] Added a new command wrapper to reduce boilerplate #443
 
 ## v1.1.0 - Persian Longhair
 

--- a/map_gen/Diggy/Debug.lua
+++ b/map_gen/Diggy/Debug.lua
@@ -1,4 +1,5 @@
 -- dependencies
+local BaseDebug = require 'utils.debug'
 local min = math.min
 local max = math.max
 local floor = math.floor
@@ -10,76 +11,19 @@ local Debug = {}
 local default_base_color = {r = 1, g = 1, b = 1}
 local default_delta_color = {r = 0, g = 0, b = 0}
 
--- private state
-local debug = false
-local cheats = false
-
-function Debug.enable_debug()
-    debug = true
-end
-
-function Debug.disable_debug()
-    debug = false
-end
-
-function Debug.enable_cheats()
-    cheats = true
-end
-
-function Debug.disable_cheats()
-    cheats = true
-end
-
-global.message_count = 0
-
---[[--
-    Shows the given message if debug is enabled.
-
-    @param message string
-]]
+---@deprecated use 'utils.debug'.print instead
 function Debug.print(message)
-    if type(message) ~= 'string' and type(message) ~= 'number'  and type(message) ~= 'boolean' then message = type(message) end
-    global.message_count = global.message_count + 1
-    if (debug) then
-        game.print('[' .. global.message_count .. '] ' .. tostring(message))
-        log('[' .. global.message_count .. '] ' .. tostring(message))
-    end
+    BaseDebug.print(message)
 end
 
---[[--
-    Shows the given message with serpent enabled, if debug is enabled.
-
-    @param message string
-]]
-function Debug.print_serpent(message)
-    Debug.print(serpent.line(message))
-end
-
---[[--
-    Shows the given message if debug is on.
-
-    @param x number
-    @param y number
-    @param message string
-]]
+---@deprecated use 'utils.debug'.print_position instead
 function Debug.print_position(position, message)
-    message = message or ''
-    if type(message) ~= 'string' and type(message) ~= 'number'  and type(message) ~= 'boolean' then message = type(message) end
-    global.message_count = global.message_count + 1
-    if (debug) then
-        game.print('[' .. global.message_count .. '] {x=' .. position.x .. ', y=' .. position.y .. '} ' .. tostring(message))
-    end
+    BaseDebug.print_position(position, message)
 end
 
---[[--
-    Executes the given callback if cheating is enabled.
-
-    @param callback function
-]]
+---@deprecated use 'utils.debug'.cheat instead
 function Debug.cheat(callback)
-    if (cheats) then
-        callback()
-    end
+    BaseDebug.cheat(callback)
 end
 
 --[[--

--- a/map_gen/Diggy/Scenario.lua
+++ b/map_gen/Diggy/Scenario.lua
@@ -1,6 +1,5 @@
 -- dependencies
 local Config = require 'map_gen.Diggy.Config'
-local Debug = require 'map_gen.Diggy.Debug'
 local ScenarioInfo = require 'features.gui.info'
 local Event = require 'utils.event'
 
@@ -36,10 +35,8 @@ local function each_enabled_feature(if_enabled)
     end
 end
 
---[[--
-    Register the events required to initialize the scenario.
-]]
-function Scenario.register(debug, cheats)
+---Register the events required to initialize the scenario.
+function Scenario.register()
     if global.diggy_scenario_registered then
         error('Cannot register the Diggy scenario multiple times.')
         return
@@ -48,14 +45,6 @@ function Scenario.register(debug, cheats)
     global.config.player_list.enable_coin_col = false
     if global.config then
         global.config.fish_market.enable = nil
-    end
-
-    if debug then
-        Debug.enable_debug()
-    end
-
-    if cheats then
-        Debug.enable_cheats()
     end
 
     local extra_map_info = ''

--- a/map_gen/combined/diggy.lua
+++ b/map_gen/combined/diggy.lua
@@ -1,2 +1,2 @@
 -- authors Linaori, valansch
-require 'map_gen.Diggy.Scenario'.register(_DEBUG, _CHEATS)
+require 'map_gen.Diggy.Scenario'.register()

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -1,4 +1,4 @@
-require 'utils.list_utils'
+require 'utils.table'
 
 local insert = table.insert
 local size = table.size

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -85,7 +85,7 @@ function Command.add(command_name, options, callback)
         error(format("The command '%s' is not allowed by the server nor player, please enable at least one of them.", command_name))
     end
 
-    for index, argument_name in ipairs(arguments) do
+    for index, argument_name in pairs(arguments) do
         local argument_display = argument_name
         for default_value_name, _ in pairs(default_values) do
             if default_value_name == argument_name then
@@ -152,7 +152,7 @@ function Command.add(command_name, options, callback)
 
         local errors = {}
 
-        for index, argument in ipairs(arguments) do
+        for index, argument in pairs(arguments) do
             local parameter = from_command[index]
 
             if not parameter then
@@ -173,7 +173,7 @@ function Command.add(command_name, options, callback)
 
         local return_early = false
 
-        for _, error in ipairs(errors) do
+        for _, error in pairs(errors) do
             return_early = true
             print(error)
         end

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -1,7 +1,6 @@
 require 'utils.table'
 
 local insert = table.insert
-local size = table.size
 local format = string.format
 local next = next
 local serialize = serpent.line
@@ -68,7 +67,7 @@ function Command.add(command_name, options, callback)
     local allowed_by_server = options.allowed_by_server or false
     local allowed_by_player = options.allowed_by_player
     local log_command = options.log_command or options.admin_only or false
-    local argument_list_size = size(arguments)
+    local argument_list_size = table_size(arguments)
     local argument_list = ''
 
     assert_existing_options(command_name, options)

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -1,13 +1,18 @@
 local insert = table.insert
+local format = string.format
 
 local Command = {}
 
 ---Adds a command to be executed.
 ---
 ---Options table accepts the following structure: {
----    description = 'Teleports you to the player',
----    arguments = {'foo', 'bar'},
+---    description = 'A description of the command',
+---    arguments = {'foo', 'bar'}, -- maps arguments to these names in the given sequence
+---    default_values = {'bar' = nil}, -- gives a default value to 'bar' when omitted
 ---    admin_only = true, -- defaults to false
+---    debug_only = false, -- only registers it if _DEBUG is set to true when false
+---    allowed_by_server = false -- lets the server execute this, defaults to false
+---    allowed_by_player = true -- lets players execute this, defaults to true
 ---    log_command = true, -- defaults to false unless admin only, then always true
 ---}
 ---
@@ -22,27 +27,69 @@ local Command = {}
 function Command.add(command_name, options, callback)
     local description = options.description or '[Undocumented command]'
     local arguments = options.arguments or {}
+    local default_values = options.default_values or {}
     local admin_only = options.admin_only or false
+    local debug_only = options.debug_only or false
+    local allowed_by_server = options.allowed_by_server or false
+    local allowed_by_player = options.allowed_by_player
     local log_command = options.log_command or options.admin_only or false
     local argument_list = ''
 
-    for _, argument in ipairs(arguments) do
-        argument_list = string.format('%s<%s> ', argument_list, argument)
+    if nil == options.allowed_by_player then
+        allowed_by_player = true
     end
 
-    commands.add_command(command_name, argument_list .. description .. (admin_only and ' (Admin Only)' or ''), function (command)
+    if not _DEBUG and debug_only then
+        return
+    end
+
+    if not allowed_by_player and not allowed_by_server then
+        error(format("The command '%s' is not allowed by the server nor player, please enable at least one of them.", command_name))
+    end
+
+    for _, argument_name in ipairs(arguments) do
+        local argument_display = argument_name
+        for default_value_name, _ in pairs(default_values) do
+            if default_value_name == argument_name then
+                argument_display = argument_display .. ':optional'
+                break
+            end
+        end
+
+        argument_list = format('%s<%s> ', argument_list, argument_display)
+    end
+
+    local extra = ''
+
+    if allowed_by_server and not allowed_by_player then
+        extra = ' (Server Only)'
+    elseif allowed_by_player and admin_only then
+        extra = ' (Admin Only)'
+    end
+
+    commands.add_command(command_name, argument_list .. description .. extra, function (command)
         local print -- custom print reference in case no player is present
         local player_index = command.player_index
         local player = game.player
         if not player or not player.valid then
             print = function (message)
-                log(string.format('Trying to print message to player #%d, but not such player found: %s', player_index, message))
+                log(format('Trying to print message to player #%d, but not such player found: %s', player_index, message))
+            end
+
+            if not allowed_by_server then
+                log(format("The command '%s' is not allowed to be executed by the server.", command_name))
+                return
             end
         else
             print = player.print
 
+            if not allowed_by_player then
+                print(format("The command '%s' is not allowed to be executed by players.", command_name))
+                return
+            end
+
             if admin_only and not player.admin then
-                print(string.format('The %s command is only available to admins.', command_name))
+                print(format("The command '%s' requires an admin to be be executed", command_name))
                 return
             end
         end
@@ -57,8 +104,18 @@ function Command.add(command_name, options, callback)
 
         for index, argument in ipairs(arguments) do
             local parameter = from_command[index]
+
             if not parameter then
-                insert(errors, string.format('Argument %s from command %s is missing.', argument, command_name))
+                for default_value_name, default_value in pairs(default_values) do
+                    if default_value_name == argument then
+                        parameter = default_value
+                        break
+                    end
+                end
+            end
+
+            if not parameter then
+                insert(errors, format('Argument %s from command %s is missing.', argument, command_name))
             else
                 named_arguments[argument] = parameter
             end
@@ -76,7 +133,7 @@ function Command.add(command_name, options, callback)
         end
 
         if log_command then
-            log(string.format(
+            log(format(
                 '[%s Command] %s, used: %s %s',
                 admin_only and 'Admin' or 'Player',
                 player and player.valid and player.name or '<server>',
@@ -97,8 +154,8 @@ function Command.add(command_name, options, callback)
         end)
 
         if not success then
-            log(string.format('Error while running %s: %s', command_name, error))
-            print(string.format('There was an error running %s, it has been logged.', command_name))
+            log(format('Error while running %s: %s', command_name, error))
+            print(format('There was an error running %s, it has been logged.', command_name))
         end
     end)
 end

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -40,6 +40,11 @@ function Command.add(command_name, options, callback)
             end
         else
             print = player.print
+
+            if admin_only and not player.admin then
+                print(string.format('The %s command is only available to admins.', command_name))
+                return
+            end
         end
 
         local named_arguments = {}
@@ -48,14 +53,26 @@ function Command.add(command_name, options, callback)
             insert(from_command, param)
         end
 
+        local errors = {}
+
         for index, argument in ipairs(arguments) do
             local parameter = from_command[index]
             if not parameter then
-                print(string.format('Argument %s from command %s is missing.', argument, command_name))
-                return
+                insert(errors, string.format('Argument %s from command %s is missing.', argument, command_name))
+            else
+                named_arguments[argument] = parameter
             end
+        end
 
-            named_arguments[argument] = parameter
+        local return_early = false
+
+        for _, error in ipairs(errors) do
+            return_early = true
+            print(error)
+        end
+
+        if return_early then
+            return
         end
 
         if log_command then

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -1,0 +1,90 @@
+local Utils = require 'utils.utils'
+local insert = table.insert
+
+local Command = {}
+
+---Adds a command to be executed.
+---
+---Options table accepts the following structure: {
+---    description = 'Teleports you to the player',
+---    arguments = {'foo', 'bar'},
+---    admin_only = true, -- defaults to false
+---    log_command = true, -- defaults to false unless admin only, then always true
+---}
+---
+---The callback receives the following arguments:
+--- - arguments (indexed by name, value is extracted from the parameters)
+--- - the LuaPlayer or nil if it doesn't exist
+--- - the game tick in which the command was executed
+---
+---@param command_name string
+---@param options table
+---@param callback function
+function Command.add(command_name, options, callback)
+    local description = options.description or '[Undocumented command]'
+    local arguments = options.arguments or {}
+    local admin_only = options.admin_only or false
+    local log_command = options.log_command or options.admin_only or false
+    local argument_list = ''
+
+    for _, argument in ipairs(arguments) do
+        argument_list = string.format('%s<%s> ', argument_list, argument)
+    end
+
+    commands.add_command(command_name, argument_list .. description .. (admin_only and ' (Admin Only)' or ''), function (command)
+        local print
+        local player_index = command.player_index
+        local player = game.players[player_index]
+        if not player or not player.valid then
+            print = function (message)
+                log(string.format('Trying to print message to player #%d, but not such player found: %s', player_index, message))
+            end
+        else
+            print = player.print
+        end
+
+        local named_arguments = {}
+        local from_command = {}
+        for param in string.gmatch(command.parameter or '', '%S+') do
+            insert(from_command, param)
+        end
+
+        for index, argument in ipairs(arguments) do
+            local parameter = from_command[index]
+            if not parameter then
+                print(string.format('Argument %s from command %s is missing.', argument, command_name))
+                return
+            end
+
+            named_arguments[argument] = parameter
+        end
+
+        if log_command then
+            log(string.format(
+                '[%s Command] %s, used: %s %s',
+                admin_only and 'Admin' or 'Player',
+                player and player.valid and player.name or '<server>',
+                command_name,
+                serpent.line(named_arguments)
+            ))
+        end
+
+        if _DEBUG then
+            -- in debug mode it will crash and report errors directly
+            callback(named_arguments, player, command.tick)
+            return
+        end
+
+        -- safety check for the command
+        local success, error = pcall(function ()
+            callback(named_arguments, player, command.tick)
+        end)
+
+        if not success then
+            log(error)
+            print(string.format('There was an error running %s, it has been logged.', command_name))
+        end
+    end)
+end
+
+return Command

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -1,4 +1,3 @@
-local Utils = require 'utils.utils'
 local insert = table.insert
 
 local Command = {}
@@ -14,7 +13,7 @@ local Command = {}
 ---
 ---The callback receives the following arguments:
 --- - arguments (indexed by name, value is extracted from the parameters)
---- - the LuaPlayer or nil if it doesn't exist
+--- - the LuaPlayer or nil if it doesn't exist (such as the server player)
 --- - the game tick in which the command was executed
 ---
 ---@param command_name string
@@ -32,9 +31,9 @@ function Command.add(command_name, options, callback)
     end
 
     commands.add_command(command_name, argument_list .. description .. (admin_only and ' (Admin Only)' or ''), function (command)
-        local print
+        local print -- custom print reference in case no player is present
         local player_index = command.player_index
-        local player = game.players[player_index]
+        local player = game.player
         if not player or not player.valid then
             print = function (message)
                 log(string.format('Trying to print message to player #%d, but not such player found: %s', player_index, message))
@@ -81,7 +80,7 @@ function Command.add(command_name, options, callback)
         end)
 
         if not success then
-            log(error)
+            log(string.format('Error while running %s: %s', command_name, error))
             print(string.format('There was an error running %s, it has been logged.', command_name))
         end
     end)

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -111,16 +111,13 @@ function Command.add(command_name, options, callback)
 
     commands.add_command(command_name, argument_list .. description .. extra, function (command)
         local print -- custom print reference in case no player is present
-        local player_index = command.player_index
         local player = game.player
         local player_name = player and player.valid and player.name or '<server>'
         if not player or not player.valid then
-            print = function (message)
-                log(format('Trying to print message to player #%d, but not such player found: %s', player_index, message))
-            end
+            print = _G.print
 
             if not allowed_by_server then
-                log(format("The command '%s' is not allowed to be executed by the server.", command_name))
+                print(format("The command '%s' is not allowed to be executed by the server.", command_name))
                 return
             end
         else
@@ -196,11 +193,12 @@ function Command.add(command_name, options, callback)
         if not success then
             local serialized_arguments = serialize(named_arguments)
             if _DEBUG then
-                game.print(format("%s triggered an error running a command and has been logged: '%s' with arguments %s", player_name, command_name, serialized_arguments))
-                game.print(error)
-            else
-                print(format('There was an error running %s, it has been logged.', command_name))
+                print(format("%s triggered an error running a command and has been logged: '%s' with arguments %s", player_name, command_name, serialized_arguments))
+                print(error)
+                return
             end
+
+            print(format('There was an error running %s, it has been logged.', command_name))
             log(format("Error while running '%s' with arguments %s: %s", command_name, serialized_arguments, error))
         end
     end)

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -9,15 +9,15 @@ local serialize = serpent.line
 local Command = {}
 
 local option_names = {
-    ['description'] = true,
-    ['arguments'] = true,
-    ['default_values'] = true,
-    ['admin_only'] = true,
-    ['debug_only'] = true,
-    ['allowed_by_server'] = true,
-    ['allowed_by_player'] = true,
-    ['log_command'] = true,
-    ['capture_excess_arguments'] = true,
+    ['description'] = 'A description of the command',
+    ['arguments'] = 'A table of arguments, example: {"foo", "bar"} would map the first 2 arguments to foo and bar',
+    ['default_values'] = 'A default value for a given argument when omitted, example: {bar = false}',
+    ['admin_only'] = 'Set this to true if only admins may execute this command',
+    ['debug_only'] = 'Set this to true if it should only be registered when _DEBUG is true',
+    ['allowed_by_server'] = 'Set to true if the server (host) may execute this command',
+    ['allowed_by_player'] = 'Set to false to disable players from executing this command',
+    ['log_command'] = 'Set to true to log commands. Always true when admin_only is enabled',
+    ['capture_excess_arguments'] = 'Allows the last argument to be the remaining text in the command',
 }
 
 ---Validates if there aren't any wrong fields in the options.
@@ -41,7 +41,7 @@ end
 ---Options table accepts the following structure: {
 ---    description = 'A description of the command',
 ---    arguments = {'foo', 'bar'}, -- maps arguments to these names in the given sequence
----    default_values = {'bar' = nil}, -- gives a default value to 'bar' when omitted
+---    default_values = {bar = false}, -- gives a default value to 'bar' when omitted
 ---    admin_only = true, -- defaults to false
 ---    debug_only = false, -- only registers it if _DEBUG is set to true when false
 ---    allowed_by_server = false -- lets the server execute this, defaults to false

--- a/utils/debug.lua
+++ b/utils/debug.lua
@@ -1,0 +1,49 @@
+-- dependencies
+local format = string.format
+local serialize = serpent.line
+
+-- this
+local Debug = {}
+
+global.debug_message_count = 0
+
+---@return number next index
+local function increment()
+    local next = global.debug_message_count + 1
+    global.debug_message_count = next
+
+    return next
+end
+
+---Shows the given message if debug is enabled. Uses serpent to print non scalars.
+---@param message table
+function Debug.print(message)
+    if not _DEBUG then
+        return
+    end
+
+    if type(message) ~= 'string' and type(message) ~= 'number' and type(message) ~= 'boolean' then
+        message = serialize(message)
+    end
+
+    message = format('[%d] %s', increment(), tostring(message))
+    game.print(message)
+    log(message)
+end
+
+---Shows the given message if debug is on.
+---@param position Position
+---@param message string
+function Debug.print_position(position, message)
+    Debug.print(format('%s %s', serialize(position), message))
+end
+
+---Executes the given callback if cheating is enabled.
+---@param callback function
+function Debug.cheat(callback)
+    if _CHEATS then
+        callback()
+    end
+end
+
+return Debug


### PR DESCRIPTION
This wrapper should make it slightly easier to write custom commands. It supports:
 - logging when a command failed
 - error out when in debug instead of logging
 - should be supporting the server as actor, but untested
 - log prints if the actor doesn't exist (thus server)
 - automatic logging for admin only commands
 - optional logging for player commands
 - named arguments from commands and validation for missing arguments

```lua
local Command = require 'utils.command'

local command_options = {
    description = 'this is a test command',
    arguments = {'player_index', 'x', 'y'},
    admin_only = true,
}

Command.add('test-command', command_options, function (arguments, player, tick)
    game.print(string.format('[t:%d][p:%s]]', tick, player.name))
    game.print(serpent.line(arguments))
end)
```
Edit by plague006:
Closes #358, Closes #56