### PR TITLE
Some small performance fixes and cleanup

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,5 @@
 _DEBUG = false
+_CHEATS = false
 MARKET_ITEM = 'coin'
 
 global.scenario = {}

--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -2,12 +2,6 @@
 
 -- this
 local Config = {
-    -- enable debug mode, shows extra messages
-    debug = false,
-
-    -- allow cheats, primarily configured under SetupPlayer
-    cheats = false,
-
     -- a list of features to register and enable
     -- to disable a feature, change the flag
     features = {

--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -300,8 +300,8 @@ local Config = {
             cluster_mode = true,
 
             -- location of file to find the cluster definition file
-            cluster_file_location = 'map_gen.Diggy.Orepattern.Tendrils',
-            --cluster_file_location = 'map_gen.Diggy.Orepattern.Clusters',
+            ore_pattern = require 'map_gen.Diggy.Orepattern.Tendrils',
+            --ore_pattern = require 'map_gen.Diggy.Orepattern.Clusters',
 
         },
 

--- a/map_gen/Diggy/Debug.lua
+++ b/map_gen/Diggy/Debug.lua
@@ -53,7 +53,7 @@ function Debug.print_serpent(message)
 end
 
 --[[--
-    Shows the given message if _DEBUG == true for a given position.
+    Shows the given message if debug is on.
 
     @param x number
     @param y number

--- a/map_gen/Diggy/Feature/DiggyHole.lua
+++ b/map_gen/Diggy/Feature/DiggyHole.lua
@@ -15,12 +15,6 @@ local insert = table.insert
 local random = math.random
 local raise_event = script.raise_event
 
--- todo remove this dependency
-local ResourceConfig = require 'map_gen.Diggy.Config'.features.ScatteredResources
-
-local Perlin = require 'map_gen.shared.perlin_noise'
-local Simplex = require 'map_gen.shared.simplex_noise'
-
 -- this
 local DiggyHole = {}
 
@@ -62,120 +56,15 @@ local function diggy_hole(entity)
     local rocks = {}
     local surface = entity.surface
     local position = entity.position
-    local x = position.x
-    local y = position.y
 
     local out_of_map_found = Scanner.scan_around_position(surface, position, 'out-of-map');
-    local distance = ResourceConfig.distance(x, y)
 
-    -- source of noise for resource generation
-    -- index determines offset
-    -- '-1' is reserved for cluster mode
-    -- compound clusters use as many indexes as needed > 1
-    local base_seed
-    local function seeded_noise(surface, x, y, index, sources)
-        base_seed = base_seed or surface.map_gen_settings.seed + surface.index + 4000
-        local noise = 0
-        for _, settings in ipairs(sources) do
-            settings.type = settings.type or 'perlin'
-            settings.offset = settings.offset or 0
-            if settings.type == 'zero' then
-                noise = noise + 0
-            elseif settings.type == 'one' then
-                noise = noise + settings.weight * 1
-            elseif settings.type == 'perlin' then
-                noise = noise + settings.weight * Perlin.noise(x/settings.variance, y/settings.variance,
-                            base_seed + 2000*index + settings.offset)
-            elseif settings.type == 'simplex' then
-                noise = noise + settings.weight * Simplex.d2(x/settings.variance, y/settings.variance,
-                            base_seed + 2000*index + settings.offset)
-            else
-                Debug.print('noise type \'' .. settings.type .. '\' not recognized')
-            end
-
-        end
-        return noise
-    end
-
-    -- global config values
-    local resource_richness_weights = ResourceConfig.resource_richness_weights
-    local resource_richness_weights_sum = 0
-    for _, weight in pairs(resource_richness_weights) do
-        resource_richness_weights_sum = resource_richness_weights_sum + weight
-    end
-
-    local s_resource_weights = ResourceConfig.scattered_resource_weights
-    local s_resource_weights_sum = 0
-    for _, weight in pairs(s_resource_weights) do
-        s_resource_weights_sum = s_resource_weights_sum + weight
-    end
-
-    -- compound cluster spawning
-    local c_mode = ResourceConfig.cluster_mode
---    local c_clusters = Config.features.ScatteredResources.clusters
-    local c_clusters = require(ResourceConfig.cluster_file_location)
-    if ('table' ~= type(c_clusters)) then
-        error('cluster_file_location invalid')
-    end
-
-    local c_count = 0
-    for _, cluster in ipairs(c_clusters) do
-        c_count = c_count + 1
-        cluster.weights_sum = 0
-        for _, weight in pairs(cluster.weights) do
-            cluster.weights_sum = cluster.weights_sum + weight
-        end
-    end
-
-    local function spawn_cluster_resource(surface, x, y, cluster_index, cluster)
-        for name, weight in pairs(cluster.weights) do
-            if name == 'skip' then return false end
-        end
-        return true
-    end
-
-        local huge_rock_inserted = false
-    for _, position in pairs(out_of_map_found) do
-        insert(tiles, {name = 'dirt-' .. random(1, 7), position = position})
-
-
-        if c_mode then
-            for index,cluster in ipairs(c_clusters) do
-                if distance >= cluster.min_distance and cluster.noise_settings.type ~= 'skip' then
-                    if cluster.noise_settings.type == "connected_tendril" then
-                        local noise = seeded_noise(surface, x, y, index, cluster.noise_settings.sources)
-                        if -1 * cluster.noise_settings.threshold < noise and noise < cluster.noise_settings.threshold then
-                            if spawn_cluster_resource(surface, x, y, index, cluster) then
-                                insert(rocks, {name = 'rock-huge', position = position})
-                                huge_rock_inserted = true
-                            end
-                        end
-                    elseif cluster.noise_settings.type == "fragmented_tendril" then
-                        local noise1 = seeded_noise(surface, x, y, index, cluster.noise_settings.sources)
-                        local noise2 = seeded_noise(surface, x, y, index, cluster.noise_settings.discriminator)
-                        if -1 * cluster.noise_settings.threshold < noise1 and noise1 < cluster.noise_settings.threshold
-                                and -1 * cluster.noise_settings.discriminator_threshold < noise2
-                                and noise2 < cluster.noise_settings.discriminator_threshold then
-                            if spawn_cluster_resource(surface, x, y, index, cluster) then
-                                insert(rocks, {name = 'rock-huge', position = position})
-                                huge_rock_inserted = true
-                            end
-                        end
-                    else
-                        local noise = seeded_noise(surface, x, y, index, cluster.noise_settings.sources)
-                        if noise >= cluster.noise_settings.threshold then
-                            if spawn_cluster_resource(surface, x, y, index, cluster) then
-                                insert(rocks, {name = 'rock-huge', position = position})
-                                huge_rock_inserted = true
-                            end
-                        end
-                    end
-                end
-            end
-        end
-
-    if (huge_rock_inserted == false) then
-        insert(rocks, {name = 'sand-rock-big', position = position})
+    for _, void_position in ipairs(out_of_map_found) do
+        insert(tiles, {name = 'dirt-' .. random(1, 7), position = void_position })
+        if random() < 0.35 then
+            insert(rocks, {name = 'rock-huge', position = void_position })
+        else
+            insert(rocks, {name = 'sand-rock-big', position = void_position })
         end
     end
 

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -40,7 +40,7 @@ Global.register({
 end)
 
 
-local Config = {}
+local config = {}
 local string_format = string.format
 local alien_coin_modifiers = require 'map_gen.Diggy.Config'.features.ArtefactHunting.alien_coin_modifiers
 local floor = math.floor
@@ -51,7 +51,7 @@ local level_up_formula = (function (level_reached)
     local Config = require 'map_gen.Diggy.Config'.features.Experience
     local difficulty_scale = floor(Config.difficulty_scale)
     local level_fine_tune = floor(Config.xp_fine_tune)
-    local start_value = (floor(Config.first_lvl_xp)/2)
+    local start_value = (floor(Config.first_lvl_xp) * 0.5)
     local precision = (floor(Config.cost_precision))
     local function formula(level)
         return (
@@ -68,7 +68,7 @@ local level_up_formula = (function (level_reached)
     if lower_value == 0 then
         return value - lower_value
     end
-    lower_value = lower_value - (lower_value % (10 ^ (floor(log(lower_value,10)) - precision)))
+    lower_value = lower_value - (lower_value % (10 ^ (floor(log(lower_value, 10)) - precision)))
     return value - lower_value
 end)
 
@@ -76,10 +76,10 @@ end)
 ---@param force LuaForce the force of which will be updated
 ---@param level_up number a level if updating as part of a level up (optional)
 function Experience.update_mining_speed(force, level_up)
-    local level_up = level_up ~= nil and level_up or 0
-    local buff = Config.buffs['mining_speed']
+    level_up = level_up ~= nil and level_up or 0
+    local buff = config.buffs['mining_speed']
     if level_up > 0 and buff ~= nil then
-        local value = (buff.double_level ~= nil and level_up%buff.double_level == 0) and buff.value*2 or buff.value
+        local value = (buff.double_level ~= nil and level_up % buff.double_level == 0) and buff.value * 2 or buff.value
         mining_efficiency.level_modifier = mining_efficiency.level_modifier + (value * 0.01)
     end
     -- remove the current buff
@@ -96,10 +96,10 @@ end
 ---@param force LuaForce the force of which will be updated
 ---@param level_up number a level if updating as part of a level up (optional)
 function Experience.update_inventory_slots(force, level_up)
-    local level_up = level_up ~= nil and level_up or 0
-    local buff = Config.buffs['inventory_slot']
+    level_up = level_up ~= nil and level_up or 0
+    local buff = config.buffs['inventory_slot']
     if level_up > 0 and buff ~= nil then
-        local value = (buff.double_level ~= nil and level_up%buff.double_level == 0) and buff.value*2 or buff.value
+        local value = (buff.double_level ~= nil and level_up % buff.double_level == 0) and buff.value * 2 or buff.value
         inventory_slots.level_modifier = inventory_slots.level_modifier + value
     end
 
@@ -117,8 +117,8 @@ end
 ---@param force LuaForce the force of which will be updated
 ---@param level_up number a level if updating as part of a level up (optional)
 function Experience.update_health_bonus(force, level_up)
-    local level_up = level_up ~= nil and level_up or 0
-    local buff = Config.buffs['health_bonus']
+    level_up = level_up ~= nil and level_up or 0
+    local buff = config.buffs['health_bonus']
     if level_up > 0 and buff ~= nil then
         local value = (buff.double_level ~= nil and level_up%buff.double_level == 0) and buff.value*2 or buff.value
         health_bonus.level_modifier = health_bonus.level_modifier + value
@@ -166,7 +166,7 @@ local function on_research_finished(event)
 
     for _, ingredient in pairs(research.research_unit_ingredients) do
         local name = ingredient.name
-        local reward = Config.XP[name]
+        local reward = config.XP[name]
         award_xp = award_xp + reward
     end
     local exp = award_xp * research.research_unit_count
@@ -179,7 +179,7 @@ local function on_research_finished(event)
 
 
     local current_modifier = mining_efficiency.research_modifier
-    local new_modifier = force.mining_drill_productivity_bonus * Config.mining_speed_productivity_multiplier * 0.5
+    local new_modifier = force.mining_drill_productivity_bonus * config.mining_speed_productivity_multiplier * 0.5
 
     if (current_modifier == new_modifier) then
         -- something else was researched
@@ -198,7 +198,7 @@ end
 ---Awards experience when a rocket has been launched
 ---@param event LuaEvent
 local function on_rocket_launched(event)
-    local exp = Config.XP['rocket_launch']
+    local exp = config.XP['rocket_launch']
     local force = event.force
     local text = string_format('Rocket launched! +%d XP', exp)
     for _, p in pairs(game.connected_players) do
@@ -246,7 +246,7 @@ local function on_entity_died (event)
         return
     end
 
-    local exp = Config.XP['enemy_killed'] * alien_coin_modifiers[entity.name]
+    local exp = config.XP['enemy_killed'] * alien_coin_modifiers[entity.name]
     local text = string_format('+ %d XP', exp)
     local player_index = cause.player.index
     Game.print_player_floating_text_position(player_index, text, {r = 144, g = 202, b = 249},-1, -0.5)
@@ -258,7 +258,7 @@ end
 local function on_player_respawned(event)
     local player = Game.get_player_by_index(event.player_index)
     local force = player.force
-    local exp = ForceControl.remove_experience_percentage(force, Config.XP['death-penalty'], 50)
+    local exp = ForceControl.remove_experience_percentage(force, config.XP['death-penalty'], 50)
     local text = string_format('%s died! -%d XP', player.name, exp)
     for _, p in pairs(game.connected_players) do
         Game.print_player_floating_text_position(p.index, text, {r = 255, g = 0, b = 0},-1, -0.5)
@@ -269,7 +269,7 @@ end
 ---@return table with the same format as in the Diggy Config
 ---@see Diggy.Config.features.Experience.Buffs
 function Experience.get_buffs()
-    return Config.buffs
+    return config.buffs
 end
 
 local level_table = {}
@@ -291,7 +291,7 @@ function Experience.calculate_level_xp(level)
 end
 
 function Experience.register(cfg)
-    Config = cfg
+    config = cfg
 
     --Adds the function on how to calculate level caps (When to level up)
     ForceControl_builder = ForceControl.register(level_up_formula)
@@ -318,8 +318,8 @@ function Experience.register(cfg)
     Event.add(defines.events.on_entity_died, on_entity_died)
 
     -- Prevents table lookup thousands of times
-    sand_rock_xp = Config.XP['sand-rock-big']
-    rock_huge_xp = Config.XP['rock-huge']
+    sand_rock_xp = config.XP['sand-rock-big']
+    rock_huge_xp = config.XP['rock-huge']
 end
 
 function Experience.on_init()

--- a/map_gen/Diggy/Feature/MarketExchange.lua
+++ b/map_gen/Diggy/Feature/MarketExchange.lua
@@ -9,7 +9,6 @@ local Task = require 'utils.Task'
 local Gui = require 'utils.gui'
 local Debug = require 'map_gen.Diggy.Debug'
 local Template = require 'map_gen.Diggy.Template'
-local Global = require 'utils.global'
 local Game = require 'utils.game'
 local insert = table.insert
 local force_control = require 'features.force_control'
@@ -17,7 +16,6 @@ local Experience = require 'map_gen.Diggy.Feature.Experience'
 local max = math.max
 local floor = math.floor
 local utils = require 'utils.utils'
-local prefix = '## - '
 
 -- this
 local MarketExchange = {}
@@ -25,7 +23,7 @@ local MarketExchange = {}
 local config = {}
 
 local on_market_timeout_finished = Token.register(function(params)
-    Template.market(params.surface, params.position, params.player_force, {})
+    Template.market(params.surface, params.position, params.player_force)
 end)
 
 ---Updates market content with new items if they are to be unlocked
@@ -366,13 +364,11 @@ function MarketExchange.update_gui()
 end
 
 function MarketExchange.on_init()
-    Task.set_timeout_in_ticks(50, on_market_timeout_finished, {
+    Task.set_timeout_in_ticks(1, on_market_timeout_finished, {
         surface = game.surfaces.nauvis,
         position = config.market_spawn_position,
         player_force = game.forces.player,
     })
-
-
 end
 
 --[[--

--- a/map_gen/Diggy/Feature/ScatteredResources.lua
+++ b/map_gen/Diggy/Feature/ScatteredResources.lua
@@ -96,9 +96,9 @@ function ScatteredResources.register(config)
 
     -- compound cluster spawning
     local c_mode = config.cluster_mode
-    local c_clusters = require(config.cluster_file_location)
-    if ('table' ~= type(c_clusters)) then
-        error('cluster_file_location invalid')
+    local c_clusters = config.ore_pattern
+    if 'table' ~= type(c_clusters) then
+        error('ore_pattern invalid')
     end
     local c_count = 0
     for _, cluster in ipairs(c_clusters) do

--- a/map_gen/Diggy/Scenario.lua
+++ b/map_gen/Diggy/Scenario.lua
@@ -39,7 +39,7 @@ end
 --[[--
     Register the events required to initialize the scenario.
 ]]
-function Scenario.register(debug)
+function Scenario.register(debug, cheats)
     if global.diggy_scenario_registered then
         error('Cannot register the Diggy scenario multiple times.')
         return
@@ -50,11 +50,11 @@ function Scenario.register(debug)
         global.scenario.config.fish_market.enable = nil
     end
 
-    if (_DEBUG) then
+    if debug then
         Debug.enable_debug()
     end
 
-    if (_CHEATS) then
+    if cheats then
         Debug.enable_cheats()
     end
 

--- a/map_gen/Diggy/Scenario.lua
+++ b/map_gen/Diggy/Scenario.lua
@@ -50,15 +50,11 @@ function Scenario.register(debug)
         global.scenario.config.fish_market.enable = nil
     end
 
-    if ('boolean' == type(debug)) then
-        Config.Debug = debug
-    end
-
-    if (Config.debug) then
+    if (_DEBUG) then
         Debug.enable_debug()
     end
 
-    if (Config.cheats) then
+    if (_CHEATS) then
         Debug.enable_cheats()
     end
 

--- a/map_gen/Diggy/Template.lua
+++ b/map_gen/Diggy/Template.lua
@@ -163,14 +163,9 @@ end
     @param force LuaForce
     @param market_items Table
 ]]
-function Template.market(surface, position, force, market_inventory)
+function Template.market(surface, position, force)
     local market = surface.create_entity({name = 'market', position = position})
-    local add_market_item = market.add_market_item
     market.destructible = false
-
-    for _, item in ipairs(market_inventory) do
-        add_market_item(item)
-    end
 
     force.add_chart_tag(surface, {
         text = 'Market',

--- a/map_gen/combined/diggy.lua
+++ b/map_gen/combined/diggy.lua
@@ -1,2 +1,2 @@
 -- authors Linaori, valansch
-require 'map_gen.Diggy.Scenario'.register(_DEBUG)
+require 'map_gen.Diggy.Scenario'.register(_DEBUG, _CHEATS)


### PR DESCRIPTION
Moved enabling cheats and debug to the main config, it's not really diggy specific anyway and the debug was already redundant (it was only used if `_DEBUG` wasn't found). Removed duplicate noise based rock generation, it now does it randomly instead of on resources. It's less performance intensive and code to maintain until we have a generic noise functionality.