### PR TITLE
Ban sync

### DIFF
--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -2,6 +2,7 @@ local Event = require 'utils.event'
 local UserGroups = require 'features.user_groups'
 local Utils = require 'utils.utils'
 local Game = require 'utils.game'
+local Server = require 'features.server'
 
 local function allowed_to_nuke(player)
     return player.admin or UserGroups.is_regular(player.name) or
@@ -128,7 +129,7 @@ local function on_capsule_used(event)
     end
 
     local nuke_control = global.config.nuke_control
-    if not nuke_control.enable_autokick and not nuke_control.enable_autoban then        
+    if not nuke_control.enable_autokick and not nuke_control.enable_autoban then
         return
     end
 
@@ -148,13 +149,14 @@ local function on_capsule_used(event)
         if count > 8 then
             if global.players_warned[event.player_index] then
                 if nuke_control.enable_autoban then
-                    game.ban_player(
+                    Server.ban_sync(
                         player,
                         string.format(
                             'Damaged %i entities with %s. This action was performed automatically. If you want to contest this ban please visit redmew.com/discord.',
                             count,
                             item.name
-                        )
+                        ),
+                        '<script>'
                     )
                 end
             else
@@ -170,7 +172,7 @@ end
 local function on_player_joined(event)
     local player = game.players[event.player_index]
     if string.match(player.name, '^[Ili1|]+$') then
-        game.ban_player(player) --No reason given, to not give them any hints to change their name
+        Server.ban_sync(player, '', '<script>') --No reason given, to not give them any hints to change their name
     end
 end
 

--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -150,7 +150,7 @@ local function on_capsule_used(event)
             if global.players_warned[event.player_index] then
                 if nuke_control.enable_autoban then
                     Server.ban_sync(
-                        player,
+                        player.name,
                         string.format(
                             'Damaged %i entities with %s. This action was performed automatically. If you want to contest this ban please visit redmew.com/discord.',
                             count,
@@ -172,7 +172,7 @@ end
 local function on_player_joined(event)
     local player = game.players[event.player_index]
     if string.match(player.name, '^[Ili1|]+$') then
-        Server.ban_sync(player, '', '<script>') --No reason given, to not give them any hints to change their name
+        Server.ban_sync(player.name, '', '<script>') --No reason given, to not give them any hints to change their name
     end
 end
 

--- a/features/server.lua
+++ b/features/server.lua
@@ -413,7 +413,7 @@ function Public.unban_sync(username, admin)
         admin = '<script>'
     end
 
-    -- game.ban_player errors if player not found.
+    -- game.unban_player errors if player not found.
     -- However we may still want to use this function to unban player names.
     local player = game.players[username]
     if player then

--- a/features/server.lua
+++ b/features/server.lua
@@ -357,7 +357,7 @@ local function escape(str)
 end
 
 --- If the player exists bans the player.
--- Regardless of if the player exists the name is synchronized with other servers
+-- Regardless of whether or not the player exists the name is synchronized with other servers
 -- and stored in the database.
 -- @param  username<string>
 -- @param  reason<string?> defaults to empty string.
@@ -400,7 +400,7 @@ function Public.ban_non_sync(PlayerSpecification, reason)
 end
 
 --- If the player exists unbans the player.
--- Regardless of if the player exists the name is synchronized with other servers
+-- Regardless of whether or not the player exists the name is synchronized with other servers
 -- and removed from the database.
 -- @param  username<string>
 -- @param  admin<string?> admin's name, defaults to '<script>'. This name is stored in the logs for who removed the ban.

--- a/features/server.lua
+++ b/features/server.lua
@@ -24,6 +24,8 @@ local data_set_tag = '[DATA-SET]'
 local data_get_tag = '[DATA-GET]'
 local data_get_all_tag = '[DATA-GET-ALL]'
 local data_tracked_tag = '[DATA-TRACKED]'
+local ban_sync_tag = '[BAN-SYNC]'
+local unbanned_sync_tag = '[UNBANNED-SYNC]'
 
 Public.raw_print = raw_print
 
@@ -348,6 +350,88 @@ function Public.get_tracked_data_sets()
 
     message = table.concat(message)
     raw_print(message)
+end
+
+local function escape(str)
+    return str:gsub('\\', '\\\\'):gsub('"', '\\"')
+end
+
+--- If the player exists bans the player.
+-- Regardless of if the player exists the name is synchronized with other servers
+-- and stored in the database.
+-- @param  username<string>
+-- @param  reason<string?> defaults to empty string.
+-- @param  admin<string?> admin's name, defaults to '<script>'
+function Public.ban_sync(username, reason, admin)
+    if type(username) ~= 'string' then
+        error('username must be a string')
+    end
+
+    if type(reason) ~= 'string' then
+        reason = ''
+    end
+
+    if type(admin) ~= 'string' then
+        admin = '<script>'
+    end
+
+    -- game.ban_player errors if player not found.
+    -- However we may still want to use this function to ban player names.
+    local player = game.players[username]
+    if player then
+        game.ban_player(player, reason)
+    end
+
+    username = escape(username)
+    reason = escape(reason)
+    admin = escape(admin)
+
+    local message =
+        table.concat({ban_sync_tag, '{username:"', username, '",reason:"', reason, '",admin:"', admin, '"}'})
+    raw_print(message)
+end
+
+--- If the player exists bans the player else throws error.
+-- The ban is not synchronized with other servers or stored in the database.
+-- @param  PlayerSpecification
+-- @param  reason<string?> defaults to empty string.
+function Public.ban_non_sync(PlayerSpecification, reason)
+    game.ban_player(PlayerSpecification, reason)
+end
+
+--- If the player exists unbans the player.
+-- Regardless of if the player exists the name is synchronized with other servers
+-- and removed from the database.
+-- @param  username<string>
+-- @param  admin<string?> admin's name, defaults to '<script>'. This name is stored in the logs for who removed the ban.
+function Public.unban_sync(username, admin)
+    if type(username) ~= 'string' then
+        error('username must be a string')
+    end
+
+    if type(admin) ~= 'string' then
+        admin = '<script>'
+    end
+
+    -- game.ban_player errors if player not found.
+    -- However we may still want to use this function to unban player names.
+    local player = game.players[username]
+    if player then
+        game.unban_player(username)
+    end
+
+    username = escape(username)
+    admin = escape(admin)
+
+    local message = table.concat({unbanned_sync_tag, '{username:"', username, '",admin:"', admin, '"}'})
+    raw_print(message)
+end
+
+--- If the player exists unbans the player else throws error.
+-- The ban is not synchronized with other servers or removed from the database.
+-- @param  PlayerSpecification
+function Public.unban_non_sync(PlayerSpecification)
+    game.unban_player(PlayerSpecification)
 end
 
 return Public

--- a/features/server.lua
+++ b/features/server.lua
@@ -367,12 +367,16 @@ function Public.ban_sync(username, reason, admin)
         error('username must be a string')
     end
 
-    if type(reason) ~= 'string' then
+    if reason == nil then
         reason = ''
+    elseif type(reason) ~= 'string' then
+        error('reason must be a string or nil')
     end
 
-    if type(admin) ~= 'string' then
+    if admin == nil then
         admin = '<script>'
+    elseif type(admin) ~= 'string' then
+        error('admin must be a string or nil')
     end
 
     -- game.ban_player errors if player not found.
@@ -409,8 +413,10 @@ function Public.unban_sync(username, admin)
         error('username must be a string')
     end
 
-    if type(admin) ~= 'string' then
+    if admin == nil then
         admin = '<script>'
+    elseif type(admin) ~= 'string' then
+        error('admin must be a string or nil')
     end
 
     -- game.unban_player errors if player not found.


### PR DESCRIPTION
Due to the way the web interface synchronises bans, bans that happen in scripts with `game.ban_player` wont be synced.

This PR adds `Server.ban_sync` and `Server.unban_sync` which allows bans that happen from scripts to be synchronised.

I also added `Server.ban_non_sync` and `Server.unban_non_sync` for symmetry but they just call `game.ban_player` and `game.unban_player` respectively.  