### PR TITLE
Gave the player_create feature the same as diggy SetupPlayer

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -14,6 +14,8 @@ global.config = {
     -- New Scenario Features, appears in the "What's new" tab
     new_info_key = 'Nothing is new. The world is at peace',
 
+    -- Adds a command to scale UPS and movement speed. Use with caution
+    -- as it might break scenarios that modify movement speed
     performance = {
         enabled = true,
     },
@@ -96,6 +98,66 @@ global.config = {
     -- enable the mentioning system, which notifies a player when their name is mentioned
     mentions = {
         enabled = true,
+    },
+
+    player_create = {
+        enabled = true,
+
+        -- items automatically inserted into the player inventory
+        starting_items = {
+            {name = 'iron-gear-wheel', count = 8},
+            {name = 'iron-plate', count = 16},
+        },
+
+        -- opens the scenario popup when the player joins
+        show_info_at_start = true,
+
+        -- prints messages when the player joins
+        join_messages = {
+            'Welcome to this map created by the RedMew team. You can join our discord at: redmew.com/discord',
+            'Click the question mark in the top left corner for server information and map details.',
+        },
+
+        -- format is a table: {{message, weight}, {message, weight}}, where a higher weight has more chance to be shown
+        random_join_message_set = require 'resources.join_messages',
+
+        -- applied when cheat_mode is set to true
+        cheats = {
+            -- Sets the manual mining speed for the player force. A value of 1 = 100% faster. Setting it
+            -- to 0.5 would make it 50% faster than the base speed.
+            manual_mining_speed_modifier = 1000,
+
+            -- increase the amount of inventory slots for the player force
+            character_inventory_slots_bonus = 0,
+
+            -- increases the run speed of all characters for the player force
+            character_running_speed_modifier = 5,
+
+            -- a flat health bonus to the player force
+            character_health_bonus = 1000000,
+
+            -- unlock all research by default, only useful when testing
+            unlock_all_research = true,
+
+            -- starts with a fully slotted power armor mk2
+            start_with_power_armor = true,
+
+            -- adds additional items to the player when _CHEATS is true
+            starting_items = {
+                {name = 'steel-axe', count = 10},
+                {name = 'submachine-gun', count = 1},
+                {name = 'uranium-rounds-magazine', count = 200},
+                {name = 'construction-robot', count = 250},
+                {name = 'electric-energy-interface', count = 50},
+                {name = 'substation', count = 50},
+                {name = 'roboport', count = 10},
+                {name = 'infinity-chest', count = 10},
+                {name = 'small-plane', count = 2},
+                {name = 'coin', count = 20000},
+                {name = 'rocket-part', count = 2},
+                {name = 'computer', count = 2},
+            },
+        },
     },
 }
 

--- a/config.lua
+++ b/config.lua
@@ -136,9 +136,6 @@ global.config = {
             -- a flat health bonus to the player force
             character_health_bonus = 1000000,
 
-            -- unlock all research by default, only useful when testing
-            unlock_all_research = true,
-
             -- starts with a fully slotted power armor mk2
             start_with_power_armor = true,
 

--- a/features/player_create.lua
+++ b/features/player_create.lua
@@ -86,10 +86,6 @@ local function player_created(event)
             force.character_inventory_slots_bonus = cheats.character_inventory_slots_bonus
             force.character_running_speed_modifier = cheats.character_running_speed_modifier
             force.character_health_bonus = cheats.character_health_bonus
-
-            if cheats.unlock_all_research then
-                force.research_all_technologies()
-            end
         end
     end
 

--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -46,9 +46,6 @@ local Config = {
                 -- a flat health bonus to the player force
                 character_health_bonus = 1000000,
 
-                -- unlock all research by default, only useful when testing
-                unlock_all_research = true,
-
                 -- adds additional items to the player force when starting in addition to defined in start_items above
                 starting_items = {
                     {name = 'power-armor-mk2', count = 1},

--- a/map_gen/Diggy/Feature/SetupPlayer.lua
+++ b/map_gen/Diggy/Feature/SetupPlayer.lua
@@ -1,33 +1,19 @@
---[[-- info
-    Provides the ability to setup a player when first joined.
-]]
-
--- dependencies
 local Event = require 'utils.event'
-local Debug = require 'map_gen.Diggy.Debug'
 local Game = require 'utils.game'
 
--- this
 local SetupPlayer = {}
 
 global.SetupPlayer = {
     first_player_spawned = false,
 }
 
---[[--
-    Registers all event handlers.
-]]
 function SetupPlayer.register(config)
     Event.add(defines.events.on_player_created, function (event)
         local player = Game.get_player_by_index(event.player_index)
         local force = player.force
-        local player_insert = player.insert
         local position = {0, 0}
         local surface = player.surface
-
-        for _, item in pairs(config.starting_items) do
-            player_insert(item)
-        end
+        local redmew_player_create = global.config.player_create
 
         if global.SetupPlayer.first_player_spawned then
             position = surface.find_non_colliding_position('player', position, 3, 0.1)
@@ -35,23 +21,24 @@ function SetupPlayer.register(config)
             global.SetupPlayer.first_player_spawned = true
         end
 
+        if #config.starting_items > 0 then
+            redmew_player_create.starting_items = config.starting_items
+        end
+
         force.set_spawn_position(position, surface)
         player.teleport(position)
 
-        Debug.cheat(function()
-            local cheats = config.cheats
-            force.manual_mining_speed_modifier = cheats.manual_mining_speed_modifier
-            force.character_inventory_slots_bonus = cheats.character_inventory_slots_bonus
-            force.character_running_speed_modifier = cheats.character_running_speed_modifier
-            force.character_health_bonus = cheats.character_health_bonus
-            if cheats.unlock_all_research then
-                force.research_all_technologies()
-            end
+        local cheats = config.cheats
+        local redmew_cheats = redmew_player_create.cheats
+        redmew_cheats.manual_mining_speed_modifier = cheats.manual_mining_speed_modifier
+        redmew_cheats.character_inventory_slots_bonus = cheats.character_inventory_slots_bonus
+        redmew_cheats.character_running_speed_modifier = cheats.character_running_speed_modifier
+        redmew_cheats.character_health_bonus = cheats.character_health_bonus
+        redmew_cheats.unlock_all_research = cheats.unlock_all_research
 
-            for _, item in pairs(cheats.starting_items) do
-                player_insert(item)
-            end
-        end)
+        if #cheats.starting_items > 0 then
+            redmew_cheats.starting_items = cheats.starting_items
+        end
     end)
 end
 

--- a/map_gen/Diggy/Feature/SetupPlayer.lua
+++ b/map_gen/Diggy/Feature/SetupPlayer.lua
@@ -34,7 +34,6 @@ function SetupPlayer.register(config)
         redmew_cheats.character_inventory_slots_bonus = cheats.character_inventory_slots_bonus
         redmew_cheats.character_running_speed_modifier = cheats.character_running_speed_modifier
         redmew_cheats.character_health_bonus = cheats.character_health_bonus
-        redmew_cheats.unlock_all_research = cheats.unlock_all_research
 
         if #cheats.starting_items > 0 then
             redmew_cheats.starting_items = cheats.starting_items


### PR DESCRIPTION
Enables config for:
 - starting items
 - join messages
 - weighted join message
 - whether or not to show the info at the start
 - cheats (combined with diggy cheats)
 - now only sets the force config once
 - Diggy's SetupPlayer now configures player_create instead