### PR TITLE
Market tracking

### DIFF
--- a/features/admin_commands.lua
+++ b/features/admin_commands.lua
@@ -331,6 +331,16 @@ local function revive_ghosts(args, player)
     end
 end
 
+local function destroy(_, player)
+    local ent = player.selected
+    if ent then
+        Game.player_print(ent.name .. ' destroyed')
+        ent.destroy()
+    else
+        Game.player_print('Nothing found to destroy.')
+    end
+end
+
 -- Event registrations
 
 Event.add(defines.events.on_built_entity, built_entity)
@@ -498,4 +508,13 @@ Command.add(
         required_rank = Ranks.admin,
     },
     Apocalypse.begin_apocalypse
+)
+
+Command.add(
+    'destroy',
+    {
+        description = 'Destroys the entity under your cursor',
+        admin_only = true
+    },
+    destroy
 )

--- a/features/admin_commands.lua
+++ b/features/admin_commands.lua
@@ -514,7 +514,7 @@ Command.add(
     'destroy',
     {
         description = 'Destroys the entity under your cursor',
-        admin_only = true
+        required_rank = Ranks.admin
     },
     destroy
 )

--- a/features/admin_commands.lua
+++ b/features/admin_commands.lua
@@ -331,13 +331,14 @@ local function revive_ghosts(args, player)
     end
 end
 
-local function destroy(_, player)
+--- Destroys the player's selected entity
+local function destroy_selected(_, player)
     local ent = player.selected
     if ent then
         Game.player_print(ent.name .. ' destroyed')
         ent.destroy()
     else
-        Game.player_print('Nothing found to destroy.')
+        Game.player_print('Nothing found to destroy. (You must have an entity under your cursor when you hit enter)')
     end
 end
 
@@ -513,8 +514,8 @@ Command.add(
 Command.add(
     'destroy',
     {
-        description = 'Destroys the entity under your cursor',
+        description = 'Destroys the entity under your cursor when you run this command',
         required_rank = Ranks.admin
     },
-    destroy
+    destroy_selected
 )

--- a/features/market.lua
+++ b/features/market.lua
@@ -25,14 +25,14 @@ local running_speed_boost_messages = {
     '%s found the lost Dragon Scroll and got a lv.1 speed boost!',
     'Guided by Master Oogway, %s got a lv.2 speed boost!',
     'Kung Fu Master %s defended the village and was awarded a lv.3 speed boost!',
-    'Travelled at the speed of light. %s saw a black hole. Oops.',
+    'Travelled at the speed of light. %s saw a black hole. Oops.'
 }
 
 local mining_speed_boost_messages = {
     '%s is going on a tree harvest!',
     'In search of a sharper axe, %s got a lv.2 mining boost!',
     'Wood fiend, %s, has picked up a massive chain saw and is awarded a lv.3 mining boost!',
-    'Better learn to control that saw, %s, chopped off their legs. Oops.',
+    'Better learn to control that saw, %s, chopped off their legs. Oops.'
 }
 
 -- Global registered local vars
@@ -118,9 +118,12 @@ local function pre_player_mined_item(event)
     end
 end
 
-local spill_items = Token.register(function(data)
-    data.surface.spill_item_stack(data.position, {name = currency, count = data.count}, true)
-end)
+local spill_items =
+    Token.register(
+    function(data)
+        data.surface.spill_item_stack(data.position, {name = currency, count = data.count}, true)
+    end
+)
 
 -- Determines how many coins to drop when enemy entity dies based upon the entity_drop_amount table in config.lua
 local function fish_drop_entity_died(event)
@@ -134,7 +137,6 @@ local function fish_drop_entity_died(event)
         return
     end
 
-
     local chance = bounds.chance
 
     if chance == 0 then
@@ -144,8 +146,15 @@ local function fish_drop_entity_died(event)
     if chance == 1 or random() <= chance then
         local count = random(bounds.low, bounds.high)
         if count > 0 then
-            Task.set_timeout_in_ticks(1, spill_items, {count = count, surface = entity.surface, position = entity.position}
-        )
+            Task.set_timeout_in_ticks(
+                1,
+                spill_items,
+                {
+                    count = count,
+                    surface = entity.surface,
+                    position = entity.position
+                }
+            )
         end
     end
 end
@@ -164,11 +173,10 @@ local function boost_player_running_speed(player)
         global.player_speed_boost_records[player.index] = {
             start_tick = game.tick,
             pre_boost_modifier = player.character_running_speed_modifier,
-            boost_lvl = 0,
+            boost_lvl = 0
         }
     end
-    global.player_speed_boost_records[player.index].boost_lvl =
-        1 + global.player_speed_boost_records[player.index].boost_lvl
+    global.player_speed_boost_records[player.index].boost_lvl = 1 + global.player_speed_boost_records[player.index].boost_lvl
 
     player.character_running_speed_modifier = 1 + player.character_running_speed_modifier
 
@@ -196,11 +204,10 @@ local function boost_player_mining_speed(player)
         global.player_mining_boost_records[player.index] = {
             start_tick = game.tick,
             pre_mining_boost_modifier = player.character_mining_speed_modifier,
-            boost_lvl = 0,
+            boost_lvl = 0
         }
     end
-    global.player_mining_boost_records[player.index].boost_lvl =
-        1 + global.player_mining_boost_records[player.index].boost_lvl
+    global.player_mining_boost_records[player.index].boost_lvl = 1 + global.player_mining_boost_records[player.index].boost_lvl
 
     if global.player_mining_boost_records[player.index].boost_lvl >= 4 then
         game.print(format(mining_speed_boost_messages[global.player_mining_boost_records[player.index].boost_lvl], player.name))

--- a/features/market.lua
+++ b/features/market.lua
@@ -280,7 +280,7 @@ Command.add(
         description = 'Places a market near you. Use /market removeall to remove all markets on a map',
         arguments = {'removeall'},
         default_values = {removeall = false},
-        required_rank = Ranks.admin,
+        required_rank = Ranks.admin
     },
     spawn_market
 )

--- a/features/market.lua
+++ b/features/market.lua
@@ -166,59 +166,61 @@ local function fish_drop_entity_died(event)
 end
 
 local function reset_player_running_speed(player)
-    local p_name = player.name
-    player.character_running_speed_modifier = speed_records[p_name].pre_boost_modifier
-    speed_records[p_name] = nil
+    local index = player.index
+    player.character_running_speed_modifier = speed_records[index].pre_boost_modifier
+    speed_records[index] = nil
 end
 
 local function reset_player_mining_speed(player)
-    local p_name = player.name
-    player.character_mining_speed_modifier = mining_records[p_name].pre_mining_boost_modifier
-    mining_records[p_name] = nil
+    local index = player.index
+    player.character_mining_speed_modifier = mining_records[index].pre_mining_boost_modifier
+    mining_records[index] = nil
 end
 
 local function boost_player_running_speed(player)
+    local index = player.index
     local p_name = player.name
-    if not speed_records[p_name] then
-        speed_records[p_name] = {
+    if not speed_records[index] then
+        speed_records[index] = {
             start_tick = game.tick,
             pre_boost_modifier = player.character_running_speed_modifier,
             boost_lvl = 0
         }
     end
-    speed_records[p_name].boost_lvl = 1 + speed_records[p_name].boost_lvl
+    speed_records[index].boost_lvl = 1 + speed_records[index].boost_lvl
 
     player.character_running_speed_modifier = 1 + player.character_running_speed_modifier
 
-    if speed_records[p_name].boost_lvl >= 4 then
-        game.print(format(running_speed_boost_messages[speed_records[p_name].boost_lvl], p_name))
+    if speed_records[index].boost_lvl >= 4 then
+        game.print(format(running_speed_boost_messages[speed_records[index].boost_lvl], p_name))
         reset_player_running_speed(player)
         player.character.die(player.force, player.character)
         return
     end
 
-    player.print(format(running_speed_boost_messages[speed_records[p_name].boost_lvl], p_name))
+    player.print(format(running_speed_boost_messages[speed_records[index].boost_lvl], p_name))
 end
 
 local function boost_player_mining_speed(player)
+    local index = player.index
     local p_name = player.name
-    if not mining_records[p_name] then
-        mining_records[p_name] = {
+    if not mining_records[index] then
+        mining_records[index] = {
             start_tick = game.tick,
             pre_mining_boost_modifier = player.character_mining_speed_modifier,
             boost_lvl = 0
         }
     end
-    mining_records[p_name].boost_lvl = 1 + mining_records[p_name].boost_lvl
+    mining_records[index].boost_lvl = 1 + mining_records[index].boost_lvl
 
-    if mining_records[p_name].boost_lvl >= 4 then
-        game.print(format(mining_speed_boost_messages[mining_records[p_name].boost_lvl], p_name))
+    if mining_records[index].boost_lvl >= 4 then
+        game.print(format(mining_speed_boost_messages[mining_records[index].boost_lvl], p_name))
         reset_player_mining_speed(player)
         player.character.die(player.force, player.character)
         return
     end
 
-    player.print(format(mining_speed_boost_messages[mining_records[p_name].boost_lvl], p_name))
+    player.print(format(mining_speed_boost_messages[mining_records[index].boost_lvl], p_name))
 end
 
 local function market_item_purchased(event)
@@ -238,7 +240,7 @@ local function on_nth_tick()
     local tick = game.tick
     for k, v in pairs(speed_records) do
         if tick - v.start_tick > 3000 then
-            local player = game.players[k]
+            local player = Game.get_player_by_index(k)
             if player and player.valid and player.connected and player.character then
                 reset_player_running_speed(player)
             end
@@ -247,7 +249,7 @@ local function on_nth_tick()
 
     for k, v in pairs(mining_records) do
         if tick - v.start_tick > 6000 then
-            local player = game.players[k]
+            local player = Game.get_player_by_index(k)
             if player and player.valid and player.connected and player.character then
                 reset_player_mining_speed(player)
             end


### PR DESCRIPTION
Adds a command to wipe all markets created via the `/market` command.
^^ I finally got around to it @Jayefuu. It's not *exactly* what you wanted, but it's not terrible either.
Adds a `/destroy` command which is essentially just an alias to `game.player.selected.destroy()`
Pushes market buffs from global into Global 
Tidies up market.lua

It's amazing how much space you save reading a file when:

`global.player_speed_boost_records[player.index]`  
becomes  
`speed_records[p_name]`

Requires  #713