### PR TITLE
Add _LIFECYCLE as an indicator of where we are in the data lifecycle

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -56,7 +56,7 @@ local STD_BASE_CONTROL = 'lua52c+factorio+factorio_control+factorio_defines+fact
 --[Assume Factorio Control stage as default]--
 -------------------------------------------------------------------------------
 std = STD_CONTROL
-globals = {'print', '_DEBUG', '_CHEATS', '_DUMP_ENV', 'ServerCommands', 'Debug'} -- RedMew-specific globals
+globals = {'print', '_DEBUG', '_CHEATS', '_DUMP_ENV', 'ServerCommands', 'Debug', '_LIFECYCLE'} -- RedMew-specific globals
 max_line_length = LINE_LENGTH
 
 not_globals = NOT_GLOBALS

--- a/control.lua
+++ b/control.lua
@@ -1,3 +1,8 @@
+-- If you're looking to configure anything, you want config.lua. Nearly everything in this file is dictated by the config.
+
+-- Info on the data lifecycle and how we use it: https://github.com/Refactorio/RedMew/wiki/The-data-lifecycle
+_LIFECYCLE = 4 -- Control stage
+
 -- Omitting the math library is a very bad idea
 require 'utils.math'
 

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -152,7 +152,7 @@ end
 -- @param event_name<number>
 -- @param handler<function>
 function Event.add(event_name, handler)
-    if EventCore.runtime then
+    if _LIFECYCLE == 8 then
         error('Calling Event.add after on_init() or on_load() has run is a desync risk.', 2)
     end
 
@@ -164,7 +164,7 @@ end
 -- See documentation at top of file for details on using events.
 -- @param handler<function>
 function Event.on_init(handler)
-    if EventCore.runtime then
+    if _LIFECYCLE == 8 then
         error('Calling Event.on_init after on_init() or on_load() has run is a desync risk.', 2)
     end
 
@@ -176,7 +176,7 @@ end
 -- See documentation at top of file for details on using events.
 -- @param handler<function>
 function Event.on_load(handler)
-    if EventCore.runtime then
+    if _LIFECYCLE == 8 then
         error('Calling Event.on_load after on_init() or on_load() has run is a desync risk.', 2)
     end
 
@@ -189,7 +189,7 @@ end
 -- @param tick<number> The handler will be called every nth tick
 -- @param handler<function>
 function Event.on_nth_tick(tick, handler)
-    if EventCore.runtime then
+    if _LIFECYCLE == 8 then
         error('Calling Event.on_nth_tick after on_init() or on_load() has run is a desync risk.', 2)
     end
 

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -6,8 +6,6 @@ local Public = {}
 local init_event_name = -1
 local load_event_name = -2
 
-Public.runtime = false -- Set to true after on_init or on_load has finished.
-
 -- map of event_name to handlers[]
 local event_handlers = {}
 -- map of nth_tick to handlers[]
@@ -34,23 +32,25 @@ local function on_event(event)
 end
 
 local function on_init()
+    _LIFECYCLE = 5 -- on_init
     local handlers = event_handlers[init_event_name]
     call_handlers(handlers)
 
     event_handlers[init_event_name] = nil
     event_handlers[load_event_name] = nil
 
-    Public.runtime = true
+    _LIFECYCLE = 8 -- Runtime
 end
 
 local function on_load()
+    _LIFECYCLE = 6 -- on_load
     local handlers = event_handlers[load_event_name]
     call_handlers(handlers)
 
     event_handlers[init_event_name] = nil
     event_handlers[load_event_name] = nil
 
-    Public.runtime = true
+    _LIFECYCLE = 8 -- Runtime
 end
 
 local function on_nth_tick_event(event)

--- a/utils/token.lua
+++ b/utils/token.lua
@@ -1,5 +1,3 @@
-local EventCore = require 'utils.event_core'
-
 local Token = {}
 
 local tokens = {}

--- a/utils/token.lua
+++ b/utils/token.lua
@@ -13,7 +13,7 @@ local counter = 0
 -- @param  var<any>
 -- @return number the unique token for the variable.
 function Token.register(var)
-    if EventCore.runtime then
+    if _LIFECYCLE == 8 then
         error('Calling Token.register after on_init() or on_load() has run is a desync risk.', 2)
     end
 


### PR DESCRIPTION
See: https://github.com/Refactorio/RedMew/wiki/The-data-lifecycle

Mark the start of the control stage at the beginning of control.lua
On_load and On_init inside event_core's hook on `script`.
Similarly, mark the beginning of runtime at the end of event_core's `script` hooks on on_init and on_load.