### PR TITLE
Add inspect and size to table util

### DIFF
--- a/utils/table.lua
+++ b/utils/table.lua
@@ -143,3 +143,7 @@ table.binary_search =
 
     return -1 - lower -- ~lower
 end
+
+table.inspect = require'inspect'
+
+table.size = table_size


### PR DESCRIPTION
Now that I understand refs a bit better, adding these to make table functions a little more consistent.

For my own peace of mind, I tested `table.size` and `table_size` on a 10,000,000 entry table and they were the same speed.

I also found out that if you use table.inspect on a 10,000,000 entry table 1) it takes long (no surprise) but
2) it slows down your whole game if your chat log/history is overstuffed. After pausing to let the game catch up, it was still running below 60 UPS, a /clear brought game speed back up to expected levels.