### PR TITLE
Add /whois command

### DIFF
--- a/features/player_create.lua
+++ b/features/player_create.lua
@@ -62,6 +62,7 @@ local function player_created(event)
 
     if _DEBUG and player.admin then
         UserGroups.add_regular(player.name)
+        game.print("HEY GRILLED DON'T LAUNCH THIS MAP! DEBUG MODE IS ENABLED!!!")
     end
 
     if _CHEATS then

--- a/features/player_stats.lua
+++ b/features/player_stats.lua
@@ -223,6 +223,14 @@ function Public.get_death_count(player_index)
     return player_deaths[player_index].count
 end
 
+function Public.get_crafted_item(player_index)
+    return player_crafted_items[player_index]
+end
+
+function Public.get_console_chat(player_index)
+    return player_console_chats[player_index]
+end
+
 -- Returns a dictionary of cause_name -> count
 function Public.get_all_death_counts_by_cause(player_index)
     return player_deaths[player_index].causes or {}
@@ -242,14 +250,6 @@ end
 
 function Public.get_total_player_rocks_mined()
     return total_player_rocks_mined[1]
-end
-
-function Public.get_player_crafted_item(player_index)
-    return player_crafted_items[player_index]
-end
-
-function Public.get_player_console_chat(player_index)
-    return player_console_chats[player_index]
 end
 
 function Public.get_total_robot_built_entities()

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -239,7 +239,7 @@ local function print_player_info(args, player)
         'Rank: ' .. UserGroups.get_rank(target),
         UserGroups.is_donator(target.name) and 'Donator: yes' or 'Donator: no',
         'Time played: ' .. Utils.format_time(target.online_time),
-        'AFK time: ' .. target.afk_time or 0,
+        'AFK time: ' .. Utils.format_time(target.afk_time or 0),
         'Force: ' .. target.force.name,
         'Surface: ' .. target.surface.name,
         'Tag: ' .. target.tag,

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -223,22 +223,6 @@ local function print_version()
     Game.player_print(version_str)
 end
 
---- Returns a string indicating the player's rank
-local function get_rank(player)
-    if player.admin then
-        return 'Admin'
-    end
-
-    local name = player.name
-    if UserGroups.is_donator(name) then
-        return 'Donator'
-    elseif UserGroups.is_regular(name) then
-        return 'Regular'
-    end
-
-    return 'Guest'
-end
-
 --- Prints information about the target player
 local function print_player_info(args, player)
     local name = args.player
@@ -255,7 +239,8 @@ local function print_player_info(args, player)
         'Name: ' .. name,
         player.connected and 'Online: ' .. 'yes' or 'Online: ' .. 'no',
         'Index: ' .. player.index,
-        'Rank: ' .. get_rank(player),
+        'Rank: ' .. UserGroups.get_rank(player),
+        'Donator: ' .. UserGroups.is_donator(player.name),
         'Time played: ' .. Utils.format_time(player.online_time),
         'AFK time: ' .. player.afk_time or 0,
         'Force: ' .. player.force.name,

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -5,6 +5,9 @@ local Server = require 'features.server'
 local Timestamp = require 'utils.timestamp'
 local Command = require 'utils.command'
 local Walkabout = require 'features.walkabout'
+local redmew_version = require 'resources.version'
+local PlayerStats = require 'features.player_stats'
+local Utils = require 'utils.core'
 
 local format = string.format
 local ceil = math.ceil
@@ -127,6 +130,7 @@ local function show_rail_block(_, player)
     Game.player_print('show_rail_block_visualisation set to ' .. tostring(show))
 end
 
+--- Provides the time on the server
 local function server_time(_, player)
     local p
     if not player then
@@ -219,6 +223,60 @@ local function print_version()
     Game.player_print(version_str)
 end
 
+--- Returns a string indicating the player's rank
+local function get_rank(player)
+    if player.admin then
+        return 'Admin'
+    end
+
+    local name = player.name
+    if UserGroups.is_donator(name) then
+        return 'Donator'
+    elseif UserGroups.is_regular(name) then
+        return 'Regular'
+    end
+
+    return 'Guest'
+end
+
+--- Prints information about the target player
+local function print_player_info(args, player)
+    local name = args.player
+    local target = game.players[name]
+    if not target then
+        Game.player_print('Target not found')
+    end
+    local index = player.index
+    local m_inventory = player.get_inventory(defines.inventory.player_main)
+    m_inventory = m_inventory.get_contents()
+    local q_inventory = player.get_inventory(defines.inventory.player_quickbar)
+    q_inventory = q_inventory.get_contents()
+    local info_t = {
+        'Name: ' .. name,
+        player.connected and 'Online: ' .. 'yes' or 'Online: ' .. 'no',
+        'Index: ' .. player.index,
+        'Rank: ' .. get_rank(player),
+        'Time played: ' .. Utils.format_time(player.online_time),
+        'AFK time: ' .. player.afk_time or 0,
+        'Force: ' .. player.force.name,
+        'Surface: ' .. player.surface.name,
+        'Tag: ' .. player.tag,
+        'Distance walked: ' .. PlayerStats.get_walk_distance(index),
+        'Coin earned: ' .. PlayerStats.get_coin_earned(index),
+        'Coin spent: ' .. PlayerStats.get_coin_spent(index),
+        'Deaths: ' .. PlayerStats.get_death_count(index),
+        'Crafted items: ' .. PlayerStats.get_crafted_item(index),
+        'Chat messages: ' .. PlayerStats.get_console_chat(index)
+    }
+    Game.player_print(concat(info_t, ' - '))
+
+    if player and player.admin and not args.inventory then
+        Game.player_print('Main and hotbar inventories: ')
+        Game.player_print(serpent.line(m_inventory))
+        Game.player_print(serpent.line(q_inventory))
+    end
+end
+
 -- Command registrations
 
 Command.add(
@@ -227,7 +285,7 @@ Command.add(
         description = 'Will kill you.',
         arguments = {'player'},
         default_values = {player = false},
-        allowed_by_server = true,
+        allowed_by_server = true
     },
     kill
 )
@@ -236,7 +294,7 @@ Command.add(
     'afk',
     {
         description = 'Shows how long players have been afk.',
-        allowed_by_server = true,
+        allowed_by_server = true
     },
     afk
 )
@@ -245,7 +303,7 @@ Command.add(
     'zoom',
     {
         description = 'Sets your zoom.',
-        arguments = {'zoom'},
+        arguments = {'zoom'}
     },
     zoom
 )
@@ -254,7 +312,7 @@ Command.add(
     'find',
     {
         description = 'shows an alert on the map where the player is located',
-        arguments = {'player'},
+        arguments = {'player'}
     },
     find_player
 )
@@ -262,7 +320,7 @@ Command.add(
 Command.add(
     'show-rail-block',
     {
-        description = 'Toggles rail block visualisation.',
+        description = 'Toggles rail block visualisation.'
     },
     show_rail_block
 )
@@ -271,7 +329,7 @@ Command.add(
     'server-time',
     {
         description = "Prints the server's time.",
-        allowed_by_server = true,
+        allowed_by_server = true
     },
     server_time
 )
@@ -282,7 +340,7 @@ Command.add(
         description = 'Search for commands matching the keyword in name or description',
         arguments = {'keyword', 'page'},
         default_values = {page = 1},
-        allowed_by_server = true,
+        allowed_by_server = true
     },
     search_command
 )
@@ -291,7 +349,7 @@ Command.add(
     'seeds',
     {
         description = 'List the seeds of all surfaces',
-        allowed_by_server = true,
+        allowed_by_server = true
     },
     list_seeds
 )
@@ -300,19 +358,30 @@ Command.add(
     'redmew-version',
     {
         description = 'Prints the version of the RedMew scenario',
-        allowed_by_server = true,
+        allowed_by_server = true
     },
     print_version
 )
 
--- Commands with no local functions, only calls to other modules
+Command.add(
+    'whois',
+    {
+        description = 'provides information about a given player, admins get additional information',
+        arguments = {'player', 'inventory'},
+        default_values = {inventory = false},
+        allowed_by_server = true
+    },
+    print_player_info
+)
+
+-- Commands with no functions, only calls to other modules
 
 Command.add(
     'report',
     {
         description = 'Reports a user to admins',
         arguments = {'player', 'message'},
-        capture_excess_arguments = true,
+        capture_excess_arguments = true
     },
     Report.report_command
 )
@@ -321,7 +390,7 @@ Command.add(
     'regulars',
     {
         description = 'Prints a list of game regulars.',
-        allowed_by_server = true,
+        allowed_by_server = true
     },
     UserGroups.print_regulars
 )

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -230,22 +230,18 @@ local function print_player_info(args, player)
     if not target then
         Game.player_print('Target not found')
     end
-    local index = player.index
-    local m_inventory = player.get_inventory(defines.inventory.player_main)
-    m_inventory = m_inventory.get_contents()
-    local q_inventory = player.get_inventory(defines.inventory.player_quickbar)
-    q_inventory = q_inventory.get_contents()
+    local index = target.index
     local info_t = {
         'Name: ' .. name,
-        player.connected and 'Online: ' .. 'yes' or 'Online: ' .. 'no',
-        'Index: ' .. player.index,
-        'Rank: ' .. UserGroups.get_rank(player),
-        'Donator: ' .. UserGroups.is_donator(player.name),
-        'Time played: ' .. Utils.format_time(player.online_time),
-        'AFK time: ' .. player.afk_time or 0,
-        'Force: ' .. player.force.name,
-        'Surface: ' .. player.surface.name,
-        'Tag: ' .. player.tag,
+        target.connected and 'Online: ' .. 'yes' or 'Online: ' .. 'no',
+        'Index: ' .. target.index,
+        'Rank: ' .. UserGroups.get_rank(target),
+        'Donator: ' .. UserGroups.is_donator(target.name),
+        'Time played: ' .. Utils.format_time(target.online_time),
+        'AFK time: ' .. target.afk_time or 0,
+        'Force: ' .. target.force.name,
+        'Surface: ' .. target.surface.name,
+        'Tag: ' .. target.tag,
         'Distance walked: ' .. PlayerStats.get_walk_distance(index),
         'Coin earned: ' .. PlayerStats.get_coin_earned(index),
         'Coin spent: ' .. PlayerStats.get_coin_spent(index),
@@ -253,9 +249,13 @@ local function print_player_info(args, player)
         'Crafted items: ' .. PlayerStats.get_crafted_item(index),
         'Chat messages: ' .. PlayerStats.get_console_chat(index)
     }
-    Game.player_print(concat(info_t, ' - '))
+    Game.player_print(concat(info_t, '\n- '))
 
-    if player and player.admin and not args.inventory then
+    if (not player or player.admin) and args.inventory then
+        local m_inventory = target.get_inventory(defines.inventory.player_main)
+        m_inventory = m_inventory.get_contents()
+        local q_inventory = target.get_inventory(defines.inventory.player_quickbar)
+        q_inventory = q_inventory.get_contents()
         Game.player_print('Main and hotbar inventories: ')
         Game.player_print(serpent.line(m_inventory))
         Game.player_print(serpent.line(q_inventory))
@@ -351,7 +351,7 @@ Command.add(
 Command.add(
     'whois',
     {
-        description = 'provides information about a given player, admins get additional information',
+        description = 'provides information about a given player, admins can see the inventory of a player by adding "yes" as a second argument',
         arguments = {'player', 'inventory'},
         default_values = {inventory = false},
         allowed_by_server = true

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -233,10 +233,10 @@ local function print_player_info(args, player)
     local index = target.index
     local info_t = {
         'Name: ' .. name,
-        target.connected and 'Online: ' .. 'yes' or 'Online: ' .. 'no',
+        target.connected and 'Online: yes' or 'Online: no',
         'Index: ' .. target.index,
         'Rank: ' .. UserGroups.get_rank(target),
-        'Donator: ' .. UserGroups.is_donator(target.name),
+        UserGroups.is_donator(target.name) and 'Donator: yes' or 'Donator: no',
         'Time played: ' .. Utils.format_time(target.online_time),
         'AFK time: ' .. target.afk_time or 0,
         'Force: ' .. target.force.name,

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -1,13 +1,12 @@
-local Report = require 'features.report'
-local UserGroups = require 'features.user_groups'
 local Game = require 'utils.game'
-local Server = require 'features.server'
 local Timestamp = require 'utils.timestamp'
 local Command = require 'utils.command'
-local Walkabout = require 'features.walkabout'
-local redmew_version = require 'resources.version'
-local PlayerStats = require 'features.player_stats'
 local Utils = require 'utils.core'
+local Report = require 'features.report'
+local Server = require 'features.server'
+local UserGroups = require 'features.user_groups'
+local Walkabout = require 'features.walkabout'
+local PlayerStats = require 'features.player_stats'
 
 local format = string.format
 local ceil = math.ceil

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -228,7 +228,9 @@ local function print_player_info(args, player)
     local target = game.players[name]
     if not target then
         Game.player_print('Target not found')
+        return
     end
+
     local index = target.index
     local info_t = {
         'Name: ' .. name,


### PR DESCRIPTION
Rename stat get functions to match others
`/whois <player>` -- and if you explicitly don't want to see their inventory you would use `/whois <player> no`. The specific use case I had in mind was when you want to get some info from the server console about a player.

![image](https://user-images.githubusercontent.com/10162554/51874542-6d8e7b00-232f-11e9-9772-4d412728f9ae.png)
