### PR TITLE
only luacheck files changed in latest commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ install:
   - luarocks install luacheck
 
 script:
-  - luacheck .
+  - git diff-tree -r --no-commit-id --name-only HEAD
+    | grep '\.lua$'
+    | xargs -r luacheck


### PR DESCRIPTION
Uses the existing travis setup to run luacheck on `.lua` files modified in the most recent commit.