### PR TITLE
Add generic entity restriction module

### DIFF
--- a/map_gen/shared/danger_ore_banned_entities.lua
+++ b/map_gen/shared/danger_ore_banned_entities.lua
@@ -22,9 +22,15 @@ RestrictEntities.add_allowed(
 )
 
 --- The logic for checking that there are resources under the entity's position
-RestrictEntities.set_logic(
-    function(surface, area)
-        local count = surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
+RestrictEntities.set_keep_alive_callback(
+    function(entity)
+        -- Some entities have a bounding_box area of zero, eg robots.
+        local area = entity.bounding_box
+        local left_top, right_bottom = area.left_top, area.right_bottom
+        if left_top.x == right_bottom.x and left_top.y == right_bottom.y then
+            return
+        end
+        local count = entity.surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
         if count == 0 then
             return true
         end
@@ -35,7 +41,7 @@ RestrictEntities.set_logic(
 local function on_destroy(event)
     local p = event.player
     if p and p.valid then
-        p.print('You cannot build on top of ores')
+        p.print('You cannot build that on top of ores, only belts, mining drills, and power poles are allowed.')
     end
 end
 

--- a/map_gen/shared/danger_ore_banned_entities.lua
+++ b/map_gen/shared/danger_ore_banned_entities.lua
@@ -28,7 +28,7 @@ RestrictEntities.set_keep_alive_callback(
         local area = entity.bounding_box
         local left_top, right_bottom = area.left_top, area.right_bottom
         if left_top.x == right_bottom.x and left_top.y == right_bottom.y then
-            return
+            return true
         end
         local count = entity.surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
         if count == 0 then

--- a/map_gen/shared/danger_ore_banned_entities.lua
+++ b/map_gen/shared/danger_ore_banned_entities.lua
@@ -1,67 +1,42 @@
+-- This module prevents all but the allowed items from being built on top of resources
+local RestrictEntities = require 'map_gen.shared.entity_placement_restriction'
 local Event = require 'utils.event'
-local Game = require 'utils.game'
 
-global.allowed_entites = {
-    ['transport-belt'] = true,
-    ['fast-transport-belt'] = true,
-    ['express-transport-belt'] = true,
-    ['underground-belt'] = true,
-    ['fast-underground-belt'] = true,
-    ['express-underground-belt'] = true,
-    ['small-electric-pole'] = true,
-    ['medium-electric-pole'] = true,
-    ['big-electric-pole'] = true,
-    ['substation'] = true,
-    ['electric-mining-drill'] = true,
-    ['burner-mining-drill'] = true,
-    ['pumpjack'] = true
-}
+--- Items explicitly allowed on ores
+RestrictEntities.add_allowed(
+    {
+        'transport-belt',
+        'fast-transport-belt',
+        'express-transport-belt',
+        'underground-belt',
+        'fast-underground-belt',
+        'express-underground-belt',
+        'small-electric-pole',
+        'medium-electric-pole',
+        'big-electric-pole',
+        'substation',
+        'electric-mining-drill',
+        'burner-mining-drill',
+        'pumpjack'
+    }
+)
 
-Event.add(
-    defines.events.on_built_entity,
-    function(event)
-        local entity = event.created_entity
-        if not entity or not entity.valid then
-            return
-        end
-
-        local name = entity.name
-
-        if name == 'tile-ghost' then
-            return
-        end
-
-        local ghost = false
-        if name == 'entity-ghost' then
-            name = entity.ghost_name
-            ghost = true
-        end
-
-        if global.allowed_entites[name] then
-            return
-        end
-
-        -- Some entities have a bounding_box area of zero, eg robots.
-        local area = entity.bounding_box
-        local left_top, right_bottom = area.left_top, area.right_bottom
-        if left_top.x == right_bottom.x and left_top.y == right_bottom.y then
-            return
-        end
-
-        local count = entity.surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
-
+--- The logic for checking that there are resources under the entity's position
+RestrictEntities.set_logic(
+    function(surface, area)
+        local count = surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
         if count == 0 then
-            return
-        end
-
-        local p = Game.get_player_by_index(event.player_index)
-        if not p or not p.valid then
-            return
-        end
-
-        entity.destroy()
-        if not ghost then
-            p.insert(event.stack)
+            return true
         end
     end
 )
+
+--- Warning for players when their entities are destroyed
+local function on_destroy(event)
+    local p = event.player
+    if p and p.valid then
+        p.print('You cannot build on top of ores')
+    end
+end
+
+Event.add(RestrictEntities.events.on_restricted_entity_destroyed, on_destroy)

--- a/map_gen/shared/entity_placement_restriction.lua
+++ b/map_gen/shared/entity_placement_restriction.lua
@@ -121,8 +121,7 @@ local on_built_token =
 
         event.ghost = ghost
         event.player = p
-        raise_event(Public.events.on_pre_restricted_entity_destroyed, deep_copy(event)) -- use deepcopy so that any potential writes to `event` aren't passed backwards
-
+        raise_event(Public.events.on_pre_restricted_entity_destroyed, event)
         -- Need to revalidate the entity since we sent it via the event
         if entity.valid then
             entity.destroy()

--- a/map_gen/shared/entity_placement_restriction.lua
+++ b/map_gen/shared/entity_placement_restriction.lua
@@ -1,11 +1,12 @@
 --[[
     Regulates the placement of entities and their ghosts
     Can be called through public function to provide lists of allowed or banned entities.
-    Can also set a keep_alive_callback function to check what is beneath the entity, for example for checking for ores or certain tiles.
+    Can also set a keep_alive_callback function to process information about the entity about to be destroyed
+    for example, checking for resources underneath the entity or checking the pollution in the entity's chunk.
 
-    Example of keep_alive_callback function to check if there are ores beneath:
-    function keep_alive_callback (surface, area)
-        local count = surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
+    Example of keep_alive_callback function to check if there are resources beneath:
+    function keep_alive_callback (entity)
+        local count = entity.surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
         if count == 0 then
             return true
         end

--- a/map_gen/shared/entity_placement_restriction.lua
+++ b/map_gen/shared/entity_placement_restriction.lua
@@ -121,30 +121,17 @@ local on_built_token =
             name = entity.ghost_name
             ghost = true
         end
-        game.print('-----------------------') -- debug
+
         if allowed_entities[name] then
-            Debug.print(string.format('Allowed: %s', allowed_entities[name]))
             return
         end
 
         -- Takes the keep_alive_callback function and runs it with the entity as an argument
         -- If true is returned, we exit. If false, we destroy the entity.
         local keep_alive_callback = primitives.keep_alive_callback
-        Debug.print(string.format('Banned: %s', banned_entities[name]))
-        local result  -- debug
-        if keep_alive_callback then -- debug
-            result = keep_alive_callback(entity) -- debug
-        else -- debug
-            result = 'no function' -- debug
-        end -- debug
-
-        Debug.print(string.format('Function return: %s', result))
         if not banned_entities[name] and keep_alive_callback and keep_alive_callback(entity) then
-            Debug.print('Entity was spared')
             return
         end
-
-        Debug.print('Entity was killed')
 
         local p = Game.get_player_by_index(event.player_index)
         if not p or not p.valid then

--- a/map_gen/shared/entity_placement_restriction.lua
+++ b/map_gen/shared/entity_placement_restriction.lua
@@ -35,6 +35,7 @@ local Public = {
             tick :: uint: Tick the event was generated.
             created_entity :: LuaEntity
             player_index :: uint
+            player :: LuaPlayer
             stack :: LuaItemStack
             ghost :: boolean indicating if the entity was a ghost
         ]]
@@ -123,6 +124,7 @@ local on_built_token =
             event.item_returned = true
         end
         event.ghost = ghost
+        event.player = p
         raise_event(Public.events.on_restricted_entity_destroyed, event)
     end
 )

--- a/map_gen/shared/entity_placement_restriction.lua
+++ b/map_gen/shared/entity_placement_restriction.lua
@@ -1,0 +1,224 @@
+--[[
+    Regulates the placement of entities and their ghosts
+    Can be called through public function to provide lists of allowed or banned entities.
+    Can also set a logic function to check what is beneath the entity, for example for checking for ores or certain tiles.
+
+    Example of logic function to check if there are ores beneath:
+    function logic(surface, area)
+        local count = surface.count_entities_filtered {area = area, type = 'resource', limit = 1}
+        if count == 0 then
+            return true
+        end
+    end
+
+    Allowed entities: are exempt from the logic check and are never destroyed.
+    Banned entities: are always destroyed.
+
+    Maps can hook the on_restricted_entity_destroyed event to generate whatever feedback they deem appropriate
+]]
+local Event = require 'utils.event'
+local Game = require 'utils.game'
+local Global = require 'utils.global'
+local Token = require 'utils.token'
+local table = require 'utils.table'
+
+-- Localized functions
+local raise_event = script.raise_event
+
+local Public = {
+    events = {
+        --[[
+        on_restricted_entity_destroyed
+        Triggered when an entity is destroyed by this script
+        Contains
+            name :: defines.events: Identifier of the event
+            tick :: uint: Tick the event was generated.
+            created_entity :: LuaEntity
+            player_index :: uint
+            stack :: LuaItemStack
+            ghost :: boolean indicating if the entity was a ghost
+        ]]
+        on_restricted_entity_destroyed = script.generate_event_name()
+    }
+}
+
+-- Global-registered locals
+
+local allowed_entites = {}
+local banned_entites = {}
+local primitives = {
+    event = nil,
+    allowed_ents = nil,
+    banned_ents = nil,
+    logic = nil
+}
+
+Global.register(
+    {
+        allowed_entites = allowed_entites,
+        banned_entites = banned_entites,
+        primitives = primitives
+    },
+    function(tbl)
+        allowed_entites = tbl.allowed_entites
+        banned_entites = tbl.banned_entites
+        primitives = tbl.primitives
+    end
+)
+
+-- Local functions
+
+--- Token for on_built callback, checks if an entity should be destroyed.
+local on_built_token =
+    Token.register(
+    function(event)
+        local entity = event.created_entity
+        if not entity or not entity.valid then
+            return
+        end
+
+        local name = entity.name
+        if name == 'tile-ghost' then
+            return
+        end
+
+        local ghost = false
+        if name == 'entity-ghost' then
+            name = entity.ghost_name
+            ghost = true
+        end
+
+        if primitives.allowed_ents and allowed_entites[name] then
+            return
+        end
+
+        -- Some entities have a bounding_box area of zero, eg robots.
+        local area = entity.bounding_box
+        local left_top, right_bottom = area.left_top, area.right_bottom
+        if left_top.x == right_bottom.x and left_top.y == right_bottom.y then
+            return
+        end
+
+        -- Takes the logic function (if provided) and runs it with the surface and area as arguments
+        -- this allows the logic function to scan underneath the entity. if true is returned, we exit.
+        -- If false, we destroy the entity and return it
+        local logic = primitives.logic
+        if logic and logic(entity.surface, area) then
+            return
+        end
+
+        if primitives.banned_ents and not banned_entites[name] and not primitives.allowed_ents then
+            return
+        end
+
+        local p = Game.get_player_by_index(event.player_index)
+        if not p or not p.valid then
+            return
+        end
+
+        entity.destroy()
+        event.item_returned = false
+        if not ghost then
+            p.insert(event.stack)
+            event.item_returned = true
+        end
+        event.ghost = ghost
+        raise_event(Public.events.on_restricted_entity_destroyed, event)
+    end
+)
+
+--- Adds the event hook for on_built_entity
+local function add_event()
+    if not primitives.event then
+        Event.add_removable(defines.events.on_built_entity, on_built_token)
+        primitives.event = true
+    end
+end
+
+--- Removes the event hook for on_built_entity
+local function remove_event()
+    if primitives.event then
+        Event.remove_removable(defines.events.on_built_entity, on_built_token)
+        primitives.event = nil
+    end
+end
+
+-- Public functions
+
+--- Sets the function to be used for logic
+-- @param logic <function>
+function Public.set_logic(logic)
+    primitives.logic = logic
+end
+
+--- Adds to the list of allowed entities
+-- @param ents <table> array of entity strings
+function Public.add_allowed(ents)
+    primitives.allowed_ents = true
+    for _, v in pairs(ents) do
+        allowed_entites[v] = true
+    end
+    if not primitives.event then
+        add_event()
+    end
+end
+
+--- Removes from the list of allowed entities
+-- @param ents <table> array of entity strings
+function Public.remove_allowed(ents)
+    for _, v in pairs(ents) do
+        allowed_entites[v] = true
+    end
+    if table.size(allowed_entites) == 0 then
+        primitives.allowed_ents = nil
+        if primitives.event and not primitives.banned_ents then
+            remove_event()
+        end
+    end
+end
+
+--- Resets the list of banned entities
+function Public.reset_allowed()
+    table.clear_table(allowed_entites)
+    primitives.allowed_ents = nil
+    if primitives.event and not primitives.banned_ents then
+        remove_event()
+    end
+end
+
+--- Adds to the list of banned entities
+-- @param ents <table> array of entity strings
+function Public.add_banned(ents)
+    primitives.banned_ents = true
+    for _, v in pairs(ents) do
+        banned_entites[v] = true
+    end
+    if not primitives.event then
+        add_event()
+    end
+end
+
+--- Removes from the list of banned entities
+-- @param ents <table> array of entity strings
+function Public.remove_banned(ents)
+    for _, v in pairs(ents) do
+        banned_entites[v] = true
+    end
+    if table.size(banned_entites) == 0 then
+        primitives.banned_ents = nil
+        if primitives.event and not primitives.allowed_ents then
+            remove_event()
+        end
+    end
+end
+
+--- Resets the list of banned entities
+function Public.reset_banned()
+    primitives.banned_ents = nil
+    table.clear_table(banned_entites)
+    if primitives.event and not primitives.allowed_ents then
+        remove_event()
+    end
+end
+
+return Public

--- a/utils/table.lua
+++ b/utils/table.lua
@@ -226,6 +226,7 @@ table.inspect = require 'utils.inspect'
 table.size = table_size
 
 --- Creates a deepcopy of a table. Metatables and LuaObjects inside the table are shallow copies.
+-- Shallow copies meaning it copies the reference to the object instead of the object itself.
 -- @param object <table> the object to copy
 -- @return <table> the copied object
 table.deep_copy = table.deepcopy


### PR DESCRIPTION
**Hey!**
A lot of this module got overhauled and fixed up. This comment is completely rewritten as well.

Shameless copy-paste of the in-code doc:

This module restricts the placement of entities and ghosts based on an allowed and banned list,
as well as by the (optionally) provided function.

The table of allowed_entities are *always* allowed to be placed.
The table of banned_entities are *never* allowed to be placed, and are destroyed.

For anything not in either of those lists, you can use the set_keep_alive_callback function to set a keep_alive_callback function.
This means you can use any custom logic you want to determine whether an entity should be destroyed or not.
The callback function is supplied a valid LuaEntity as an argument.
A return of true indicates the entity should be kept alive, while false or nil indicate it should be destroyed.

Refunds for items that were placed can be toggled on or off via the enable and disable_refund functions

Lastly, this module raises 2 events: on_pre_restricted_entity_destroyed and on_restricted_entity_destroyed events.
They are fully defined below.
```
Examples (only the first example will include the require):
-- A map which allows no roboports:
local RestrictEntities = require 'map_gen.shared.entity_placement_restriction'
RestrictEntities.add_banned({'roboport'})

-- A map which allows only belts (for a foot race map, of course)
-- The function provided does nothing but return nil
-- every entity will be destroyed except those on the allowed list
RestrictEntities.add_allowed({'transport-belt'})
RestrictEntities.set_keep_alive_callback(function() end)

-- Danger ores (a lot of important code omitted for the sake of a brief example)
RestrictEntities.add_allowed({belts, power_poles, mining_drills, 'pumpjack'})
RestrictEntities.set_keep_alive_callback(
    function(entity)
        if entity.surface.count_entities_filtered {area = entity.bounding_box, type = 'resource', limit = 1} == 0 then
            return true
        end
    end
)
```

-----

In-module debug is included in commit: https://github.com/Refactorio/RedMew/pull/723/commits/d6e37cdba72a98eefaa37a00cb825982c3da6831

I'm not sure where to put `danger_ore_banned_entities.lua` now.. Do I just whip up a wiki page for this module and drop the contents of banned ores into it? Do we add the code to the modules that traditionally use danger ore?

I can't figure out why nothing actually requires `danger_ore_banned_entities`. -_-

Closes https://github.com/Refactorio/RedMew/pull/722