### PR TITLE
refactor blueprint_helper to not call Token directly and to correct lint warnings

### DIFF
--- a/features/gui/blueprint_helper.lua
+++ b/features/gui/blueprint_helper.lua
@@ -13,8 +13,7 @@ Global.register(
     },
     function(tbl)
         player_filters = tbl.player_filters
-    end,
-    'blueprint_helper'
+    end
 )
 
 local function getBlueprintCursorStack(player)

--- a/features/gui/blueprint_helper.lua
+++ b/features/gui/blueprint_helper.lua
@@ -1,9 +1,21 @@
 -- Soft mod version of Blueprint Flipper and Turner https://mods.factorio.com/mods/Marthen/Blueprint_Flip_Turn
 
 local Event = require 'utils.event'
-local Token = require 'utils.token'
+local Global = require 'utils.global'
 local Gui = require 'utils.gui'
 local Game = require 'utils.game'
+
+local player_filters = {}
+
+Global.register(
+    {
+        player_filters = player_filters
+    },
+    function(tbl)
+        player_filters = tbl.player_filters
+    end,
+    'blueprint_helper'
+)
 
 local function getBlueprintCursorStack(player)
     local cursor = player.cursor_stack
@@ -63,7 +75,7 @@ local function flip_v(cursor)
         cursor.set_blueprint_entities(ents)
     end
     if cursor.get_blueprint_tiles() ~= nil then
-        local ents = cursor.get_blueprint_tiles()
+        ents = cursor.get_blueprint_tiles()
         for i = 1, #ents do
             local dir = ents[i].direction or 0
             ents[i].direction = (12 - dir) % 8
@@ -120,7 +132,7 @@ local function flip_h(cursor)
         cursor.set_blueprint_entities(ents)
     end
     if cursor.get_blueprint_tiles() ~= nil then
-        local ents = cursor.get_blueprint_tiles()
+        ents = cursor.get_blueprint_tiles()
         for i = 1, #ents do
             local dir = ents[i].direction or 0
             ents[i].direction = (16 - dir) % 8
@@ -242,15 +254,6 @@ local valid_filters = {
 }
 
 -- Gui implementation.
-
-local player_filters = {}
-local player_filters_token = Token.register_global(player_filters)
-
-Event.on_load(
-    function()
-        player_filters = Token.get_global(player_filters_token)
-    end
-)
 
 local main_button_name = Gui.uid_name()
 local main_frame_name = Gui.uid_name()


### PR DESCRIPTION
(cherry picked from commit 1beef8ba6a6ce118a82d9bf590bd8848a4fe90b1)

Cherry picked this into its own PR because #688 got stuck due to a possible future alternate implementation.