### PR TITLE
Added electric poles to Support List

### DIFF
--- a/map_gen/Diggy/Config.lua
+++ b/map_gen/Diggy/Config.lua
@@ -99,6 +99,9 @@ local Config = {
                 ['concrete'] = 0.04,
                 ['hazard-concrete'] = 0.04,
                 ['refined-concrete'] = 0.06,
+				['small-electric-pole'] = .25,
+				['medium-electric-pole'] = .5,
+				['big-electric-pole'] = 2
             },
             cracking_sounds = {
                 ' R U NY O UF O O L S !',

--- a/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
+++ b/map_gen/Diggy/Feature/DiggyCaveCollapse.lua
@@ -247,14 +247,11 @@ local function on_mined_entity(event)
         if not Template.is_diggy_rock(name) then
             player_index = event.player_index
         end
-		
 		if ( name == 'small-electric-pole' or name == 'medium-electric-pole' or name == 'big-electric-pole' ) then
 			stress_map_add_pole(entity.surface, entity.position, strength, false, player_index)
 		else
 			stress_map_add(entity.surface, entity.position, strength, false, player_index)
 		end
-
-        -- stress_map_add(entity.surface, entity.position, strength, false, player_index)
     end
 end
 
@@ -273,7 +270,6 @@ local function on_entity_died(event)
 		else
 			stress_map_add(entity.surface, entity.position, strength, false, player_index)
 		end
-		-- stress_map_add(entity.surface, entity.position, strength, false, player_index)
     end
 end
 
@@ -288,7 +284,6 @@ local function on_built_entity(event)
 		else
 			stress_map_add(entity.surface, entity.position, -1 * strength)
 		end
-		-- stress_map_add(entity.surface, entity.position, -1 * strength)
     end
 end
 
@@ -303,7 +298,6 @@ local function on_placed_entity(event)
 		else
 			stress_map_add(entity.surface, entity.position, -1 * strength)
 		end
-		-- stress_map_add(entity.surface, entity.position, -1 * strength)
     end
 end
 


### PR DESCRIPTION
Added the three electric poles to map_gen\Diggy\Config.lua as supports with some initial values.

Copied stress_map_add to stress_map_add_pole in map_gen\Diggy\Feature\DiggyCaveCollapse.Lua.
     - Set the furthest support value to 0. This means all power poles only provide support in the center and disc regions, not the ring region.

Added a check to each entity add/remove event to check if the entity is a power pole. If yes proceeds to stress_map_add_pole, otherwise continues to stress_map_add as before.