### PR TITLE
Fixed Diggy cave collapses by disabling the redmew surface

### DIFF
--- a/map_gen/Diggy/Scenario.lua
+++ b/map_gen/Diggy/Scenario.lua
@@ -48,6 +48,7 @@ function Scenario.register()
 
     -- disabled redmew features for diggy
     local redmew_config = global.config
+    redmew_config.redmew_surface.enabled = false
     redmew_config.market.enabled = false
     redmew_config.reactor_meltdown.enabled = false
     redmew_config.hodor.enabled = false


### PR DESCRIPTION
Fixes #661. Looks like the create_surface isn't properly calling the event (perhaps due to being in on_init). 