### PR TITLE
[Diggy] Tweaking Diggy controls

### DIFF
--- a/features/force_control.lua
+++ b/features/force_control.lua
@@ -212,7 +212,7 @@ end
 ---@return number the experience being removed
 ---@see ForceControl.remove_experience
 function ForceControl.remove_experience_percentage(lua_force_or_name, percentage, min_experience)
-    local min_experience = min_experience ~= nil and min_experience or 0
+    min_experience = min_experience ~= nil and min_experience or 0
     local force = get_valid_force(lua_force_or_name)
     if not force then
         return
@@ -274,7 +274,7 @@ end
 ---@return number the experience being added
 ---@see ForceControl.add_experience
 function ForceControl.add_experience_percentage(lua_force_or_name, percentage, min_experience)
-    local min_experience = min_experience ~= nil and min_experience or 0
+    min_experience = min_experience ~= nil and min_experience or 0
     local force = get_valid_force(lua_force_or_name)
     if not force then
         return

--- a/features/force_control.lua
+++ b/features/force_control.lua
@@ -267,6 +267,29 @@ function ForceControl.add_experience(lua_force_or_name, experience, recursive_ca
     ForceControl.add_experience(force, new_experience - experience_level_up_cap, true)
 end
 
+---Adds experience from a force, based on a percentage of the total obtained experience
+---@param lua_force_or_name LuaForce|string
+---@param percentage number percentage of total obtained experience to add
+---@param min_experience number minimum amount of experience to add (optional)
+---@return number the experience being added
+---@see ForceControl.add_experience
+function ForceControl.add_experience_percentage(lua_force_or_name, percentage, min_experience)
+    local min_experience = min_experience ~= nil and min_experience or 0
+    local force = get_valid_force(lua_force_or_name)
+    if not force then
+        return
+    end
+    local force_config = forces[force.name]
+    if not force_config then
+        return
+    end
+
+    local reward = force_config.total_experience * percentage
+    reward = (reward >= min_experience) and ceil(reward) or ceil(min_experience)
+    ForceControl.add_experience(lua_force_or_name, reward)
+    return reward
+end
+
 ---Return the force data as {
 ---    current_experience = number,
 ---    current_level = number,

--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -347,16 +347,7 @@ local Config = {
 
             -- market config
             market_spawn_position = {x = 0, y = 3},
-            stone_to_surface_amount = 50,
             currency_item = 'coin',
-
-            -- locations where chests will be automatically cleared from currency_item
-            void_chest_tiles = {
-                {x = -1, y = 5}, {x = 0, y = 5}, {x = 1, y = 5},
-            },
-
-            -- every x ticks it will clear y currency_item
-            void_chest_frequency = 307,
 
             -- add or remove a table entry to add or remove a unlockable item from the mall.
             -- format: {unlock_at_level, price, prototype_name},
@@ -365,20 +356,20 @@ local Config = {
                 {
                     {level = 1, price = 5, name = 'iron-axe'},
                     {level = 2, price = 5, name = 'raw-wood'},
-                    {level = 2, price = 10, name = 'raw-fish'},
-                    {level = 3, price = 5, name = 'stone-brick'},
-                    {level = 5, price = 12, name = 'stone-wall'},
-                    {level = 7, price = 6, name = 'small-lamp'},
-                    {level = 9, price = 5, name = 'firearm-magazine'},
-                    {level = 9, price = 25, name = 'pistol'},
-                    {level = 11, price = 85, name = 'shotgun'},
-                    {level = 11, price = 5, name = 'shotgun-shell'},
-                    {level = 14, price = 50, name = 'light-armor'},
-                    {level = 16, price = 85, name = 'submachine-gun'},
-                    {level = 16, price = 25, name = 'steel-axe'},
-                    {level = 19, price = 15, name = 'piercing-rounds-magazine'},
-                    {level = 19, price = 15, name = 'piercing-shotgun-shell'},
-                    {level = 21, price = 100, name = 'heavy-armor'},
+                    {level = 3, price = 20, name = 'pistol'},
+                    {level = 3, price = 2, name = 'firearm-magazine'},
+                    {level = 5, price = 2, name = 'stone-brick'},
+                    {level = 6, price = 6, name = 'small-lamp'},
+                    {level = 6, price = 5, name = 'raw-fish'},
+                    {level = 8, price = 10, name = 'stone-wall'},
+                    {level = 10, price = 85, name = 'shotgun'},
+                    {level = 10, price = 2, name = 'shotgun-shell'},
+                    {level = 13, price = 25, name = 'steel-axe'},
+                    {level = 13, price = 50, name = 'light-armor'},
+                    {level = 15, price = 85, name = 'submachine-gun'},
+                    {level = 18, price = 8, name = 'piercing-rounds-magazine'},
+                    {level = 18, price = 8, name = 'piercing-shotgun-shell'},
+                    {level = 20, price = 100, name = 'heavy-armor'},
                     {level = 25, price = 250, name = 'modular-armor'},
                     {level = 25, price = 100, name = 'landfill'},
                     {level = 28, price = 250, name = 'personal-roboport-equipment'},
@@ -387,11 +378,11 @@ local Config = {
                     {level = 34, price = 100, name = 'battery-equipment'},
                     {level = 33, price = 1000, name = 'fusion-reactor-equipment'},
                     {level = 36, price = 150, name = 'energy-shield-equipment'},
-                    {level = 42, price = 1000, name = 'combat-shotgun'},
-                    {level = 46, price = 250, name = 'uranium-rounds-magazine'},
+                    {level = 42, price = 650, name = 'combat-shotgun'},
+                    {level = 46, price = 25, name = 'uranium-rounds-magazine'},
                     {level = 58, price = 250, name = 'rocket-launcher'},
-                    {level = 58, price = 50, name = 'rocket'},
-                    {level = 66, price = 100, name = 'explosive-rocket'},
+                    {level = 58, price = 40, name = 'rocket'},
+                    {level = 66, price = 80, name = 'explosive-rocket'},
                     {level = 73, price = 2000, name = 'satellite'},
                     {level = 100, price = 1, name = 'iron-stick'},
                 }
@@ -409,8 +400,8 @@ local Config = {
         Experience = {
             enabled = true,
             -- controls the formula for calculating level up costs in stone sent to surface
-            difficulty_scale = 25, -- Diggy default 25. Higher increases experience requirement climb
-            first_lvl_xp = 600, -- Diggy default 600. This sets the price for the first level.
+            difficulty_scale = 16, -- Diggy default 16. Higher increases experience requirement climb
+            first_lvl_xp = 400, -- Diggy default 400. This sets the price for the first level.
             xp_fine_tune = 200, -- Diggy default 200. This value is used to fine tune the overall requirement climb without affecting the speed
             cost_precision = 3, -- Diggy default 3. This sets the precision of the required experience to level up. E.g. 1234 becomes 1200 with precision 2 and 1230 with precision 3.
 
@@ -420,16 +411,16 @@ local Config = {
             XP = {
               ['sand-rock-big']             = 5,
               ['rock-huge']                 = 10,
-              ['rocket_launch']             = 5000,     -- XP reward for a single rocket launch
-              ['science-pack-1']            = 2,
-              ['science-pack-2']            = 4,
-              ['science-pack-3']            = 10,
-              ['military-science-pack']     = 8,
+              ['rocket_launch']             = 0.01,     -- XP reward in percentage of total experience when a rocket launches (Diggy default: 0.01 which equals 1%)
+              ['science-pack-1']            = 4,
+              ['science-pack-2']            = 8,
+              ['science-pack-3']            = 15,
+              ['military-science-pack']     = 12,
               ['production-science-pack']   = 25,
               ['high-tech-science-pack']    = 50,
               ['space-science-pack']        = 10,
               ['enemy_killed']              = 10,       -- Base XP for killing biters and spitters. This value is multiplied by the alien_coin_modifiers from ArtefactHunting
-              ['death-penalty']             = 0.005,    -- XP deduct in percentage of total experience when a player dies (Diggy default: 0.005 which equals 0.5%)
+              ['death-penalty']             = 0.002,    -- XP deduct in percentage of total experience when a player dies (Diggy default: 0.002 which equals 0.2%)
             },
 
             buffs = { --Define new buffs here, they are handed out for each level.

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -213,29 +213,28 @@ end
 local function on_entity_died (event)
     local entity = event.entity
     local force = event.force
-
     local cause = event.cause
 
-    --For bot mining
+    --For bot mining and turrets
     if not cause or cause.type ~= 'player' or not cause.valid then
         local exp
         if force and force.name == 'player' then
-            local level = ForceControl.get_force_data(force).current_level
-            if entity.name == 'sand-rock-big' then
-                exp = floor((sand_rock_xp + (level / 5)) / 2)
-            elseif entity.name == 'rock-huge' then
-                exp = floor((rock_huge_xp + (level / 5)) / 2)
-            else
+            if cause and (cause.name == 'artillery-turret' or cause.name == 'gun-turret' or cause.name == 'laser-turret' or cause.name == 'flamethrower-turret') then
+                exp = config.XP['enemy_killed'] * alien_coin_modifiers[entity.name]
+                local text = string_format('+ %d XP', exp)
+                Game.print_floating_text(cause.surface, cause.position, text, {r = 144, g = 202, b = 249})
+                ForceControl.add_experience(force, exp)
                 return
+            else
+                local level = ForceControl.get_force_data(force).current_level
+                if entity.name == 'sand-rock-big' then
+                    exp = floor((sand_rock_xp + (level / 5)) / 2)
+                elseif entity.name == 'rock-huge' then
+                    exp = floor((rock_huge_xp + (level / 5)) / 2)
+                else
+                    return
+                end
             end
-        elseif cause and (cause.name == 'artillery-turret' or cause.name == 'gun-turret' or cause.name == 'laser-turret' or cause.name == 'flamethrower-turret') then
-            exp = Config.XP['enemy_killed'] * alien_coin_modifiers[entity.name]
-            local text = string_format('+ %d XP', exp)
-            Game.print_floating_text(cause.surface, cause.position, text, {r = 144, g = 202, b = 249})
-            ForceControl.add_experience(force, exp)
-            return
-        else
-            return
         end
         local text = string_format('+ %d XP', exp)
         Game.print_floating_text(entity.surface, entity.position, text, {r = 144, g = 202, b = 249})
@@ -246,7 +245,6 @@ local function on_entity_died (event)
     if entity.force.name ~= 'enemy' then
         return
     end
-
     local exp = config.XP['enemy_killed'] * alien_coin_modifiers[entity.name]
     local text = string_format('+ %d XP', exp)
     local player_index = cause.player.index

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -147,9 +147,9 @@ local function on_player_mined_entity(event)
     local level = ForceControl.get_force_data(force).current_level
     local exp
     if entity.name == 'sand-rock-big' then
-        exp = sand_rock_xp * (floor(level / 5) +1 )
+        exp = sand_rock_xp + (floor(level / 5))
     elseif entity.name == 'rock-huge' then
-        exp = rock_huge_xp * (floor(level / 5) + 1)
+        exp = rock_huge_xp + (floor(level / 5))
     else
         return
     end
@@ -222,9 +222,9 @@ local function on_entity_died (event)
         local level = ForceControl.get_force_data(force).current_level
         if force.name == 'player' then
             if entity.name == 'sand-rock-big' then
-                exp = floor((sand_rock_xp * (floor(level / 5) +1 )) / 2)
+                exp = floor((sand_rock_xp + (floor(level / 5))) / 2)
             elseif entity.name == 'rock-huge' then
-                exp = floor((rock_huge_xp * (floor(level / 5) +1 )) / 2)
+                exp = floor((rock_huge_xp + (floor(level / 5))) / 2)
             else
                 return
             end

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -79,7 +79,9 @@ function Experience.update_mining_speed(force, level_up)
     level_up = level_up ~= nil and level_up or 0
     local buff = config.buffs['mining_speed']
     if level_up > 0 and buff ~= nil then
-        local value = (buff.double_level ~= nil and level_up % buff.double_level == 0) and buff.value * 2 or buff.value
+        local level = ForceControl.get_force_data(force).current_level
+        local adjusted_value = floor(math.max(buff.value, 24*0.9^level))
+        local value = (buff.double_level ~= nil and level_up % buff.double_level == 0) and adjusted_value * 2 or adjusted_value
         mining_efficiency.level_modifier = mining_efficiency.level_modifier + (value * 0.01)
     end
     -- remove the current buff

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -147,9 +147,9 @@ local function on_player_mined_entity(event)
     local level = ForceControl.get_force_data(force).current_level
     local exp
     if entity.name == 'sand-rock-big' then
-        exp = sand_rock_xp + (floor(level / 5))
+        exp = sand_rock_xp + floor(level / 5)
     elseif entity.name == 'rock-huge' then
-        exp = rock_huge_xp + (floor(level / 5))
+        exp = rock_huge_xp + floor(level / 5)
     else
         return
     end
@@ -200,7 +200,7 @@ end
 ---@param event LuaEvent
 local function on_rocket_launched(event)
     local force = event.rocket.force
-    local exp = ForceControl.add_experience_percentage(force, config.XP['rocket_launch'], 5000)
+    local exp = ForceControl.add_experience_percentage(force, config.XP['rocket_launch'])
     local text = string_format('Rocket launched! +%d XP', exp)
     for _, p in pairs(game.connected_players) do
         local player_index = p.index
@@ -222,9 +222,9 @@ local function on_entity_died (event)
         if force and force.name == 'player' then
             local level = ForceControl.get_force_data(force).current_level
             if entity.name == 'sand-rock-big' then
-                exp = floor((sand_rock_xp + (floor(level / 5))) / 2)
+                exp = floor((sand_rock_xp + (level / 5)) / 2)
             elseif entity.name == 'rock-huge' then
-                exp = floor((rock_huge_xp + (floor(level / 5))) / 2)
+                exp = floor((rock_huge_xp + (level / 5)) / 2)
             else
                 return
             end

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -219,8 +219,8 @@ local function on_entity_died (event)
     --For bot mining
     if not cause or cause.type ~= 'player' or not cause.valid then
         local exp
-        local level = ForceControl.get_force_data(force).current_level
-        if force.name == 'player' then
+        if force and force.name == 'player' then
+            local level = ForceControl.get_force_data(force).current_level
             if entity.name == 'sand-rock-big' then
                 exp = floor((sand_rock_xp + (floor(level / 5))) / 2)
             elseif entity.name == 'rock-huge' then


### PR DESCRIPTION
Fixed rockets not giving experience and converted it to 1% of total experience.

Decreased player died deduct to 0.2%

Increased xp from rocks by 1 every fifth level

Increased xp from bots by about 1 every tenth level.

Increased early science XP reward (doubled for red and green, 50% for black and blue)

Level 100 is not 19,990,000 XP (Down from 30 million)

Starting XP is 400.