### PR TITLE
Ability to disable market items without removal

### DIFF
--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -5,6 +5,7 @@ local Event = require 'utils.event'
 local PlayerStats = require 'features.player_stats'
 local Game = require 'utils.game'
 local math = require 'utils.math'
+local Color = require 'resources.color_presets'
 local format = string.format
 local size = table.size
 local insert = table.insert
@@ -19,8 +20,6 @@ local market_frame_close_button_name = Gui.uid_name()
 local item_button_name = Gui.uid_name()
 local count_slider_name = Gui.uid_name()
 local count_text_name = Gui.uid_name()
-local color_red = {r = 255, b = 0, g = 0}
-local color_dark_grey = {r = 169, g = 169, b = 169}
 
 local Retailer = {}
 
@@ -139,10 +138,10 @@ local function redraw_market_items(data)
         label_style.vertical_align = 'center'
 
         if disabled then
-            label_style.font_color = color_dark_grey
+            label_style.font_color = Color.dark_grey
             button.enabled = false
         elseif is_missing_coins then
-            label_style.font_color = color_red
+            label_style.font_color = Color.red
             button.enabled = false
         end
     end

--- a/map_gen/Diggy/Feature/Experience.lua
+++ b/map_gen/Diggy/Feature/Experience.lua
@@ -20,6 +20,9 @@ local print_player_floating_text_position = Game.print_player_floating_text_posi
 local get_force_data = ForceControl.get_force_data
 local get_player_by_index = Game.get_player_by_index
 local set_item = Retailer.set_item
+local disable_item = Retailer.disable_item
+local enable_item = Retailer.enable_item
+
 
 -- this
 local Experience = {}
@@ -90,8 +93,11 @@ function Experience.update_market_contents(force)
     local current_level = get_force_data(force).current_level
     local force_name = force.name
     for _, prototype in pairs(config.unlockables) do
-        if (current_level >= prototype.level) then
-            set_item(force_name, prototype)
+        local prototype_level = prototype.level
+        if current_level < prototype_level then
+            disable_item(force_name, prototype.name, format('Unlocks at level %d', prototype_level))
+        else
+            enable_item(force_name, prototype.name)
         end
     end
 end
@@ -548,6 +554,13 @@ function Experience.on_init()
     --Adds the 'player' force to participate in the force control system.
     local force = game.forces.player
     ForceControl.register_force(force)
+
+    local force_name = force.name
+    for _, prototype in pairs(config.unlockables) do
+        set_item(force_name, prototype)
+    end
+
+    Experience.update_market_contents(force)
 end
 
 return Experience


### PR DESCRIPTION
This allows you to add market items that are disabled, and enable or disable them later with a message. This comes in handy for several things:
 - Diggy shows all items now, but makes it impossible to buy them until the level is reached
 - Custom triggers can be added with a message on how to unlock them
 - Example: buff enemy team biter strength by 10% for 30 seconds could be disabled for 1 minute after buying it.

Disabled tooltip:
![image](https://user-images.githubusercontent.com/1754678/50527423-7bf73600-0ae8-11e9-8d06-5db76024f9d2.png)

Overview when reaching level 1 in Diggy:
![image](https://user-images.githubusercontent.com/1754678/50527427-84e80780-0ae8-11e9-8685-b5e4466236fa.png)

When reaching all techs:
![image](https://user-images.githubusercontent.com/1754678/50527433-8f0a0600-0ae8-11e9-9e4c-61569f656bb2.png)

When you have not reached the level nor have enough coins:
![image](https://user-images.githubusercontent.com/1754678/50527448-9c26f500-0ae8-11e9-8718-2fdcc7a23fb3.png)

When trying to buy something that's disabled (fallback when the GUI wasn't updated)
![image](https://user-images.githubusercontent.com/1754678/50527503-ee681600-0ae8-11e9-99f6-ca890422976a.png)

