### PR TITLE
Added anti grief for trains

### DIFF
--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -241,7 +241,7 @@ local function on_entity_died(event)
 
     -- If there was a passenger who was unpunished along with a punished passenger, let the admins know
     if player_punished and player_unpunished then
-        local name_string = table.concat(name_list, ' - ')
+        local name_string = table.concat(name_list, ', ')
         Utils.print_admins({'nuke_control.multiple_passengers', num_passengers, name_string})
     end
 end

--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -12,13 +12,13 @@ local Ranks = require 'resources.ranks'
 local format = string.format
 local match = string.match
 
-local function allowed_to_nuke(player)
+local function is_trusted(player)
     return Rank.equal_or_greater_than(player.name, Ranks.auto_trusted)
 end
 
 local function ammo_changed(event)
     local player = Game.get_player_by_index(event.player_index)
-    if allowed_to_nuke(player) then
+    if is_trusted(player) then
         return
     end
     local nukes = player.remove_item({name = 'atomic-bomb', count = 1000})
@@ -39,7 +39,7 @@ end
 
 local function on_player_deconstructed_area(event)
     local player = Game.get_player_by_index(event.player_index)
-    if allowed_to_nuke(player) then
+    if is_trusted(player) then
         return
     end
     player.remove_item({name = 'deconstruction-planner', count = 1000})
@@ -141,7 +141,7 @@ local function on_capsule_used(event)
         return
     end
 
-    if not allowed_to_nuke(player) then
+    if not is_trusted(player) then
         local area = {{event.position.x - 5, event.position.y - 5}, {event.position.x + 5, event.position.y + 5}}
         local count = 0
         local entities = player.surface.find_entities_filtered {force = player.force, area = area}
@@ -213,7 +213,7 @@ local function on_entity_died(event)
     for i = 1, #passengers do
         local player = passengers[i]
         if player.valid then
-            if allowed_to_nuke(player) then
+            if is_trusted(player) then
                 player_unpunished = true
                 name_list[#name_list + 1] = player.name
             else

--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -4,6 +4,7 @@ local Utils = require 'utils.core'
 local Game = require 'utils.game'
 local Task = require 'utils.task'
 local Token = require 'utils.token'
+local Global = require 'utils.global'
 local Server = require 'features.server'
 local Report = require 'features.report'
 local Popup = require 'features.gui.popup'
@@ -11,6 +12,44 @@ local Ranks = require 'resources.ranks'
 
 local format = string.format
 local match = string.match
+
+local players_warned = {}
+local entities_allowed_to_bomb = {
+    ['stone-wall'] = true,
+    ['transport-belt'] = true,
+    ['fast-transport-belt'] = true,
+    ['express-transport-belt'] = true,
+    ['construction-robot'] = true,
+    ['player'] = true,
+    ['gun-turret'] = true,
+    ['laser-turret'] = true,
+    ['flamethrower-turret'] = true,
+    ['rail'] = true,
+    ['rail-chain-signal'] = true,
+    ['rail-signal'] = true,
+    ['tile-ghost'] = true,
+    ['entity-ghost'] = true,
+    ['gate'] = true,
+    ['electric-pole'] = true,
+    ['small-electric-pole'] = true,
+    ['medium-electric-pole'] = true,
+    ['big-electric-pole'] = true,
+    ['logistic-robot'] = true,
+    ['defender'] = true,
+    ['destroyer'] = true,
+    ['distractor'] = true
+}
+
+Global.register(
+    {
+        players_warned = players_warned,
+        entities_allowed_to_bomb = entities_allowed_to_bomb
+    },
+    function(tbl)
+        players_warned = tbl.players_warned
+        entities_allowed_to_bomb = tbl.entities_allowed_to_bomb
+    end
+)
 
 local function is_trusted(player)
     return Rank.equal_or_greater_than(player.name, Ranks.auto_trusted)
@@ -79,37 +118,6 @@ local function item_not_sanctioned(item)
     local name = item.name
     return (name:find('capsule') or name == 'cliff-explosives' or name == 'raw-fish' or name == 'discharge-defense-remote')
 end
-
-global.nuke_control = {
-    entities_allowed_to_bomb = {
-        ['stone-wall'] = true,
-        ['transport-belt'] = true,
-        ['fast-transport-belt'] = true,
-        ['express-transport-belt'] = true,
-        ['construction-robot'] = true,
-        ['player'] = true,
-        ['gun-turret'] = true,
-        ['laser-turret'] = true,
-        ['flamethrower-turret'] = true,
-        ['rail'] = true,
-        ['rail-chain-signal'] = true,
-        ['rail-signal'] = true,
-        ['tile-ghost'] = true,
-        ['entity-ghost'] = true,
-        ['gate'] = true,
-        ['electric-pole'] = true,
-        ['small-electric-pole'] = true,
-        ['medium-electric-pole'] = true,
-        ['big-electric-pole'] = true,
-        ['logistic-robot'] = true,
-        ['defender'] = true,
-        ['destroyer'] = true,
-        ['distractor'] = true
-    },
-    players_warned = {}
-}
-local entities_allowed_to_bomb = global.nuke_control.entities_allowed_to_bomb
-local players_warned = global.nuke_control.players_warned
 
 local function entity_allowed_to_bomb(entity)
     return entities_allowed_to_bomb[entity.name]

--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -184,8 +184,7 @@ local train_to_manual =
 local function on_entity_died(event)
     -- We only care is a train is killed by a member of its own force
     local entity = event.entity
-    local force = event.force
-    if (not entity or not entity.valid) or (not force or not force.valid) or (force ~= entity.force) then
+    if (not entity or not entity.valid) or (event.force ~= entity.force) then
         return
     end
     -- Check that an entity did the killing

--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -218,7 +218,7 @@ local function on_entity_died(event)
     local player_punished
     local player_unpunished
     local name_list = {}
-    for i = 1, #passengers do
+    for i = 1, num_passengers do
         local player = passengers[i]
         if player.valid then
             if is_trusted(player) then
@@ -231,10 +231,10 @@ local function on_entity_died(event)
                 player.driving = false
                 train.manual_mode = false
                 Task.set_timeout_in_ticks(30, train_to_manual, train)
-                if players_warned[player.index] then -- jail for later offenses
+                if players_warned[player.index] and num_passengers == 1 then -- jail for later offenses if they're solely guilty
                     Report.jail(player)
                     Utils.print_admins({'nuke_control.train_jailing', player.name})
-                else -- warn for first offense
+                else -- warn for first offense or if there's someone else in the train
                     players_warned[player.index] = true
                     Utils.print_admins({'nuke_control.train_warning', player.name})
                     Popup.player(player, {'nuke_control.train_player_warning'})

--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -182,9 +182,9 @@ local train_to_manual =
 )
 
 local function on_entity_died(event)
-    -- We only care is a train is killed by a member of its own force
+    -- We only care if a train is killed by a member of its own force
     local entity = event.entity
-    if (not entity or not entity.valid) or (event.force ~= entity.force) then
+    if (not entity or not entity.valid) or not entity.train or (event.force ~= entity.force) then
         return
     end
     -- Check that an entity did the killing

--- a/locale/en/redmew.cfg
+++ b/locale/en/redmew.cfg
@@ -46,4 +46,4 @@ train_jailing=__1__ used a train to destroy an entity and has been jailed.
 multiple_passengers=Note: There were __1__ players in the train and any could have been controlling it: __2__
 
 [utils_core]
-print_admins='__1__(ADMIN) __2__: __3__
+print_admins=__1__(ADMIN) __2__: __3__

--- a/locale/en/redmew.cfg
+++ b/locale/en/redmew.cfg
@@ -38,3 +38,9 @@ toast_message=The end times are here. The four biters of the apocalypse have bee
 [toast]
 toast_all=__1__ sent a toast to all players.
 toast_player=__1__ sent a toast to __2__.
+
+[nuke_control]
+train_warning=__1__ used a train to destroy an entity and has been warned.
+train_player_warning=You have destroyed another train with yours.\nRepeated infractions will be punished.
+train_jailing=__1__ used a train to destroy an entity and has been jailed.
+multiple_passengers=Note: There were __1__ players in the train and any could have been controlling it: __2__

--- a/locale/en/redmew.cfg
+++ b/locale/en/redmew.cfg
@@ -40,9 +40,9 @@ toast_all=__1__ sent a toast to all players.
 toast_player=__1__ sent a toast to __2__.
 
 [nuke_control]
-train_warning=__1__ used a train to destroy an entity and has been warned.
+train_warning=__1__ used a train to destroy another train and has been warned.
 train_player_warning=You have destroyed another train with yours.\nRepeated infractions will be punished.
-train_jailing=__1__ used a train to destroy an entity and has been jailed.
+train_jailing=__1__ used a train to destroy another train and has been jailed.
 multiple_passengers=Note: There were __1__ players in the train and any could have been controlling it: __2__
 
 [utils_core]

--- a/locale/en/redmew.cfg
+++ b/locale/en/redmew.cfg
@@ -44,3 +44,6 @@ train_warning=__1__ used a train to destroy an entity and has been warned.
 train_player_warning=You have destroyed another train with yours.\nRepeated infractions will be punished.
 train_jailing=__1__ used a train to destroy an entity and has been jailed.
 multiple_passengers=Note: There were __1__ players in the train and any could have been controlling it: __2__
+
+[utils_core]
+print_admins='__1__(ADMIN) __2__: __3__

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -65,8 +65,8 @@ function Module.print_admins(msg, source)
         source_name = 'Server'
         chat_color = Color.yellow
     end
-    local formatted_msg = format('%s(ADMIN) %s: %s', prefix, source_name, msg) -- to the server
-    print(formatted_msg)
+    local formatted_msg = {'utils_core.print_admins',prefix, source_name, msg}
+    log(formatted_msg)
     for _, p in pairs(game.connected_players) do
         if p.admin then
             p.print(formatted_msg, chat_color)


### PR DESCRIPTION
Features include:
* Popups for players when they destroy part of a train
* Kicking players when they have destroyed more than 2 train parts
* Banning guest when they have destroyed more than 3 train parts
* Jailing regulars when they have destroyed more than 3 train parts
* Sets train to automatic mode when a train part has been destroyed
* Does not trigger if the train is in automatic mode
* Toggle able just like on_capsule_used
* Works with on_capsule_used, triggering the ban for guests if they already have been kicked once, regardless of offence.

Tested with heavy mode and on the test server.

closes #701 