### PR TITLE
Added a toast feature

### DIFF
--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -1,0 +1,160 @@
+local Event = require 'utils.event'
+local Game = require 'utils.game'
+local Global = require 'utils.global'
+local Gui = require 'utils.gui'
+local Color = require 'resources.color_presets'
+
+local type = type
+local tonumber = tonumber
+local pairs = pairs
+local size = table.size
+
+local Public = {}
+
+local memory = {
+    id = 0,
+    active_toasts = {},
+}
+
+Global.register(memory, function (tbl) memory = tbl end)
+
+---Creates a unique ID for a toast message
+local function autoincrement()
+    local id = memory.id + 1
+    memory.id = id
+    return id
+end
+
+---Toast to a specific player
+---@param p number|string|LuaPlayer player index or object
+---@param duration number in seconds
+---@param message|nil message displayed, leave empty to have an empty LuaGuiElement
+function Public.toast_player(p, duration, message)
+    local player
+
+    if type(p) == 'string' then
+        player = Game.get_player_by_index(tonumber(p))
+    elseif type(p) == 'number' then
+        player = Game.get_player_by_index(p)
+    else
+        player = p
+    end
+
+    if not player or not player.valid then
+        return nil
+    end
+
+    local frame = player.gui.left.add({type = 'frame', direction = 'vertical', style = 'captionless_frame'})
+    frame.style.width = 300
+
+    local container = frame.add({type = 'flow', direction = 'horizontal'})
+    container.style.horizontally_stretchable = true
+
+    local progressbar = frame.add({type = 'progressbar'})
+    local style = progressbar.style
+    style.width = 290
+    style.height = 3
+    style.color = Color.grey
+    progressbar.value = 1 -- it starts full
+
+    local id = autoincrement()
+    local tick = game.tick
+    if not duration then
+        duration = 15
+    end
+
+    Gui.set_data(frame, {
+        is_toast = true,
+        toast_id = id,
+        progressbar = progressbar,
+        start_tick = tick,
+        end_tick = tick + duration * 60
+    })
+    memory.active_toasts[id] = true
+
+    if message ~= nil then
+        local label = container.add({type = 'label', caption = message})
+        label.style.single_line = false
+    end
+
+    return container
+end
+
+---Attempts to get a toast based on the element, will traverse through parents to find it.
+---@param element LuaGuiElement
+local function get_toast(element)
+    if not element or not element.valid then
+        return nil
+    end
+
+    local data = Gui.get_data(element)
+
+    if data and data.is_toast then
+        return element, data
+    end
+
+    -- no data, have to check the parent
+    return get_toast(element.parent)
+end
+
+Event.add(defines.events.on_gui_click, function (event)
+    local element = get_toast(event.element)
+    if not element then
+        return
+    end
+
+    Gui.destroy(element)
+end)
+
+Event.on_nth_tick(2, function (event)
+    local active_toasts = memory.active_toasts
+    if size(active_toasts) == 0 then
+        return
+    end
+
+    local tick = event.tick
+    local players = game.connected_players
+
+    local finished_toasts = {}
+
+    for _, player in pairs(players) do
+        for _, element in pairs(player.gui.left.children) do
+            local toast, data = get_toast(element)
+            if toast and data then
+                local toast_id = data.toast_id
+                local end_tick = data.end_tick
+
+                if tick > end_tick then
+                    Gui.destroy(element)
+                    finished_toasts[toast_id] = true
+                else
+                    local start_tick = data.start_tick
+                    local limit = end_tick - start_tick
+                    local current = end_tick - tick
+                    data.progressbar.value = current / limit
+                end
+            end
+        end
+    end
+
+    for toast_id, _ in pairs(finished_toasts) do
+        active_toasts[toast_id] = nil
+    end
+end)
+
+Event.add(defines.events.on_player_left_game, function (event)
+    local active_toasts = memory.active_toasts
+    if size(active_toasts) == 0 then
+        return
+    end
+
+    -- active toasts, do a cleanup so data remains uncorrupted
+    for _, element in pairs(Game.get_player_by_index(event.player_index).gui.left.children) do
+        local toast = get_toast(element)
+        if toast then
+            Gui.destroy(element)
+        end
+    end
+end)
+
+return Public

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -16,7 +16,7 @@ local memory = {
     active_toasts = {},
 }
 
-Global.register(memory, function (tbl) memory = tbl end)
+Global.register(memory, function (tbl) memory = tbl end, 'toast')
 
 ---Creates a unique ID for a toast message
 local function autoincrement()

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -83,7 +83,7 @@ local function get_toast(element)
 
     local data = Gui.get_data(element)
 
-    if type(data) == 'table' and data.is_toast then
+    if data and type(data) == 'table' and not data.__self and data.is_toast then
         return element, data
     end
 
@@ -128,21 +128,6 @@ Event.on_nth_tick(2, function (event)
                     end
                 end
             end
-        end
-    end
-end)
-
-Event.add(defines.events.on_player_left_game, function (event)
-    local active_toasts = memory.active_toasts
-    if size(active_toasts) == 0 then
-        return
-    end
-
-    -- active toasts, do a cleanup so data remains uncorrupted
-    for _, element in pairs(Game.get_player_by_index(event.player_index).gui.left.children) do
-        local toast = get_toast(element)
-        if toast then
-            Gui.destroy(element)
         end
     end
 end)

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -83,7 +83,7 @@ local function get_toast(element)
 
     local data = Gui.get_data(element)
 
-    if data and data.is_toast then
+    if type(data) == 'table' and data.is_toast then
         return element, data
     end
 


### PR DESCRIPTION
Will add toast messages to a given player.
![image](https://user-images.githubusercontent.com/1754678/51770595-a12a9480-20e6-11e9-9990-11cb08fbe7dc.png)

Known limitations:
 - Does not support adding clickable elements (can be done with some fiddling though)
 - It's rendered in sequence of opened GUI elements, meaning it can be opened between elements
 - One color for the bar, though it's easy to add this feature if needed

Features:
 - customizable up-time
 - whole toast is clickable and will close if that happens
 - support for default setup with message
 - calling the function will return a container you can safely add elements to
 - closes when the timeout is reached
 - closes when the player leaves the game

```lua
local Toast = require 'features.gui.toast' 
local toasty = Toast.toast_player(player, duration_in_seconds) -- empty toast
local toasty = Toast.toast_player(player, duration_in_seconds, message) -- adds a label to the toast
```

In the first example it will create an empty toast, but you can add gui elements to the toast. In the second example you can also add elements but they will be placed underneath a message. The first example is useful if the default message isn't enough. 