### PR TITLE
Fixed possible gui uid collision

### DIFF
--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -21,8 +21,8 @@ local on_pre_hidden_handlers = {}
 function Gui.uid_name()
     if _DEBUG then
         -- https://stackoverflow.com/questions/48402876/getting-current-file-name-in-lua
-        local filename = debug.getinfo(2, 'S').source:match('^.+/currently%-playing/(.+)$'):sub(1, -5)
-        return filename .. ',' .. Token.uid()
+        local filepath = debug.getinfo(2, 'S').source:match('^.+/currently%-playing/(.+)$'):sub(1, -5)
+        return filepath .. ',' .. Token.uid()
     else
         return tostring(Token.uid())
     end

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -21,7 +21,7 @@ local on_pre_hidden_handlers = {}
 function Gui.uid_name()
     if _DEBUG then
         -- https://stackoverflow.com/questions/48402876/getting-current-file-name-in-lua
-        local filename = debug.getinfo(2, 'S').source:match('^.+/(.+)$'):sub(1, -5)
+        local filename = debug.getinfo(2, 'S').source:match('^.+/currently%-playing/(.+)$'):sub(1, -5)
         return filename .. ',' .. Token.uid()
     else
         return tostring(Token.uid())


### PR DESCRIPTION
The gui uid was of the form:
```lua
filename .. ',' .. x
```

This change makes it:

```
filepath .. ',' .. x
```

Making collisions of different guis from different files with the same name impossible