### PR TITLE
Fixed coin mining and behavior in Diggy

### DIFF
--- a/features/player_stats.lua
+++ b/features/player_stats.lua
@@ -1,6 +1,8 @@
 local Event = require 'utils.event'
 local Global = require 'utils.global'
 local Game = require 'utils.game'
+local pairs = pairs
+local sqrt = math.sqrt
 
 local player_last_position = {}
 local player_walk_distances = {}
@@ -69,7 +71,6 @@ end
 
 local function picked_up_item(event)
     local stack = event.item_stack
-
     if stack.name == 'coin' then
         local player_index = event.player_index
         player_coin_earned[player_index] = player_coin_earned[player_index] + stack.count
@@ -77,7 +78,7 @@ local function picked_up_item(event)
 end
 
 local function tick()
-    for _, p in ipairs(game.connected_players) do
+    for _, p in pairs(game.connected_players) do
         if (p.afk_time < 30 or p.walking_state.walking) and p.vehicle == nil then
             local index = p.index
             local last_pos = player_last_position[index]
@@ -86,7 +87,7 @@ local function tick()
             local d_x = last_pos.x - pos.x
             local d_y = last_pos.y - pos.y
 
-            player_walk_distances[index] = player_walk_distances[index] + math.sqrt(d_x * d_x + d_y * d_y)
+            player_walk_distances[index] = player_walk_distances[index] + sqrt(d_x * d_x + d_y * d_y)
             player_last_position[index] = pos
         end
     end
@@ -94,6 +95,7 @@ end
 
 Event.add(defines.events.on_player_created, player_created)
 Event.add(defines.events.on_player_died, player_died)
+Event.add(defines.events.on_player_mined_item, picked_up_item)
 Event.add(defines.events.on_picked_up_item, picked_up_item)
 Event.on_nth_tick(62, tick)
 

--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -111,7 +111,7 @@ local Config = {
         },
 
         -- Adds the ability to drop coins and track how many are sent into space
-        ArtefactHunting = {
+        CoinGathering = {
             enabled = true,
 
             -- value between 0 and 1, higher value means stronger variance between coordinates

--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -48,14 +48,7 @@ local Config = {
 
                 -- adds additional items to the player force when starting in addition to defined in start_items above
                 starting_items = {
-                    {name = 'power-armor-mk2', count = 1},
-                    {name = 'submachine-gun', count = 1},
-                    {name = 'uranium-rounds-magazine', count = 1000},
-                    {name = 'roboport', count = 2},
-                    {name = 'construction-robot', count = 50},
-                    {name = 'electric-energy-interface', count = 1},
-                    {name = 'medium-electric-pole', count = 50},
-                    {name = 'logistic-chest-storage', count = 50},
+                    {name = 'uranium-rounds-magazine', count = 200},
                 },
             },
         },

--- a/map_gen/Diggy/Feature/CoinGathering.lua
+++ b/map_gen/Diggy/Feature/CoinGathering.lua
@@ -6,7 +6,6 @@
 local Event = require 'utils.event'
 local Game = require 'utils.game'
 local ScoreTable = require 'map_gen.Diggy.ScoreTable'
-local PlayerStats = require 'features.player_stats'
 local Debug = require 'map_gen.Diggy.Debug'
 local Template = require 'map_gen.Diggy.Template'
 local Perlin = require 'map_gen.shared.perlin_noise'
@@ -18,8 +17,6 @@ local utils = require 'utils.core'
 
 -- this
 local CoinGathering = {}
-
-local coin_color = {r = 255, g = 215, b = 0}
 
 -- some GUI stuff
 local function redraw_table(data)

--- a/map_gen/Diggy/Feature/CoinGathering.lua
+++ b/map_gen/Diggy/Feature/CoinGathering.lua
@@ -6,16 +6,18 @@
 local Event = require 'utils.event'
 local Game = require 'utils.game'
 local ScoreTable = require 'map_gen.Diggy.ScoreTable'
+local PlayerStats = require 'features.player_stats'
 local Debug = require 'map_gen.Diggy.Debug'
 local Template = require 'map_gen.Diggy.Template'
 local Perlin = require 'map_gen.shared.perlin_noise'
 local random = math.random
 local ceil = math.ceil
+local pairs = pairs
 local Gui = require 'utils.gui'
 local utils = require 'utils.core'
 
 -- this
-local ArtefactHunting = {}
+local CoinGathering = {}
 
 local coin_color = {r = 255, g = 215, b = 0}
 
@@ -29,10 +31,10 @@ local function redraw_table(data)
     for name, value in pairs(ScoreTable.all()) do
         local table = list.add({type = 'table', column_count = 2})
 
-        local key = table.add({type = 'label', name = 'Diggy.ArtefactHunting.Frame.List.Key', caption = name})
+        local key = table.add({type = 'label', name = 'Diggy.CoinGathering.Frame.List.Key', caption = name})
         key.style.minimal_width = 175
 
-        local val = table.add({type = 'label', name = 'Diggy.ArtefactHunting.Frame.List.Val', caption = utils.comma_value(value)})
+        local val = table.add({type = 'label', name = 'Diggy.CoinGathering.Frame.List.Val', caption = utils.comma_value(value)})
         val.style.minimal_width = 225
     end
 end
@@ -41,7 +43,7 @@ end
 local function toggle(event)
     local player = event.player
     local center = player.gui.left
-    local frame = center['Diggy.ArtefactHunting.Frame']
+    local frame = center['Diggy.CoinGathering.Frame']
 
     if (frame and event.trigger == nil) then
         Gui.destroy(frame)
@@ -52,12 +54,12 @@ local function toggle(event)
         return
     end
 
-    frame = center.add({name = 'Diggy.ArtefactHunting.Frame', type = 'frame', direction = 'vertical'})
+    frame = center.add({name = 'Diggy.CoinGathering.Frame', type = 'frame', direction = 'vertical'})
 
     local scroll_pane = frame.add({type = 'scroll-pane'})
     scroll_pane.style.maximal_height = 400
 
-    frame.add({ type = 'button', name = 'Diggy.ArtefactHunting.Button', caption = 'Close'})
+    frame.add({type = 'button', name = 'Diggy.CoinGathering.Button', caption = 'Close'})
 
     local data = {
         frame = frame,
@@ -71,20 +73,20 @@ end
 
 local function on_player_created(event)
     Game.get_player_by_index(event.player_index).gui.top.add({
-        name = 'Diggy.ArtefactHunting.Button',
+        name = 'Diggy.CoinGathering.Button',
         type = 'sprite-button',
         sprite = 'item/steel-axe',
     })
 end
 
-Gui.on_click('Diggy.ArtefactHunting.Button', toggle)
-Gui.on_custom_close('Diggy.ArtefactHunting.Frame', function (event)
+Gui.on_click('Diggy.CoinGathering.Button', toggle)
+Gui.on_custom_close('Diggy.CoinGathering.Frame', function (event)
     event.element.destroy()
 end)
 
-function ArtefactHunting.update_gui()
+function CoinGathering.update_gui()
     for _, p in pairs(game.connected_players) do
-        local frame = p.gui.left['Diggy.ArtefactHunting.Frame']
+        local frame = p.gui.left['Diggy.CoinGathering.Frame']
 
         if frame and frame.valid then
             local data = {player = p, trigger = 'update_gui'}
@@ -93,19 +95,17 @@ function ArtefactHunting.update_gui()
     end
 end
 
---[[--
-    Registers all event handlers.
-]]
-function ArtefactHunting.register(config)
+function CoinGathering.register(config)
     Event.add(defines.events.on_player_created, on_player_created)
-    Event.on_nth_tick(61, ArtefactHunting.update_gui)
+    Event.on_nth_tick(61, CoinGathering.update_gui)
 
     ScoreTable.reset('Coins sent to space')
 
     local seed
+    local noise_variance = config.noise_variance
     local function get_noise(surface, x, y)
         seed = seed or surface.map_gen_settings.seed + surface.index + 300
-        return Perlin.noise(x * config.noise_variance * 0.9, y * config.noise_variance * 1.1, seed)
+        return Perlin.noise(x * noise_variance * 0.9, y * noise_variance * 1.1, seed)
     end
 
     local distance_required = config.minimal_treasure_chest_distance * config.minimal_treasure_chest_distance
@@ -148,22 +148,6 @@ function ArtefactHunting.register(config)
     end)
 
     local modifiers = config.alien_coin_modifiers
-
-    local function picked_up_coins(player_index, count)
-        local text
-        if count == 1 then
-            text = '+1 coin'
-            ScoreTable.increment('Collected coins')
-        else
-            text = '+' .. count ..' coins'
-            ScoreTable.add('Collected coins', count)
-        end
-
-        Game.print_player_floating_text(player_index, text, coin_color)
-    end
-
-    ScoreTable.reset('Collected coins')
-
     local alien_coin_drop_chance = config.alien_coin_drop_chance
 
     Event.add(defines.events.on_entity_died, function (event)
@@ -187,32 +171,27 @@ function ArtefactHunting.register(config)
         })
     end)
 
-    Event.add(defines.events.on_picked_up_item, function (event)
-        local stack = event.item_stack
-        if stack.name ~= 'coin' then
-            return
-        end
-
-        picked_up_coins(event.player_index, stack.count)
-    end)
-
+    local mining_coin_chance = config.mining_coin_chance
+    local mining_coin_amount_min = config.mining_coin_amount.min
+    local mining_coin_amount_max = config.mining_coin_amount.max
     Event.add(defines.events.on_pre_player_mined_item, function (event)
-        if event.entity.type ~= 'simple-entity' then
+        local entity = event.entity
+        if entity.type ~= 'simple-entity' then
             return
         end
 
-        if random() > config.mining_coin_chance then
+        if random() > mining_coin_chance then
             return
         end
 
-        local count = random(config.mining_coin_amount.min, config.mining_coin_amount.max)
-        local player_index = event.player_index
-
-        Game.get_player_by_index(player_index).insert({name = 'coin', count = count})
-        picked_up_coins(player_index, count)
+        entity.surface.create_entity({
+            name = 'item-on-ground',
+            position = entity.position,
+            stack = {name = 'coin', count = random(mining_coin_amount_min, mining_coin_amount_max)}
+        })
     end)
 
-    if (config.display_chest_locations) then
+    if config.display_chest_locations then
         Event.add(defines.events.on_chunk_generated, function (event)
             local surface = event.surface
             local area = event.area
@@ -229,8 +208,4 @@ function ArtefactHunting.register(config)
     end
 end
 
-function ArtefactHunting.get_extra_map_info(config)
-    return 'Artefact Hunting, find precious coins while mining and launch them to the surface!'
-end
-
-return ArtefactHunting
+return CoinGathering

--- a/map_gen/Diggy/Scenario.lua
+++ b/map_gen/Diggy/Scenario.lua
@@ -42,7 +42,6 @@ function Scenario.register()
         return
     end
 
-    global.config.player_list.show_coin_column = false
     global.config.fish_market.enabled = false
 
     local extra_map_info = ''


### PR DESCRIPTION
Fixes #527 

Makes mining rocks in Diggy drop coins instead of directly inserting them into the inventory of players. This makes behavior for coin tracking easier. Additionally the coin per player has been enabled in the stats.