### PR TITLE
Add dump_env

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -56,7 +56,7 @@ local STD_BASE_CONTROL = 'lua52c+factorio+factorio_control+factorio_defines+fact
 --[Assume Factorio Control stage as default]--
 -------------------------------------------------------------------------------
 std = STD_CONTROL
-globals = {'print', 'math', 'table', '_DEBUG', '_CHEATS', 'ServerCommands'} -- RedMew-specific globals
+globals = {'print', 'math', 'table', '_DEBUG', '_CHEATS', '_DUMP_ENV', 'ServerCommands'} -- RedMew-specific globals
 max_line_length = LINE_LENGTH
 
 not_globals = NOT_GLOBALS

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,6 @@
 _DEBUG = false
 _CHEATS = false
+_DUMP_ENV = false
 local market_item = 'coin'
 
 global.config = {

--- a/control.lua
+++ b/control.lua
@@ -91,6 +91,6 @@ end
 if config.camera.enabled then
     require 'features.gui.camera'
 end
-if _DEBUG then
+if _DUMP_ENV then
     require 'utils.dump_env'
 end

--- a/control.lua
+++ b/control.lua
@@ -91,3 +91,6 @@ end
 if config.camera.enabled then
     require 'features.gui.camera'
 end
+if _DEBUG then
+    require 'utils.dump_env'
+end

--- a/features/player_create.lua
+++ b/features/player_create.lua
@@ -48,7 +48,7 @@ local function player_created(event)
         p(get_random_weighted(random_messages))
     end
 
-    if config.show_info_at_start and not _DUMP_ENV then
+    if config.show_info_at_start then
         if Info ~= nil then
             Info.show_info({player = player})
         end

--- a/features/player_create.lua
+++ b/features/player_create.lua
@@ -48,7 +48,7 @@ local function player_created(event)
         p(get_random_weighted(random_messages))
     end
 
-    if config.show_info_at_start then
+    if config.show_info_at_start and not _DUMP_ENV then
         if Info ~= nil then
             Info.show_info({player = player})
         end

--- a/utils/dump_env.lua
+++ b/utils/dump_env.lua
@@ -7,7 +7,7 @@ local filename = 'env_dump.lua'
 
 local remove_package = function(item)
 	if item ~= 'package' then return item end
-  end
+end
 
 local function player_joined(event)
 	local dump_string = table.inspect(_ENV, {process = remove_package})

--- a/utils/dump_env.lua
+++ b/utils/dump_env.lua
@@ -1,0 +1,19 @@
+-- A small debugging tool that writes the contents of _ENV to a file when the game loads.
+-- Useful for ensuring you get the same information when loading
+-- the reference and desync levels in desync reports.
+require 'utils.table'
+local Event = require 'utils.event'
+local filename = 'env_dump.lua'
+
+local function player_joined(event)
+	local dump_string = table.inspect(_ENV)
+	if dump_string then
+		local s = string.format('tick on join: %s\n%s', event.tick, dump_string)
+		game.write_file(filename, s)
+		game.print('_ENV dumped into ' .. filename)
+	else
+		game.print('_ENV not dumped, dump_string was nil')
+	end
+end
+
+Event.add(defines.events.on_player_joined_game, player_joined)

--- a/utils/dump_env.lua
+++ b/utils/dump_env.lua
@@ -5,8 +5,12 @@ require 'utils.table'
 local Event = require 'utils.event'
 local filename = 'env_dump.lua'
 
+local remove_package = function(item)
+	if item ~= 'package' then return item end
+  end
+
 local function player_joined(event)
-	local dump_string = table.inspect(_ENV)
+	local dump_string = table.inspect(_ENV, {process = remove_package})
 	if dump_string then
 		local s = string.format('tick on join: %s\n%s', event.tick, dump_string)
 		game.write_file(filename, s)

--- a/utils/dump_env.lua
+++ b/utils/dump_env.lua
@@ -4,20 +4,24 @@
 require 'utils.table'
 local Event = require 'utils.event'
 local filename = 'env_dump.lua'
+local inspect = table.inspect
 
-local remove_package = function(item)
-	if item ~= 'package' then return item end
+-- Removes metatables and the package table
+local filter = function(item, path)
+    if path[#path] ~= inspect.METATABLE and item ~= 'package' then
+        return item
+    end
 end
 
 local function player_joined(event)
-	local dump_string = table.inspect(_ENV, {process = remove_package})
-	if dump_string then
-		local s = string.format('tick on join: %s\n%s', event.tick, dump_string)
-		game.write_file(filename, s)
-		game.print('_ENV dumped into ' .. filename)
-	else
-		game.print('_ENV not dumped, dump_string was nil')
-	end
+    local dump_string = inspect(_ENV, {process = filter})
+    if dump_string then
+        local s = string.format('tick on join: %s\n%s', event.tick, dump_string)
+        game.write_file(filename, s)
+        game.print('_ENV dumped into ' .. filename)
+    else
+        game.print('_ENV not dumped, dump_string was nil')
+    end
 end
 
 Event.add(defines.events.on_player_joined_game, player_joined)


### PR DESCRIPTION
When `_DEBUG` is turned on, it dumps `_ENV` into a file in the tick that the game is loaded. Nice for catching any potential diffs that can get rid of themselves over time.

In terms of workflow: open the desync report and extract the ref and desync save files, open both to edit config.lua to _DEBUG = true. Load save 1, rename dump_env.lua. Load save 2 and you can compare the two output files.

How this can be improved: automatically stripping out strings matching `<.*>` since they differ between files.

