### PR TITLE
Add camera

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -69,3 +69,4 @@ if config.score.enabled then
     require 'features.gui.score'
 end
 require 'features.gui.popup'
+require 'features.gui.camera'

--- a/features/gui/camera.lua
+++ b/features/gui/camera.lua
@@ -184,5 +184,5 @@ local function watch_close_button(event)
 end
 
 Command.add('watch', {description = 'Allows you to watch other players. Use /watch to close the camera.', arguments = {'target'}, default_values = {target = false}, admin_only = false}, watch_command)
-Event.add(defines.events.on_tick, on_tick)
+Event.on_nth_tick(120, on_tick)
 Gui.on_click(main_button_name, watch_close_button)

--- a/features/gui/camera.lua
+++ b/features/gui/camera.lua
@@ -8,11 +8,13 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]]
-
 local Event = require 'utils.event'
 local mod_gui = require 'mod-gui'
 local Command = require 'utils.command'
 local Game = require 'utils.game'
+local Gui = require 'utils.gui'
+
+local main_button_name = Gui.uid_name()
 global.camera_users = {}
 
 local zoomlevels = {1.00, 0.75, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05}
@@ -20,11 +22,65 @@ local zoomlevellabels = {'100%', '75%', '50%', '40%', '30%', '25%', '20%', '15%'
 local sizelevels = {0, 100, 200, 250, 300, 350, 400, 450, 500}
 local sizelevellabels = {'hide', '100x100', '200x200', '250x250', '300x300', '350x350', '400x400', '450x450', '500x500'}
 
+local function apply_button_style(button)
+    local button_style = button.style
+    button_style.font = 'default-bold'
+    button_style.height = 26
+    button_style.top_padding = 0
+    button_style.bottom_padding = 0
+    button_style.left_padding = 2
+    button_style.right_padding = 2
+end
+
+local function create_destroy_camera(destroy, player, args, table_index)
+    local player_index = player.index
+    local mainframeflow = mod_gui.get_frame_flow(player)
+    local mainframeid = 'mainframe_' .. player_index
+    local mainframe = mainframeflow[mainframeid]
+
+    if table_index or destroy then
+        if global.camera_users[player_index] then
+            global.camera_users[player_index] = nil
+        else
+            player.print('No current target. Correct usage is /watch <target> to watch a player.')
+        end
+        if mainframe then
+            mainframe.destroy()
+            if args then
+                player.print('Closing camera.')
+            end
+        end
+    end
+    if args and args.target then
+        local target = game.players[args.target]
+        if not target then
+            player.print('Not a valid target')
+            return
+        end
+        if not mainframe then
+            mainframe = mainframeflow.add {type = 'frame', name = mainframeid, direction = 'vertical', style = 'captionless_frame'}
+            mainframe.style.visible = true
+        end
+        local headerframe = mainframe.headerframe
+        if not headerframe then
+            mainframe.add {type = 'frame', name = 'headerframe', direction = 'horizontal', style = 'captionless_frame'}
+        end
+        local cameraframe = mainframe.cameraframe
+        if not cameraframe then
+            mainframe.add {type = 'frame', name = 'cameraframe', style = 'captionless_frame'}
+        end
+        mainframe.add {type = 'label', caption = 'Following: ' .. args.target}
+        local close_button = mainframe.add {type = 'button', name = main_button_name, caption = 'Close'}
+        apply_button_style(close_button)
+        local target_index = target.index
+        global.camera_users[player_index] = target_index
+    end
+end
+
 local function update_camera_render(target, targetframe, zoom, size, visible)
     local position = {x = target.position.x, y = target.position.y - 0.5}
     local surface_index = target.surface.index
     local preview_size = size
-
     local camera = targetframe.camera
 
     if not camera then
@@ -34,56 +90,20 @@ local function update_camera_render(target, targetframe, zoom, size, visible)
     camera.position = position
     camera.surface_index = surface_index
     camera.zoom = zoom
-
     camera.style.visible = visible
-
     camera.style.minimal_width = preview_size
     camera.style.minimal_height = preview_size
     camera.style.maximal_width = preview_size
     camera.style.maximal_height = preview_size
 end
 
-local function update_camera_playerselection(targetframe, playerlist)
-    local playerselection = targetframe.playerselection
-
-    local playerlabels = {}
-    for i = 1, #playerlist do
-        local player = playerlist[i]
-        playerlabels[i] = {player.name}
-    end
-
-    if playerselection then
-        playerselection.items = playerlabels
-    else
-        playerselection = targetframe.add {type = 'drop-down', name = 'playerselection', items = playerlabels, selected_index = 1}
-    end
-
-    local target = playerlist[playerselection.selected_index]
-    if not target.connected then
-        local done = false
-        for i = 1, #playerlist do
-            if not done then
-                local player = playerlist[i]
-                -- note(angelickite): there should always be at least one player that is connected, namely the active player itself!
-                if player.connected then
-                    playerselection.selected_index = i
-                    done = true
-                end
-            end
-        end
-    end
-
-    return playerselection.selected_index
-end
-
 local function update_camera_zoom(targetframe)
     local zoomselection = targetframe.zoomselection
-
     local zoomlabels = {}
+
     for i = 1, #zoomlevellabels do
         zoomlabels[i] = {'', '' .. zoomlevellabels[i]}
     end
-
     if zoomselection then
         zoomselection.items = zoomlabels
     else
@@ -96,12 +116,11 @@ end
 
 local function update_camera_size(targetframe)
     local sizeselection = targetframe.sizeselection
-
     local sizelabels = {}
+
     for i = 1, #sizelevellabels do
         sizelabels[i] = {'', '' .. sizelevellabels[i]}
     end
-
     if sizeselection then
         sizeselection.items = sizelabels
     else
@@ -110,54 +129,43 @@ local function update_camera_size(targetframe)
 
     local size = sizelevels[sizeselection.selected_index]
     local visible = (size ~= 0)
-
     return size, visible
 end
 
 local function on_tick()
-    for _, player_index in pairs(global.camera_users) do
-        local player = Game.get_player_by_index(player_index)
+    for table_key, camera_table in pairs(global.camera_users) do
+        local player = Game.get_player_by_index(table_key)
+        local target = Game.get_player_by_index(camera_table)
+        if not target.connected then
+            create_destroy_camera(true, player, nil, table_key)
+            player.print('Target has went offline, camera closed')
+            return
+        end
         local mainframeflow = mod_gui.get_frame_flow(player)
-        local mainframeid = 'mainframe_' .. player_index
+        local mainframeid = 'mainframe_' .. table_key
         local mainframe = mainframeflow[mainframeid]
-        local headerframe = mainframe.headerframe
-        local cameraframe = mainframe.cameraframe
-        local selected_target_index = update_camera_playerselection(headerframe, game.connected_players)
-        local zoom = update_camera_zoom(headerframe)
-        local size, visible = update_camera_size(headerframe)
-
-        update_camera_render(Game.get_player_by_index(selected_target_index), cameraframe, zoom, size, visible)
+        if mainframe then
+            local headerframe = mainframe.headerframe
+            local cameraframe = mainframe.cameraframe
+            local zoom = update_camera_zoom(headerframe)
+            local size, visible = update_camera_size(headerframe)
+            update_camera_render(target, cameraframe, zoom, size, visible)
+        end
     end
 end
 
-local function camera(_, player)
-    local player_index = player.index
-    local table_index = table.index_of(global.camera_users, player_index)
-    local mainframeflow = mod_gui.get_frame_flow(player)
-    local mainframeid = 'mainframe_' .. player_index
-    local mainframe = mainframeflow[mainframeid]
-
-    if table_index > 0 then
-        mainframe.destroy()
-        global.camera_users[table_index] = nil
+local function watch_command(args, player)
+    if args.target then
+        create_destroy_camera(nil, player, args)
     else
-        if not mainframe then
-            mainframe = mainframeflow.add {type = 'frame', name = mainframeid, direction = 'vertical', style = 'captionless_frame'}
-            mainframe.style.visible = true
-        end
-
-        local headerframe = mainframe.headerframe
-        if not headerframe then
-            mainframe.add {type = 'frame', name = 'headerframe', direction = 'horizontal', style = 'captionless_frame'}
-        end
-
-        local cameraframe = mainframe.cameraframe
-        if not cameraframe then
-            mainframe.add {type = 'frame', name = 'cameraframe', style = 'captionless_frame'}
-        end
-        table.insert(global.camera_users, player_index)
+        create_destroy_camera(true, player, args)
     end
 end
 
-Command.add('camera', {description = 'Allows you to watch other players', admin_only = false, debug_only = false}, camera)
+local function watch_close_button(event)
+    create_destroy_camera(true, event.player)
+end
+
+Command.add('watch', {description = 'Allows you to watch other players. Use /watch to close the camera.', arguments = {'target'}, default_values = {target = false}, admin_only = false, debug_only = false}, watch_command)
 Event.add(defines.events.on_tick, on_tick)
+Gui.on_click(main_button_name, watch_close_button)

--- a/features/gui/camera.lua
+++ b/features/gui/camera.lua
@@ -1,0 +1,163 @@
+--[[
+Camera, used under MIT license.
+Copyright 2018 angelickite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+]]
+
+local Event = require 'utils.event'
+local mod_gui = require 'mod-gui'
+local Command = require 'utils.command'
+local Game = require 'utils.game'
+global.camera_users = {}
+
+local zoomlevels = {1.00, 0.75, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05}
+local zoomlevellabels = {'100%', '75%', '50%', '40%', '30%', '25%', '20%', '15%', '10%', '5%'}
+local sizelevels = {0, 100, 200, 250, 300, 350, 400, 450, 500}
+local sizelevellabels = {'hide', '100x100', '200x200', '250x250', '300x300', '350x350', '400x400', '450x450', '500x500'}
+
+local function update_camera_render(target, targetframe, zoom, size, visible)
+    local position = {x = target.position.x, y = target.position.y - 0.5}
+    local surface_index = target.surface.index
+    local preview_size = size
+
+    local camera = targetframe.camera
+
+    if not camera then
+        camera = targetframe.add {type = 'camera', name = 'camera', position = position, surface_index = surface_index, zoom = zoom}
+    end
+
+    camera.position = position
+    camera.surface_index = surface_index
+    camera.zoom = zoom
+
+    camera.style.visible = visible
+
+    camera.style.minimal_width = preview_size
+    camera.style.minimal_height = preview_size
+    camera.style.maximal_width = preview_size
+    camera.style.maximal_height = preview_size
+end
+
+local function update_camera_playerselection(targetframe, playerlist)
+    local playerselection = targetframe.playerselection
+
+    local playerlabels = {}
+    for i = 1, #playerlist do
+        local player = playerlist[i]
+        playerlabels[i] = {player.name}
+    end
+
+    if playerselection then
+        playerselection.items = playerlabels
+    else
+        playerselection = targetframe.add {type = 'drop-down', name = 'playerselection', items = playerlabels, selected_index = 1}
+    end
+
+    local target = playerlist[playerselection.selected_index]
+    if not target.connected then
+        local done = false
+        for i = 1, #playerlist do
+            if not done then
+                local player = playerlist[i]
+                -- note(angelickite): there should always be at least one player that is connected, namely the active player itself!
+                if player.connected then
+                    playerselection.selected_index = i
+                    done = true
+                end
+            end
+        end
+    end
+
+    return playerselection.selected_index
+end
+
+local function update_camera_zoom(targetframe)
+    local zoomselection = targetframe.zoomselection
+
+    local zoomlabels = {}
+    for i = 1, #zoomlevellabels do
+        zoomlabels[i] = {'', '' .. zoomlevellabels[i]}
+    end
+
+    if zoomselection then
+        zoomselection.items = zoomlabels
+    else
+        zoomselection = targetframe.add {type = 'drop-down', name = 'zoomselection', items = zoomlabels, selected_index = 3}
+    end
+
+    local zoom = zoomlevels[zoomselection.selected_index]
+    return zoom
+end
+
+local function update_camera_size(targetframe)
+    local sizeselection = targetframe.sizeselection
+
+    local sizelabels = {}
+    for i = 1, #sizelevellabels do
+        sizelabels[i] = {'', '' .. sizelevellabels[i]}
+    end
+
+    if sizeselection then
+        sizeselection.items = sizelabels
+    else
+        sizeselection = targetframe.add {type = 'drop-down', name = 'sizeselection', items = sizelabels, selected_index = 4}
+    end
+
+    local size = sizelevels[sizeselection.selected_index]
+    local visible = (size ~= 0)
+
+    return size, visible
+end
+
+local function on_tick()
+    for _, player_index in pairs(global.camera_users) do
+        local player = Game.get_player_by_index(player_index)
+        local mainframeflow = mod_gui.get_frame_flow(player)
+        local mainframeid = 'mainframe_' .. player_index
+        local mainframe = mainframeflow[mainframeid]
+        local headerframe = mainframe.headerframe
+        local cameraframe = mainframe.cameraframe
+        local selected_target_index = update_camera_playerselection(headerframe, game.connected_players)
+        local zoom = update_camera_zoom(headerframe)
+        local size, visible = update_camera_size(headerframe)
+
+        update_camera_render(Game.get_player_by_index(selected_target_index), cameraframe, zoom, size, visible)
+    end
+end
+
+local function camera(_, player)
+    local player_index = player.index
+    local table_index = table.index_of(global.camera_users, player_index)
+    local mainframeflow = mod_gui.get_frame_flow(player)
+    local mainframeid = 'mainframe_' .. player_index
+    local mainframe = mainframeflow[mainframeid]
+
+    if table_index > 0 then
+        mainframe.destroy()
+        global.camera_users[table_index] = nil
+    else
+        if not mainframe then
+            mainframe = mainframeflow.add {type = 'frame', name = mainframeid, direction = 'vertical', style = 'captionless_frame'}
+            mainframe.style.visible = true
+        end
+
+        local headerframe = mainframe.headerframe
+        if not headerframe then
+            mainframe.add {type = 'frame', name = 'headerframe', direction = 'horizontal', style = 'captionless_frame'}
+        end
+
+        local cameraframe = mainframe.cameraframe
+        if not cameraframe then
+            mainframe.add {type = 'frame', name = 'cameraframe', style = 'captionless_frame'}
+        end
+        table.insert(global.camera_users, player_index)
+    end
+end
+
+Command.add('camera', {description = 'Allows you to watch other players', admin_only = false, debug_only = false}, camera)
+Event.add(defines.events.on_tick, on_tick)

--- a/features/gui/camera.lua
+++ b/features/gui/camera.lua
@@ -13,9 +13,19 @@ local mod_gui = require 'mod-gui'
 local Command = require 'utils.command'
 local Game = require 'utils.game'
 local Gui = require 'utils.gui'
+local Global = require 'utils.global'
 
 local main_button_name = Gui.uid_name()
-global.camera_users = {}
+
+local camera_users = {}
+Global.register(
+    {
+        camera_users = camera_users,
+    },
+    function(tbl)
+        camera_users = tbl.camera_users
+    end
+)
 
 local zoomlevels = {1.00, 0.75, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05}
 local zoomlevellabels = {'100%', '75%', '50%', '40%', '30%', '25%', '20%', '15%', '10%', '5%'}
@@ -39,8 +49,8 @@ local function create_destroy_camera(destroy, player, args, table_index)
     local mainframe = mainframeflow[mainframeid]
 
     if table_index or destroy then
-        if global.camera_users[player_index] then
-            global.camera_users[player_index] = nil
+        if camera_users[player_index] then
+            camera_users[player_index] = nil
         else
             player.print('No current target. Correct usage is /watch <target> to watch a player.')
         end
@@ -73,7 +83,7 @@ local function create_destroy_camera(destroy, player, args, table_index)
         local close_button = mainframe.add {type = 'button', name = main_button_name, caption = 'Close'}
         apply_button_style(close_button)
         local target_index = target.index
-        global.camera_users[player_index] = target_index
+        camera_users[player_index] = target_index
     end
 end
 
@@ -133,7 +143,7 @@ local function update_camera_size(targetframe)
 end
 
 local function on_tick()
-    for table_key, camera_table in pairs(global.camera_users) do
+    for table_key, camera_table in pairs(camera_users) do
         local player = Game.get_player_by_index(table_key)
         local target = Game.get_player_by_index(camera_table)
         if not target.connected then

--- a/features/gui/camera.lua
+++ b/features/gui/camera.lua
@@ -143,6 +143,9 @@ local function update_camera_size(targetframe)
 end
 
 local function on_tick()
+    if global.config.camera_disabled then
+        return
+    end
     for table_key, camera_table in pairs(camera_users) do
         local player = Game.get_player_by_index(table_key)
         local target = Game.get_player_by_index(camera_table)
@@ -165,6 +168,10 @@ local function on_tick()
 end
 
 local function watch_command(args, player)
+    if global.config.camera_disabled then
+        player.print('The watch/camera function has been disabled for performance reasons.')
+        return
+    end
     if args.target then
         create_destroy_camera(nil, player, args)
     else
@@ -176,6 +183,6 @@ local function watch_close_button(event)
     create_destroy_camera(true, event.player)
 end
 
-Command.add('watch', {description = 'Allows you to watch other players. Use /watch to close the camera.', arguments = {'target'}, default_values = {target = false}, admin_only = false, debug_only = false}, watch_command)
+Command.add('watch', {description = 'Allows you to watch other players. Use /watch to close the camera.', arguments = {'target'}, default_values = {target = false}, admin_only = false}, watch_command)
 Event.add(defines.events.on_tick, on_tick)
 Gui.on_click(main_button_name, watch_close_button)


### PR DESCRIPTION
Adaptation of https://mods.factorio.com/mod/camera used under MIT licensing.

`/camera` opens a window with nice zoom and size controls, allows you to choose a target and get a camera that follows them as well as your latency allows.

Thanks to @iltar's great command wrapper we can quickly and easily toggle it to admin-only if over-use causes any issues.