### PR TITLE
Have travis issue nightly releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,46 @@
 language: python
 sudo: false
-
 env:
-  - LUA="lua=5.2"
-
+  matrix:
+    - LUA="lua=5.2"
+branches:
+  only:
+    - master
+    - develop
 before_install:
   - pip install hererocks
-  - hererocks lua_install -r^ --$LUA
-  - export PATH=$PATH:$PWD/lua_install/bin
-
+  - hererocks ~/build/lua_install -r^ --$LUA
+  - export PATH=$PATH:~/build/lua_install/bin
 install:
   - luarocks install luacheck
-
 script:
-  - luacheck . --exclude-files lua_install
+  - "if [[ $TRAVIS_EVENT_TYPE != 'cron' ]]; then luacheck .; fi"
+before_deploy:
+  - git config --local user.name "$github_user_name"
+  - git config --local user.email "$github_user_email"
+  - DATE_FORMATTED=$(date +'%Y-%m-%d')
+  - export DATE_FORMATTED
+  - COMMIT_SHA=$(git log --format=%h -1)
+  - export COMMIT_SHA
+  - TRAVIS_TAG="nightly/"$DATE_FORMATTED-$COMMIT_SHA
+  - export TRAVIS_TAG
+  - git tag "$TRAVIS_TAG"
+  - RELEASE_NAME='Nightly release - '"$DATE_FORMATTED"' - '"$COMMIT_SHA"
+  - export RELEASE_NAME
+  - ./.travis/release_builder.sh
+deploy:
+  on:
+    condition: $TRAVIS_EVENT_TYPE = cron
+    repo: Refactorio/RedMew
+    branch: develop
+  provider: releases
+  api_key:
+    secure: SZsTjOLenetur34FEDCOrOw1jCI0xoZ0KyCrsrBpieQ0+P0hlVgRjEhyg74IiKC5cX5+HS329jUiIs7dUts2mGF09gCdYTPtKtkjmbhZK61DkMSplUIUDJDv5lCsR9BQTSX0x38+olkCTZAgFnU6T449auwd4Htsw6NOKI1V0h33K5YX4QJeMwnFQUorQ5lIl9+aEz/PVKHV0Glqnfp52O/Tn2nqfZxBI48UXRkJJIJLfVi74gPpD0HjspSYoCig3u6j9Rq2HcML+/geyJeM0aL6vZUsZhADIBT2x2MSZtN5KGRby+HEGnyj1u8Bp7BNpbioXtVZ3e57hrqTIbNzMx/8p4rqip9lm7ClP6uPTlgMfHKsnFYKOWiyuMGeFtJxcb/3KzMt4wXxZQQAkoJ4BnsYcm0G7H3EkAMbIF0piOwp2Fn8MCrmUSJcb+dOEe2ixe8p00vi9ffnvBr4Qz+nyqQU6D1aq3DNafmQn2eshuqrhB6+s86uj/3F9fFaPD+GhjL9t7zGgkX/RuLDPxdM7Xo7lc6yUhrFGA2yrkROqPq4M7bCmMcegRyvl27mGsh1R6FTwAEShHa7CU5/8bnnSxsp1YIdHoMWhCBEeFrm3lz6w+gly+iAxjkc0lzREjf/nYmjWSqB1TXUMbssg/G0czCgmTYlq9G7QhhPaWd0D2I=
+  file:
+    - RedMew.zip
+    #- Diggy.zip
+    #- Crashsite.zip
+  skip_cleanup: true
+  #prerelease: true
+  draft: true #after the testing phase, this will be deleted and we will issue prereleases
+  name: "$RELEASE_NAME"

--- a/.travis/release_builder.sh
+++ b/.travis/release_builder.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#Copy the repo, clean it, and write the version for the release
+cd ~/build || exit
+echo "Changing dir to :"
+pwd
+echo "Copying RedMew folder to work on"
+cp -rf Refactorio/RedMew working_copy
+echo "Removing git files"
+rm -rf working_copy/.??*
+echo "Writing the version file"
+echo 'return '"$DATE_FORMATTED"'-'"$COMMIT_SHA" > working_copy/resources/version.lua
+echo "Contents of the version file:"
+cat working_copy/resources/version.lua
+
+#Create zips for each of the major maps/scenarios
+function process_map (){
+    echo '-----'"$1"'-----'
+    mv "$3" "$1"
+    echo 'return '"'$2'" > "$1"'/map_selection.lua'
+    echo "Contents of map_selection:"
+    cat "$1"'/map_selection.lua'
+    echo "Creating zip..."
+    zip -r9q "$1"'.zip' "$1"
+    #if [ "$4" != true ]; then #Base RedMew can't be deflated
+        #echo "Deflating the zip..."
+        #Having the deflater here would be dope.
+    #fi
+    echo "Stats on the zip:"
+    ls -al "$1"'.zip'
+    cp "$1"'.zip' "$HOME/build/Refactorio/RedMew/""$1"'.zip'
+    PREVIOUS_NAME=$1
+    export PREVIOUS_NAME
+    return 0
+}
+
+#Each map after the default redmew release repeats the pattern of $1=The regular name of the map (proper casing), $2=The name of the map file (lower case), $3 "$PREVIOUS_NAME"
+process_map "RedMew" "default" "working_copy" true
+#process_map "Diggy" "diggy" "$PREVIOUS_NAME"
+#process_map "Crashsite" "crashsite" "$PREVIOUS_NAME"

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -4,6 +4,7 @@ local Game = require 'utils.game'
 local Server = require 'features.server'
 local Timestamp = require 'utils.timestamp'
 local Command = require 'utils.command'
+local redmew_version = require 'resources.version'
 
 local format = string.format
 local ceil = math.ceil
@@ -208,6 +209,10 @@ local function list_seeds()
     Game.player_print(seeds)
 end
 
+local function print_version()
+    Game.player_print(redmew_version)
+end
+
 -- Command registrations
 
 Command.add(
@@ -283,6 +288,15 @@ Command.add(
         allowed_by_server = true,
     },
     list_seeds
+)
+
+Command.add(
+    'redmew-version',
+    {
+        description = 'Prints the version of the RedMew scenario',
+        allowed_by_server = true,
+    },
+    print_version
 )
 
 -- Commands with no functions, only calls to other modules

--- a/resources/version.lua
+++ b/resources/version.lua
@@ -1,0 +1,1 @@
+return 'This map was created from source code, only releases (zips with names) have versions'


### PR DESCRIPTION
Travis will push nightly releases. Each release gets its own git tag, but the tags each start with `nightly/` so it shouldn't cause any real clutter. In the future I'll see what I can do about having travis clean up old tags.

When Travis' cron job is triggered, it will not check for linting errors for now, since we haven't cleaned up yet. In the future I would like to lint before pushing builds.
Currently Travis can write the `version` and `map_selection` files for maps/scenarios, and can assemble zip files for each scenario so that they're ready to play. When the deflater is able to handle conditional requires, I should be able to integrate it into the deploy process as well.

As part of a trial period, Travis will not publish actual releases yet but will instead create drafts of releases.

This is what releases will look like when we get the deflator+map loading where we want them:
https://github.com/plague006/RedMew/releases/tag/nightly%2F2019-01-27-9f05e06

And a build log:
https://travis-ci.org/plague006/RedMew/builds/484944639