### PR TITLE
Fix issues with silly names

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -625,7 +625,7 @@ stds.factorio_defines = {
                         "on_gui_closed", "on_gui_value_changed", "on_player_muted", "on_player_unmuted", "on_player_cheat_mode_enabled", "on_player_cheat_mode_disabled",
                         "on_character_corpse_expired", "on_pre_ghost_deconstructed", "on_player_pipette", "on_player_display_resolution_changed", "on_player_display_scale_changed",
                         "on_pre_player_crafted_item", "on_player_cancelled_crafting", "on_chunk_charted", "on_technology_effects_reset", "on_land_mine_armed", "on_forces_merged",
-                        "on_player_trash_inventory_changed",
+                        "on_player_trash_inventory_changed", "on_pre_player_left_game"
                     },
                 },
                 alert_type = {

--- a/features/gui/info.lua
+++ b/features/gui/info.lua
@@ -745,8 +745,13 @@ function Public.get_map_extra_info()
     return editable_info[map_extra_info_key]
 end
 
-function Public.set_map_extra_info(value)
-    editable_info[map_extra_info_key] = value
+--- Adds to existing map_extra_info. Removes default text if it is the only text in place.
+function Public.add_map_extra_info(value)
+    if editable_info[map_extra_info_key] == global.config.map_extra_info_key then
+        editable_info[map_extra_info_key] = value
+    else
+        editable_info[map_extra_info_key] = string.format('%s\n%s', editable_info[map_extra_info_key], value)
+    end
 end
 
 function Public.get_new_info()

--- a/features/user_groups.lua
+++ b/features/user_groups.lua
@@ -12,7 +12,7 @@ local Module = {}
 
 Module.is_regular =
     function(player_name)
-    return Utils.cast_bool(global.regulars[player_name] or global.regulars[player_name:lower()]) --to make it backwards compatible
+    return Utils.cast_bool(global.regulars[player_name] or global.regulars[player_name:lower()] or (global.silly_regulars and global.silly_regulars[player_name])) --to make it backwards compatible
 end
 
 Module.add_regular = function(player_name)

--- a/map_gen/Diggy/Scenario.lua
+++ b/map_gen/Diggy/Scenario.lua
@@ -52,8 +52,6 @@ function Scenario.register()
     redmew_config.blueprint_helper.enabled = false
     redmew_config.paint.enabled = false
 
-    local extra_map_info = ''
-
     each_enabled_feature(
         function(feature_name, feature_config)
             local feature = require ('map_gen.Diggy.Feature.' .. feature_name)
@@ -64,7 +62,7 @@ function Scenario.register()
             feature.register(feature_config)
 
             if ('function' == type(feature.get_extra_map_info)) then
-                extra_map_info = extra_map_info .. feature.get_extra_map_info(feature_config) .. '\n\n'
+                ScenarioInfo.add_map_extra_info(feature.get_extra_map_info(feature_config) .. '\n')
             end
 
             if ('function' == type(feature.on_init)) then
@@ -78,7 +76,6 @@ function Scenario.register()
 
     ScenarioInfo.set_map_name('Diggy')
     ScenarioInfo.set_map_description('Dig your way through!')
-    ScenarioInfo.set_map_extra_info(extra_map_info)
 
     global.diggy_scenario_registered = true
 end

--- a/map_gen/presets/crash_site.lua
+++ b/map_gen/presets/crash_site.lua
@@ -13,7 +13,7 @@ local ScenarioInfo = require 'features.gui.info'
 -- Comment out this block if you're getting scenario info from another source.
 ScenarioInfo.set_map_name('Crashsite')
 ScenarioInfo.set_map_description('Capture outposts and defend against the biters.')
-ScenarioInfo.set_map_extra_info(
+ScenarioInfo.add_map_extra_info(
     '- Outposts have enemy turrets defending them.\n- Outposts have loot and provide a steady stream of resources.\n- Outpost markets with different resources and at prices.\n- Capturing outposts increases evolution.\n- Reduced damage by all player weapons, turrets, and ammo.\n- Biters have more health and deal more damage.'
 )
 

--- a/map_gen/presets/venus.lua
+++ b/map_gen/presets/venus.lua
@@ -9,7 +9,7 @@ local ScenarioInfo = require 'features.gui.info'
 
 ScenarioInfo.set_map_name('Terraform Venus')
 ScenarioInfo.set_map_description('After a long journey you have reached Venus. Your mission is simple, turn this hostile environment into one where humans can thrive')
-ScenarioInfo.set_map_extra_info(
+ScenarioInfo.add_map_extra_info(
     '- Venus is an endless desert spotted with tiny oases\n' ..
     '- The atmosphere is toxic and you are not equipped to deal with it\n' ..
     '- While unsure the exact effects the atmosphere will have, you should be cautios of it\n' ..

--- a/utils/table.lua
+++ b/utils/table.lua
@@ -143,9 +143,16 @@ end
 
 --- Clears all existing entries in a table
 -- @param t table to clear
-table.clear_table = function(t)
-    for i in pairs(t) do
-        t[i] = nil
+-- @param sorted boolean to indicate whether the table is sorted by numerical index or not
+table.clear_table = function(t, sorted)
+    if sorted then
+        for i = 1, #t do
+            t[i] = nil
+        end
+    else
+        for i in pairs(t) do
+            t[i] = nil
+        end
     end
 end
 


### PR DESCRIPTION
The 2 major issues were: a new LuaPlayer being created when someone rejoined and incompatibility with user groups.

This solves those by storing the player's original name and reverting to that when they leave, and by creating a second global table for regulars. I is the lowest overhead implementation I could think of. When silly_names is not loaded, it will add 1 check for `global.silly_regulars` to user_groups::is_regular for guests.

tweaks info.lua to allow extending add_map_extra_info rather than outright overwriting it, and tweaks table.clear_table to give a faster option for sorted tables.

Edit: This also changes the naming scheme since @Jayefuu strongly urged to have the player's real name included. In the future I would like to make the naming scheme configurable.