### PR TITLE
Change how we treat players in jail

### DIFF
--- a/features/report.lua
+++ b/features/report.lua
@@ -1,6 +1,10 @@
-local Gui = require('utils.gui')
-local Utils = require('utils.core')
+local Gui = require 'utils.gui'
+local Utils = require 'utils.core'
 local Game = require 'utils.game'
+local Global = require 'utils.global'
+local Event = require 'utils.event'
+local Token = require 'utils.token'
+local Popup = require 'features.gui.popup'
 local Color = require 'resources.color_presets'
 
 local format = string.format
@@ -11,16 +15,51 @@ local report_tab_button_name = Gui.uid_name()
 local jail_offender_button_name = Gui.uid_name()
 local report_body_name = Gui.uid_name()
 local jail_name = 'Jail'
+local jail_force = 'jailed'
 local default_group = 'Default'
 local prefix = '------------------NOTICE-------------------'
 local prefix_e = '--------------------------------------------'
 
 local Module = {}
-global.reports = {}
-global.player_report_data = {}
+
+-- Global registered locals
+local report_data = {}
+local jail_data = {}
+local primitives = {
+    on_chat_registered = nil
+}
+
+Global.register(
+    {
+        report_data = report_data,
+        jail_data = jail_data
+    },
+    function(tbl)
+        report_data = tbl.report_data
+        jail_data = tbl.jail_data
+    end
+)
+
+--- If a player in jail chats to their force, let the admins know
+local on_chat =
+    Token.register(
+    function(event)
+        local index = event.player_index
+        local player = Game.get_player_by_index(index)
+        local message
+
+        if jail_data[index] then
+            message = 'From jail: ' .. event.message
+            Utils.print_admins(message, player.name)
+        elseif player.admin then
+            message = 'From admin: ' .. event.message
+            game.forces[jail_force].print(message)
+        end
+    end
+)
 
 local function draw_report(parent, report_id)
-    local report = global.reports[report_id]
+    local report = report_data[report_id]
     if report_id == 0 or not report then
         parent.add {type = 'label', caption = 'No reports yet.'}
         return
@@ -59,7 +98,7 @@ end
 
 Module.show_reports =
     function(player)
-    local reports = global.reports or {}
+    local reports = report_data
 
     local center = player.gui.center
 
@@ -102,7 +141,7 @@ function Module.report(reporting_player, reported_player, message)
         player_index = reporting_player.index
         reporting_player.print('Your report has been sent.')
     end
-    table.insert(global.reports, {reporting_player_index = player_index, reported_player_index = reported_player.index, message = message, tick = game.tick})
+    table.insert(report_data, {reporting_player_index = player_index, reported_player_index = reported_player.index, message = message, tick = game.tick})
 
     local notified = false
     for _, p in pairs(game.players) do
@@ -141,13 +180,10 @@ end
 -- @param player <LuaPlayer|nil> the admin as LuaPlayer or server as nil
 function Module.jail(target_player, player)
     local print
-    local jailed_by
     if player then
-        jailed_by = 'a server admin'
         print = player.print
     else
         player = {name = 'server'}
-        jailed_by = 'the server'
         print = log
     end
 
@@ -156,6 +192,7 @@ function Module.jail(target_player, player)
         return
     end
 
+    local target_name = target_player.name
     local permissions = game.permissions
 
     -- Check if the permission group exists, if it doesn't, create it.
@@ -169,20 +206,25 @@ function Module.jail(target_player, player)
         end
     end
 
-    if target_player.permission_group == permission_group then
-        print(format('Player %s is already in jail.', target_player.name))
+    local former_permission_group = target_player.permission_group
+    if former_permission_group == permission_group then
+        print(format('Player %s is already in jail.', target_name))
         return
     end
 
-    -- Enable writing to console to allow a person to speak
+    -- Enable writing to console to allow a person to speak, and allow them to edit permission group so that an admin can unjail themselves
     permission_group.set_allows_action(defines.input_action.write_to_console, true)
     permission_group.set_allows_action(defines.input_action.edit_permission_group, true)
 
     -- Add player to jail group
     permission_group.add_player(target_player)
 
-    -- Kick player out of vehicle
-    target_player.driving = false
+    -- If in vehicle, kick them out and set the speed to 0.
+    local vehicle = target_player.vehicle
+    if vehicle then
+        vehicle.speed = 0
+        target_player.driving = false
+    end
 
     -- If a player is shooting when they're jailed they can't stop shooting, so we change their shooting state
     if target_player.shooting_state.state ~= 0 then
@@ -194,18 +236,49 @@ function Module.jail(target_player, player)
         target_player.walking_state = {walking = false, direction = defines.direction.north}
     end
 
-    -- Check that it worked
+    -- Check they're in jail
     if target_player.permission_group == permission_group then
         -- Let admin know it worked, let target know what's going on.
-        target_player.print(prefix)
-        target_player.print('You have been placed in jail by ' .. jailed_by .. '. The only action avaliable to you is chatting.')
-        target_player.print('Please respond to inquiries from the admins.', Color.yellow)
-        target_player.print(prefix_e)
-        Utils.print_admins(format('%s has been jailed by %s', target_player.name, player.name))
-        Utils.log_command(Utils.get_actor(), 'jail', target_player.name)
+        target_player.clear_console()
+        Popup.player(target_player, 'You have been jailed.\nRespond to queries from the mod team.')
+        Utils.print_admins(format('%s has been jailed by %s', target_name, player.name))
+        Utils.log_command(Utils.get_actor(), 'jail', target_name)
+
+        local character = target_player.character
+        local former_char_dest
+        if character and character.valid then
+            former_char_dest = character.destructible
+            character.destructible = false
+        end
+
+        local former_force_name = target_player.force.name
+        if not game.forces[jail_force] then
+            local force = game.create_force(jail_force)
+            local former_force = target_player.force
+            former_force.set_cease_fire(force, true)
+            former_force.set_friend(force, true)
+        end
+
+        target_player.force = game.forces[jail_force]
+
+        jail_data[target_player.index] = {
+            name = target_name,
+            force = former_force_name,
+            perm_group = former_permission_group,
+            char_dest = former_char_dest,
+            color = target_player.color,
+            chat_color = target_player.chat_color
+        }
+
+        target_player.color = Color.white
+        target_player.chat_color = Color.white
+        if not primitives.on_chat_registered then
+            Event.add_removable(defines.events.on_console_chat, on_chat)
+            primitives.on_chat_registered = true
+        end
     else
         -- Let admin know it didn't work.
-        print(format('Something went wrong in the jailing of %s. You can still change their group via /permissions.',target_player.name))
+        print(format('Something went wrong in the jailing of %s. You can still change their group via /permissions.', target_name))
     end
 end
 
@@ -227,10 +300,12 @@ function Module.unjail(target_player, player)
     end
 
     local target_name = target_player.name
+    local target_index = target_player.index
     local permissions = game.permissions
+    local target_jail_data = jail_data[target_index]
 
     -- Check if the permission group exists, if it doesn't, create it.
-    local permission_group = permissions.get_group(default_group)
+    local permission_group = target_jail_data.perm_group or permissions.get_group(default_group)
     if not permission_group then
         permission_group = permissions.create_group(default_group)
     end
@@ -246,6 +321,16 @@ function Module.unjail(target_player, player)
     -- Set player to a non-shooting state (solves a niche case where players jailed while shooting will be locked into a shooting state)
     target_player.shooting_state.state = 0
 
+    -- Restore player's state from stored data
+    target_player.force = target_jail_data.force
+    local character = target_player.character
+    if character and character.valid then
+        character.destructible = target_jail_data.char_dest
+    end
+    target_player.color = target_jail_data.color
+    target_player.chat_color = target_jail_data.chat_color
+    jail_data[target_index] = nil
+
     -- Check that it worked
     if target_player.permission_group == permission_group then
         -- Let admin know it worked, let target know what's going on.
@@ -253,8 +338,13 @@ function Module.unjail(target_player, player)
         target_player.print(prefix)
         target_player.print('Your ability to perform actions has been restored', Color.green)
         target_player.print(prefix_e)
-        Utils.print_admins(format('%s has been released from jail by %s', target_player.name, player.name))
-        Utils.log_command(Utils.get_actor(), 'unjail', target_player.name)
+        Utils.print_admins(format('%s has been released from jail by %s', target_name, player.name))
+        Utils.log_command(Utils.get_actor(), 'unjail', target_name)
+
+        if primitives.on_chat_registered and #jail_data == 0 then
+            Event.remove_removable(defines.events.on_console_chat, on_chat)
+            primitives.on_chat_registered = nil
+        end
     else
         -- Let admin know it didn't work.
         Game.player_print(format('Something went wrong in the unjailing of %s. You can still change their group via /permissions and inform them.', target_name))

--- a/features/report.lua
+++ b/features/report.lua
@@ -296,7 +296,7 @@ function Module.unjail(target_player, player)
         -- Let admin know it worked, let target know what's going on.
         Game.player_print(target_name .. ' has been returned to the default group. They have been advised of this.')
         target_player.print(prefix)
-        target_player.print('Your ability to perform actions has been restored', Color.green)
+        target_player.print('Your ability to perform actions has been restored', Color.light_green)
         target_player.print(prefix_e)
         Utils.print_admins(format('%s has been released from jail by %s', target_name, player.name))
         Utils.log_command(Utils.get_actor(), 'unjail', target_name)


### PR DESCRIPTION
Move from global to Global

Change jailed players to a jailed force so that they can't spam general chat.

Route jailed players' chat into admin chat, and route an admin speaking in general chat to the jailed force.

Stop any vehicle a griefer was in when they're jailed.

When a player is jailed, clear their chat console so they see only what we want them to see. No distractions from old general chat.

Make players indestructible. No more players killing a griefer when we're trying to collect evidence.

Change their color and chat color to white in order to single them out more and to ensure their chat is legible.

Register/unregister the on_chat hook so that we don't have it listening if we don't need it.

Known shippable:
They can still use `/s` to spam. If anyone ever figures that out then I'll also track their command usage and if they use `/s` X times while jailed, mute them.