### PR TITLE
Added particle limits and scales

### DIFF
--- a/features/create_particles.lua
+++ b/features/create_particles.lua
@@ -1,8 +1,120 @@
 local Task = require 'utils.Task'
+local Global = require 'utils.global'
 local Token = require 'utils.token'
+local Command = require 'utils.command'
+local Event = require 'utils.event'
 local random = math.random
+local ceil = math.ceil
+local floor = math.floor
+local format = string.format
 
 local CreateParticles = {}
+
+local settings = {
+    scale = 1.0,
+    particles_spawned_buffer = 0,
+    max_particles_in_three_seconds = 12000,
+}
+
+Global.register({
+    settings = settings,
+}, function (tbl)
+    settings = tbl.settings
+end)
+
+---sets the scale of particles. 1.0 means 100%, 0.5 would mean spawn only 50% of the particles.
+---@param scale number
+function CreateParticles.set_scale(scale)
+    if scale < 0 or scale > 1 then
+        error(format('Scale must range from 0 to 1'))
+    end
+
+    settings.scale = scale
+end
+
+---Returns the current scale
+function CreateParticles.get_scale()
+    return settings.scale
+end
+
+local function get_particle_cap()
+    return settings.max_particles_in_three_seconds * (settings.scale + 0.1)
+end
+
+---Returns whether or not more particles may be spawned, scale minimum is 0.1
+local function may_spawn_particles()
+    return settings.particles_spawned_buffer < get_particle_cap()
+end
+
+--- resets the amount of particles in the past 3 seconds so new ones may spawn
+Event.on_nth_tick(191, function ()
+    settings.particles_spawned_buffer = 0
+end)
+
+Command.add('set-particle-scale', {
+    description = 'Sets the particle scale between 0 and 1. Lower means less particles per function and a lower buffer size per 3 seconds.',
+    arguments = {'scale'},
+    admin_only = true,
+    allowed_by_server = true,
+}, function (arguments, player)
+    local scale = tonumber(arguments.scale)
+    if scale == nil or scale < 0 or scale > 1 then
+        player.print('Scale must be a valid number ranging from 0 to 1')
+        return
+    end
+
+    CreateParticles.set_scale(scale)
+    local p = player.print
+    p(format('Particle scale changed to: %.2f', scale))
+    p(format('Particles per 3 seconds: %d', get_particle_cap()))
+end)
+
+Command.add('get-particle-scale', {
+    description = 'Shows the current particle scale.',
+    admin_only = true,
+    allowed_by_server = true,
+}, function (_, player)
+    local p = player.print
+    p(format('Particle scale: %.2f', CreateParticles.get_scale()))
+    p(format('Particles per 3 seconds: %d', get_particle_cap()))
+end)
+
+---Scales the count to round the fraction up. Always returns at least 1 unless the particle limit is reached.
+---Useful for particle spawning that influences gameplay for visual indications.
+---@param count number
+local function scale_ceil(count)
+    if not may_spawn_particles() then
+        return 0
+    end
+
+    local scale = settings.scale
+    if scale == 0 then
+        return 1
+    end
+    if scale < 1 and count > 1 then
+        count = ceil(count * scale)
+    end
+
+    return count
+end
+
+---Scales the count to round the fraction down.
+---Useful for particle spawning that doesn't influence gameplay.
+---@param count number
+local function scale_floor(count)
+    local scale = settings.scale
+    if scale == 0 then
+        return 0
+    end
+    if not may_spawn_particles() then
+        return 0
+    end
+    if scale < 1 then
+        count = floor(count * scale)
+    end
+
+    return count
+end
 
 local on_play_particle = Token.register(function (params)
     params.surface.create_entity(params.prototype)
@@ -25,7 +137,8 @@ end
 ---@param particle_count number particle count to spawn
 ---@param position Position
 function CreateParticles.destroy_rock(create_entity, particle_count, position)
-    for _ = particle_count, 1, -1 do
+    for _ = scale_floor(particle_count), 1, -1 do
+        settings.particles_spawned_buffer = settings.particles_spawned_buffer + 1
         create_entity({
             position = position,
             name = 'stone-particle',
@@ -57,7 +170,8 @@ end
 ---@param particle_count number particle count to spawn
 ---@param position Position
 function CreateParticles.mine_rock(create_entity, particle_count, position)
-    for _ = particle_count, 1, -1 do
+    for _ = scale_floor(particle_count), 1, -1 do
+        settings.particles_spawned_buffer = settings.particles_spawned_buffer + 1
         create_entity({
             position = position,
             name = 'stone-particle',
@@ -92,13 +206,22 @@ function CreateParticles.ceiling_crumble(surface, position)
     local sequences = {}
     local x = position.x
     local y = position.y
+    local smoke_scale = scale_ceil(2)
+    local stone_scale = scale_floor(4)
 
-    for i = 1, 2 do
+    -- pre-calculate how many particles will be spawned. Prevents spawning too many particles over ticks.
+    local particles = settings.particles_spawned_buffer
+
+    for i = 1, smoke_scale do
+        particles = particles + 1
         sequences[i] = {frame = i*random(1,15), prototype = create_ceiling_prototype('explosion-remnants-particle', x, y)}
     end
-    for i = 3, 6 do
+    for i = smoke_scale + 1, smoke_scale + stone_scale do
+        particles = particles + 1
         sequences[i] = {frame = i*random(1,15), prototype = create_ceiling_prototype('stone-particle', x, y)}
     end
+
+    settings.particles_spawned_buffer = particles
 
     play_particle_sequence(surface, sequences)
 end

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -163,7 +163,7 @@ function Command.add(command_name, options, callback)
                 end
             end
 
-            if not parameter then
+            if parameter == nil then
                 insert(errors, format('Argument %s from command %s is missing.', argument, command_name))
             else
                 named_arguments[argument] = parameter


### PR DESCRIPTION
This PR adds the following:
 - the option to scale the total particles
 - an upper limit per 191 ticks of `12000 * (scale + 0.1)` particles
 - the ability to (run-time) change the scale of particles in case of performance issues (admin/server only)

While this doesn't fix the entirety of nukes in Diggy, it does no longer crash the server. Previously it would spawn up to 450k particles, which is now limited to 13~26k (depending on when it resets).

Some particles follow a ceil instead of floor rounding, like ceiling crumbling, as this is a game mechanic rather than a visual enhancement.

Fixes #495