### PR TITLE
Added some features to the market GUI

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -179,7 +179,7 @@ global.config = {
         enabled = true,
     },
     -- logs when commands are used and when items are spawned in
-    free_item_loggin = {
+    free_item_logging = {
         enabled = true,
     },
     player_colors = {

--- a/control.lua
+++ b/control.lua
@@ -35,7 +35,7 @@ end
 if config.fish_market.enabled then
     require 'features.fish_market'
 end
-if config.free_item_loggin.enabled then
+if config.free_item_logging.enabled then
     require 'features.free_item_logging'
 end
 if config.nuke_control.enabled then

--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -18,6 +18,7 @@ local market_frame_close_button_name = Gui.uid_name()
 local item_button_name = Gui.uid_name()
 local count_slider_name = Gui.uid_name()
 local count_text_name = Gui.uid_name()
+local color_red = {r = 1, b = 0, g = 0}
 
 local Retailer = {}
 
@@ -115,7 +116,7 @@ local function redraw_market_items(data)
         label_style.font = 'default-bold'
 
         if is_missing_coins then
-            label_style.font_color = {r = 1, b = 0, g = 0}
+            label_style.font_color = color_red
             button.enabled = false
         end
     end

--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -156,16 +156,7 @@ local function draw_market_frame(player, group_name)
 
     local bottom_grid = frame.add({type = 'table', column_count = 2})
 
-    bottom_grid.add({type = 'label', caption = 'Quantity'}).style.font = 'default-bold'
-    bottom_grid.add({type = 'label'})
-
-    local count_slider = bottom_grid.add({
-        type = 'slider',
-        name = count_slider_name,
-        minimum_value = 1,
-        maximum_value = 7,
-        value = 1,
-    })
+    bottom_grid.add({type = 'label', caption = 'Quantity: '}).style.font = 'default-bold'
 
     local count_text = bottom_grid.add({
         type = 'text-box',
@@ -173,10 +164,18 @@ local function draw_market_frame(player, group_name)
         text = '1',
     })
 
+    local count_slider = frame.add({
+        type = 'slider',
+        name = count_slider_name,
+        minimum_value = 1,
+        maximum_value = 7,
+        value = 1,
+    })
+
     frame.add({name = market_frame_close_button_name, type = 'button', caption = 'Close'})
 
-    count_slider.style.width = 100
-    count_text.style.width = 60
+    count_slider.style.width = 115
+    count_text.style.width = 45
 
     data.slider = count_slider
     data.text = count_text

--- a/map_gen/Diggy/Feature/StartingZone.lua
+++ b/map_gen/Diggy/Feature/StartingZone.lua
@@ -77,7 +77,8 @@ function StartingZone.register(config)
         local market = surface.create_entity({name = 'market', position = position})
         market.destructible = false
 
-        Retailer.add_market(player_force.name, market)
+        Retailer.set_market_group_label('player', 'Diggy Market')
+        Retailer.add_market('player', market)
 
         player_force.add_chart_tag(surface, {
             text = 'Market',

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -15,7 +15,7 @@ Global.register(
 )
 
 local top_elements = {}
-local on_visable_handlers = {}
+local on_visible_handlers = {}
 local on_pre_hidden_handlers = {}
 
 function Gui.uid_name()
@@ -38,7 +38,7 @@ function Gui.get_data(element)
     return data[element.player_index * 0x100000000 + element.index]
 end
 
--- Removes data associated with LuaGuiElement and its children recursivly.
+-- Removes data associated with LuaGuiElement and its children recursively.
 function Gui.remove_data_recursively(element)
     Gui.set_data(element, nil)
 
@@ -175,7 +175,7 @@ Gui.on_value_changed = handler_factory(defines.events.on_gui_value_changed)
 -- Can only have one handler per element name.
 -- Guarantees that the element and the player are valid when calling the handler.
 -- Adds a player field to the event table.
-Gui.on_player_show_top = custom_handler_factory(on_visable_handlers)
+Gui.on_player_show_top = custom_handler_factory(on_visible_handlers)
 
 -- Register a handler for when the player hides the top LuaGuiElements with element_name.
 -- Assuming the element_name has been added with Gui.allow_player_to_toggle_top_element_visibility.
@@ -256,7 +256,7 @@ Gui.on_click(
 
                     if not style.visible then
                         style.visible = true
-                        custom_raise(on_visable_handlers, ele, player)
+                        custom_raise(on_visible_handlers, ele, player)
                     end
                 end
             end


### PR DESCRIPTION
Adds a bunch of improvements to the Retailer GUI

- Adds a close button
- Can now name a market group (defaults to "Market") and shows this in the window
- Uses localized names for items 
- Custom sprite support
- Support for extended description
- Shows the missing coins if not enough present
- Shows text in red and disables buttons if not enough coins in inventory
- Updates the market frame when buying items
- Shows a message if no items are present

![image](https://user-images.githubusercontent.com/1754678/50311784-b0df0980-04a6-11e9-949a-8db4d61bac06.png)
![image](https://user-images.githubusercontent.com/1754678/50311814-bfc5bc00-04a6-11e9-93ec-c9cf46672d04.png)
![image](https://user-images.githubusercontent.com/1754678/50311838-d53ae600-04a6-11e9-80f6-3649c462fcbf.png)
![image](https://user-images.githubusercontent.com/1754678/50311847-dc61f400-04a6-11e9-893b-63a7ad3e8222.png)
![image](https://user-images.githubusercontent.com/1754678/50311863-e8e64c80-04a6-11e9-8653-c38967407984.png)
![image](https://user-images.githubusercontent.com/1754678/50311874-f0a5f100-04a6-11e9-84b0-2dc2a4c9c8d1.png)
