### PR TITLE
allow player to toggle top buttons visibility

### DIFF
--- a/features/gui/blueprint_helper.lua
+++ b/features/gui/blueprint_helper.lua
@@ -572,4 +572,6 @@ Gui.on_custom_close(
     end
 )
 
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)
+
 Event.add(defines.events.on_player_joined_game, player_joined)

--- a/features/gui/info.lua
+++ b/features/gui/info.lua
@@ -675,6 +675,8 @@ Gui.on_custom_close(
     end
 )
 
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)
+
 local Public = {}
 
 function Public.show_info(player)

--- a/features/gui/paint.lua
+++ b/features/gui/paint.lua
@@ -216,5 +216,7 @@ Gui.on_custom_close(
     end
 )
 
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)
+
 Event.add(defines.events.on_player_joined_game, player_joined)
 Event.add(defines.events.on_player_built_tile, player_build_tile)

--- a/features/gui/player_list.lua
+++ b/features/gui/player_list.lua
@@ -758,3 +758,5 @@ Gui.on_click(
         end
     end
 )
+
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)

--- a/features/gui/poll.lua
+++ b/features/gui/poll.lua
@@ -1159,6 +1159,8 @@ Gui.on_click(
 
 Gui.on_click(poll_view_vote_name, vote)
 
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)
+
 local Class = {}
 
 function Class.validate(data)

--- a/features/gui/score.lua
+++ b/features/gui/score.lua
@@ -1,6 +1,7 @@
 local Event = require 'utils.event'
 local Game = require 'utils.game'
 local PlayerStats = require 'features.player_stats'
+local Gui = require 'utils.gui'
 
 if not global.score_rockets_launched then
     global.score_rockets_launched = 0
@@ -130,6 +131,8 @@ local function rocket_launched()
     game.print('A rocket has been launched!')
     refresh_score()
 end
+
+Gui.allow_player_to_toggle_top_element_visibility('score')
 
 Event.add(defines.events.on_entity_died, refresh_score)
 Event.add(defines.events.on_gui_click, on_gui_click)

--- a/features/gui/tag_group.lua
+++ b/features/gui/tag_group.lua
@@ -656,6 +656,8 @@ Gui.on_custom_close(
     end
 )
 
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)
+
 Event.add(defines.events.on_player_joined_game, player_joined)
 
 local function tag_command(cmd)

--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -1065,6 +1065,8 @@ Gui.on_click(
     end
 )
 
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)
+
 commands.add_command(
     'task',
     '<task> - Creates a new task (Admins and regulars only).',

--- a/map_gen/Diggy/Feature/CoinGathering.lua
+++ b/map_gen/Diggy/Feature/CoinGathering.lua
@@ -76,6 +76,8 @@ local function on_player_created(event)
     })
 end
 
+Gui.allow_player_to_toggle_top_element_visibility('Diggy.CoinGathering.Button')
+
 Gui.on_click('Diggy.CoinGathering.Button', toggle)
 Gui.on_custom_close('Diggy.CoinGathering.Frame', function (event)
     event.element.destroy()

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -488,6 +488,8 @@ local function on_player_created(event)
     })
 end
 
+Gui.allow_player_to_toggle_top_element_visibility('Diggy.Experience.Button')
+
 Gui.on_click('Diggy.Experience.Button', toggle)
 Gui.on_custom_close('Diggy.Experience.Frame', function (event)
     event.element.destroy()

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -2,7 +2,6 @@ local Token = require 'utils.token'
 local Event = require 'utils.event'
 local Game = require 'utils.game'
 local Global = require 'utils.global'
-local table = require 'utils.table'
 
 local Gui = {}
 
@@ -19,9 +18,6 @@ Global.register(
         top_elements = tbl.top_elements
     end
 )
-
-local on_visable_event_id = script.generate_event_name()
-local on_pre_hidden_event_id = script.generate_event_name()
 
 local on_visable_handlers = {}
 local on_pre_hidden_handlers = {}

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -178,14 +178,14 @@ Gui.on_text_changed = handler_factory(defines.events.on_gui_text_changed)
 -- Adds a player field to the event table.
 Gui.on_value_changed = handler_factory(defines.events.on_gui_value_changed)
 
--- Register a handler for the when the player shows the top LuaGuiElements with element_name.
+-- Register a handler for when the player shows the top LuaGuiElements with element_name.
 -- Assuming the element_name has been added with Gui.allow_player_to_toggle_top_element_visibility.
 -- Can only have one handler per element name.
 -- Guarantees that the element and the player are valid when calling the handler.
 -- Adds a player field to the event table.
 Gui.on_player_show_top = custom_handler_factory(on_visable_handlers)
 
--- Register a handler for the when the player hides the top LuaGuiElements with element_name.
+-- Register a handler for when the player hides the top LuaGuiElements with element_name.
 -- Assuming the element_name has been added with Gui.allow_player_to_toggle_top_element_visibility.
 -- Can only have one handler per element name.
 -- Guarantees that the element and the player are valid when calling the handler.

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -1,10 +1,30 @@
 local Token = require 'utils.token'
 local Event = require 'utils.event'
 local Game = require 'utils.game'
+local Global = require 'utils.global'
+local table = require 'utils.table'
 
 local Gui = {}
 
-global.Gui_data = {}
+local data = {}
+local top_elements = {}
+
+Global.register(
+    {
+        data = data,
+        top_elements = top_elements
+    },
+    function(tbl)
+        data = tbl.data
+        top_elements = tbl.top_elements
+    end
+)
+
+local on_visable_event_id = script.generate_event_name()
+local on_pre_hidden_event_id = script.generate_event_name()
+
+local on_visable_handlers = {}
+local on_pre_hidden_handlers = {}
 
 function Gui.uid_name()
     if _DEBUG then
@@ -17,13 +37,13 @@ function Gui.uid_name()
 end
 
 -- Associates data with the LuaGuiElement. If data is nil then removes the data
-function Gui.set_data(element, data)
-    global.Gui_data[element.player_index * 0x100000000 + element.index] = data
+function Gui.set_data(element, value)
+    data[element.player_index * 0x100000000 + element.index] = value
 end
 
 -- Gets the Associated data with this LuaGuiElement if any.
 function Gui.get_data(element)
-    return global.Gui_data[element.player_index * 0x100000000 + element.index]
+    return data[element.player_index * 0x100000000 + element.index]
 end
 
 -- Removes data associated with LuaGuiElement and its children recursivly.
@@ -101,6 +121,21 @@ local function handler_factory(event_id)
     end
 end
 
+local function custom_handler_factory(handlers)
+    return function(element_name, handler)
+        handlers[element_name] = handler
+    end
+end
+
+local function custom_raise(handlers, element, player)
+    local handler = handlers[element.name]
+    if not handler then
+        return
+    end
+
+    handler({element = element, player = player})
+end
+
 -- Register a handler for the on_gui_checked_state_changed event for LuaGuiElements with element_name.
 -- Can only have one handler per element name.
 -- Guarantees that the element and the player are valid when calling the handler.
@@ -142,5 +177,101 @@ Gui.on_text_changed = handler_factory(defines.events.on_gui_text_changed)
 -- Guarantees that the element and the player are valid when calling the handler.
 -- Adds a player field to the event table.
 Gui.on_value_changed = handler_factory(defines.events.on_gui_value_changed)
+
+-- Register a handler for the when the player shows the top LuaGuiElements with element_name.
+-- Assuming the element_name has been added with Gui.allow_player_to_toggle_top_element_visibility.
+-- Can only have one handler per element name.
+-- Guarantees that the element and the player are valid when calling the handler.
+-- Adds a player field to the event table.
+Gui.on_player_show_top = custom_handler_factory(on_visable_handlers)
+
+-- Register a handler for the when the player hides the top LuaGuiElements with element_name.
+-- Assuming the element_name has been added with Gui.allow_player_to_toggle_top_element_visibility.
+-- Can only have one handler per element name.
+-- Guarantees that the element and the player are valid when calling the handler.
+-- Adds a player field to the event table.
+Gui.on_pre_player_hide_top = custom_handler_factory(on_pre_hidden_handlers)
+
+--- Allows the player to show / hide this element.
+-- The element must be part in gui.top.
+-- @param element_name<string> This name must be globally unique.
+function Gui.allow_player_to_toggle_top_element_visibility(element_name)
+    top_elements[#top_elements + 1] = element_name
+end
+
+local toggle_button_name = Gui.uid_name()
+
+Event.add(
+    defines.events.on_player_created,
+    function(event)
+        local player = Game.get_player_by_index(event.player_index)
+
+        if not player or not player.valid then
+            return
+        end
+
+        local b =
+            player.gui.top.add {
+            type = 'button',
+            name = toggle_button_name,
+            caption = '<',
+            tooltip = 'Shows / hides the Redmew Gui buttons.'
+        }
+        local style = b.style
+        style.width = 18
+        style.height = 38
+        style.left_padding = 0
+        style.top_padding = 0
+        style.right_padding = 0
+        style.bottom_padding = 0
+        style.font = 'default-small-bold'
+    end
+)
+
+Gui.on_click(
+    toggle_button_name,
+    function(event)
+        local button = event.element
+        local player = event.player
+        local top = player.gui.top
+
+        if button.caption == '<' then
+            for i = 1, #top_elements do
+                local name = top_elements[i]
+                local ele = top[name]
+                if ele and ele.valid then
+                    local style = ele.style
+
+                    -- if visible is not set it has the value of nil.
+                    -- Hence nil is treated as is visible.
+                    local v = style.visible
+                    if v or v == nil then
+                        custom_raise(on_pre_hidden_handlers, ele, player)
+                        style.visible = false
+                    end
+                end
+            end
+
+            button.caption = '>'
+            button.style.height = 24
+        else
+            for i = 1, #top_elements do
+                local name = top_elements[i]
+                local ele = top[name]
+                if ele and ele.valid then
+                    local style = ele.style
+
+                    if not style.visible then
+                        style.visible = true
+                        custom_raise(on_visable_handlers, ele, player)
+                    end
+                end
+            end
+
+            button.caption = '<'
+            button.style.height = 38
+        end
+    end
+)
 
 return Gui

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -6,19 +6,15 @@ local Global = require 'utils.global'
 local Gui = {}
 
 local data = {}
-local top_elements = {}
 
 Global.register(
-    {
-        data = data,
-        top_elements = top_elements
-    },
+    data,
     function(tbl)
-        data = tbl.data
-        top_elements = tbl.top_elements
+        data = tbl
     end
 )
 
+local top_elements = {}
 local on_visable_handlers = {}
 local on_pre_hidden_handlers = {}
 
@@ -190,6 +186,7 @@ Gui.on_pre_player_hide_top = custom_handler_factory(on_pre_hidden_handlers)
 
 --- Allows the player to show / hide this element.
 -- The element must be part in gui.top.
+-- This function must be called in the control stage, i.e not inside an event.
 -- @param element_name<string> This name must be globally unique.
 function Gui.allow_player_to_toggle_top_element_visibility(element_name)
     top_elements[#top_elements + 1] = element_name


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10003572/50048991-18294200-00d2-11e9-9a7c-61c332ad6476.png)

![image](https://user-images.githubusercontent.com/10003572/50048993-1e1f2300-00d2-11e9-92c6-e6e8285ba2f0.png)

![image](https://user-images.githubusercontent.com/10003572/50048994-24150400-00d2-11e9-9b88-b684365191f5.png)

How to use in code:
1. Let Gui know that you want the button to be toggle-able by the player 
```lua
Gui.allow_player_to_toggle_top_element_visibility(element_name)
```
That is all.

If you want to register a handler for when the button is toggled you can use
```lua
Gui.on_player_show_top(element_name, handler)
Gui.on_pre_player_hide_top(element_name, handler)
```

I think I've registered all the top buttons.

Elements that are opened by the top buttons will remain open when the player hides the top buttons, like so

![image](https://user-images.githubusercontent.com/10003572/50049037-1613b300-00d3-11e9-8e9e-226e441a273d.png)


We could use the callbacks above to control that.

Closes #383 