### PR TITLE
Improve versioning

### DIFF
--- a/.travis/release_builder.sh
+++ b/.travis/release_builder.sh
@@ -9,26 +9,26 @@ cp -rf Refactorio/RedMew working_copy
 echo "Removing git files"
 rm -rf working_copy/.??*
 echo "Writing the version file"
-echo 'return '"$DATE_FORMATTED"'-'"$COMMIT_SHA" > working_copy/resources/version.lua
+echo "global.redmew_version=$DATE_FORMATTED-$COMMIT_SHA" > working_copy/resources/version.lua
 echo "Contents of the version file:"
 cat working_copy/resources/version.lua
 
 #Create zips for each of the major maps/scenarios
 function process_map (){
-    echo '-----'"$1"'-----'
+    echo "-----$1-----"
     mv "$3" "$1"
-    echo 'return '"'$2'" > "$1"'/map_selection.lua'
+    echo "return $2" > "$1/map_selection.lua"
     echo "Contents of map_selection:"
-    cat "$1"'/map_selection.lua'
+    cat "$1/map_selection.lua"
     echo "Creating zip..."
-    zip -r9q "$1"'.zip' "$1"
+    zip -r9q "$1.zip" "$1"
     #if [ "$4" != true ]; then #Base RedMew can't be deflated
         #echo "Deflating the zip..."
         #Having the deflater here would be dope.
     #fi
     echo "Stats on the zip:"
-    ls -al "$1"'.zip'
-    cp "$1"'.zip' "$HOME/build/Refactorio/RedMew/""$1"'.zip'
+    ls -al "$1.zip"
+    cp "$1.zip" "$HOME/build/Refactorio/RedMew/$1.zip"
     PREVIOUS_NAME=$1
     export PREVIOUS_NAME
     return 0

--- a/control.lua
+++ b/control.lua
@@ -1,8 +1,9 @@
 -- Omitting the math library is a very bad idea
 require 'utils.math'
 
--- Global Debug and extra global table functions to make debugging and coding significantly easier
+-- Global Debug and make sure our version file is registered
 Debug = require 'utils.debug'
+require 'resources.version'
 require 'utils.table'
 
 -- Map layout and config dictate the map you play and the settings in it
@@ -110,6 +111,7 @@ if _DUMP_ENV then
     require 'utils.dump_env'
 end
 
+require 'resources.version'
 -- Needs to be at bottom so tokens are registered last.
 if _DEBUG then
     require 'features.gui.debug.command'

--- a/features/player_colors.lua
+++ b/features/player_colors.lua
@@ -40,7 +40,7 @@ function Public.set_random_color(player)
 end
 
 Command.add(
-    'color-redmew',
+    'redmew-color',
     {
         description = 'Set will save your current color for future maps. Reset will erase your saved color. Random will give you a random color.',
         arguments = {'set-reset-random'},

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -4,7 +4,6 @@ local Game = require 'utils.game'
 local Server = require 'features.server'
 local Timestamp = require 'utils.timestamp'
 local Command = require 'utils.command'
-local redmew_version = require 'resources.version'
 
 local format = string.format
 local ceil = math.ceil
@@ -210,7 +209,13 @@ local function list_seeds()
 end
 
 local function print_version()
-    Game.player_print(redmew_version)
+    local version_str
+    if global.redmew_version then
+        version_str = global.redmew_version
+    else
+        version_str = 'This map was created from source code, only releases (zips with names) and server saves have versions'
+    end
+    Game.player_print(version_str)
 end
 
 -- Command registrations
@@ -299,7 +304,7 @@ Command.add(
     print_version
 )
 
--- Commands with no functions, only calls to other modules
+-- Commands with no local functions, only calls to other modules
 
 Command.add(
     'report',

--- a/features/server.lua
+++ b/features/server.lua
@@ -4,6 +4,7 @@ local Token = require 'utils.token'
 local Global = require 'utils.global'
 local Event = require 'utils.event'
 local Game = require 'utils.game'
+local Timestamp = require 'utils.timestamp'
 
 local serialize = serpent.serialize
 local concat = table.concat
@@ -510,6 +511,18 @@ function Public.query_online_players()
     message = concat(message)
     raw_print(message)
 end
+
+--- Sets the server time as the scenario version. Imperfect since we ideally want the commit,
+-- but an easy way to at least establish a baseline.
+local function set_scenario_version()
+    -- A 1 hour buffer is in place to account for potential playtime pre-upload.
+    if game.tick < 216000 and not global.redmew_version then
+        local time_string = Timestamp.to_string(Public.get_current_time())
+        global.redmew_version = 'Time of map launch: ' .. time_string
+    end
+end
+
+Event.add(Public.events.on_server_started, set_scenario_version)
 
 --- The [JOIN] nad [LEAVE] messages Factorio sends to stdout aren't sent in all cases of
 --  players joining or leaving. So we send our own [PLAYER-JOIN] and [PLAYER-LEAVE] tags.

--- a/resources/version.lua
+++ b/resources/version.lua
@@ -1,1 +1,1 @@
-return 'This map was created from source code, only releases (zips with names) have versions'
+global.redmew_version = nil


### PR DESCRIPTION
Have server record approx map start time as the version (if version is empty)
Have the base version.lua be empty and instead rely on the command to provide info about nil version.
Rename command to redmew-color since hitting tab after `color` doesn't autocomplete or present `color-redmew` as an option
Make build script easier to read by using double quotes properly.