### PR TITLE
Pling for toast

### DIFF
--- a/features/admin_commands.lua
+++ b/features/admin_commands.lua
@@ -8,6 +8,7 @@ local Event = require 'utils.event'
 local Command = require 'utils.command'
 
 local format = string.format
+local loadstring = loadstring
 
 --- A table of players with tpmode turned on
 global.tp_players = {}
@@ -29,12 +30,21 @@ local function silent_command(args, player)
     local func, err = loadstring(args.str)
     if not func then
         p(err)
+        return
     end
 
     local _, err2 = pcall(func)
     if err2 then
         local i = err2:find('\n')
-        p(err2:sub(1, i))
+        if i then
+            p(err2:sub(1, i))
+            return
+        end
+
+        i = err2:find('%s')
+        if i then
+            p(err2:sub(i + 1))
+        end
     end
 end
 

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -2,7 +2,7 @@ local Event = require 'utils.event'
 local Global = require 'utils.global'
 local Gui = require 'utils.gui'
 local Token = require 'utils.token'
-local Settings = require 'utils.settings'
+local Settings = require 'utils.redmew_settings'
 local Color = require 'resources.color_presets'
 
 local pairs = pairs

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -2,10 +2,14 @@ local Event = require 'utils.event'
 local Global = require 'utils.global'
 local Gui = require 'utils.gui'
 local Token = require 'utils.token'
+local Settings = require 'utils.settings'
 local Color = require 'resources.color_presets'
 
 local pairs = pairs
 local next = next
+
+local toast_volume_name = 'toast-volume'
+Settings.register(toast_volume_name, 'fraction', 1.0)
 
 local Public = {}
 
@@ -111,7 +115,7 @@ local function toast_to(player, duration, sound)
     active_toasts[id] = frame_holder
 
     if sound then
-        player.play_sound({path = sound, volume_modifier = 1})
+        player.play_sound({path = sound, volume_modifier = Settings.get(player.index, toast_volume_name)})
     end
 
     return container

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -70,7 +70,8 @@ end
 ---Toast to a specific player
 ---@param player LuaPlayer
 ---@param duration number in seconds
-local function toast_to(player, duration)
+---@param sound string sound to play, nil to not play anything
+local function toast_to(player, duration, sound)
     local frame_holder = player.gui.left.add({type = 'flow'})
 
     local frame =
@@ -108,6 +109,10 @@ local function toast_to(player, duration)
     end
 
     active_toasts[id] = frame_holder
+
+    if sound then
+        player.play_sound({path = sound, volume_modifier = 1})
+    end
 
     return container
 end
@@ -162,8 +167,10 @@ on_tick =
 ---@param player LuaPlayer
 ---@param duration table
 ---@param template function
-function Public.toast_player_template(player, duration, template)
-    local container = toast_to(player, duration)
+---@param sound string sound to play, nil to not play anything
+function Public.toast_player_template(player, duration, template, sound)
+    sound = sound or 'utility/new_objective'
+    local container = toast_to(player, duration, sound)
     if container then
         template(container, player)
     end
@@ -174,11 +181,13 @@ end
 ---@param force LuaForce
 ---@param duration number
 ---@param template function
-function Public.toast_force_template(force, duration, template)
+---@param sound string sound to play, nil to not play anything
+function Public.toast_force_template(force, duration, template, sound)
+    sound = sound or 'utility/new_objective'
     local players = force.connected_players
     for i = 1, #players do
         local player = players[i]
-        template(toast_to(player, duration), player)
+        template(toast_to(player, duration, sound), player)
     end
 end
 
@@ -186,11 +195,13 @@ end
 ---to add contents to and a player as second argument.
 ---@param duration number
 ---@param template function
-function Public.toast_all_players_template(duration, template)
+---@param sound string sound to play, nil to not play anything
+function Public.toast_all_players_template(duration, template, sound)
+    sound = sound or 'utility/new_objective'
     local players = game.connected_players
     for i = 1, #players do
         local player = players[i]
-        template(toast_to(player, duration), player)
+        template(toast_to(player, duration, sound), player)
     end
 end
 

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -1,6 +1,7 @@
 local Game = require 'utils.game'
 local Timestamp = require 'utils.timestamp'
 local Command = require 'utils.command'
+local Settings = require 'utils.settings'
 local Utils = require 'utils.core'
 local Report = require 'features.report'
 local Server = require 'features.server'
@@ -11,6 +12,10 @@ local PlayerStats = require 'features.player_stats'
 local format = string.format
 local ceil = math.ceil
 local concat = table.concat
+local pcall = pcall
+local tostring = tostring
+local tonumber = tonumber
+local pairs = pairs
 
 --- Kill a player with fish as the cause of death.
 local function do_fish_kill(player, suicide)
@@ -380,3 +385,40 @@ Command.add(
     },
     UserGroups.print_regulars
 )
+
+Command.add('setting-set', {
+    description = 'Set a setting for yourself',
+    arguments = {'setting_name', 'new_value'},
+    capture_excess_arguments = true,
+}, function (arguments, player)
+    local value
+    local setting_name = arguments.setting_name
+    local success, message = pcall(function()
+        value = Settings.set(player.index, setting_name, arguments.new_value)
+    end)
+
+    if not success then
+        player.print(message)
+        return
+    end
+
+    player.print(format('Changed "%s" to: "%s"', setting_name, value))
+end)
+
+Command.add('setting-get', {
+    description = 'Display a setting value for yourself',
+    arguments = {'setting_name'},
+}, function (arguments, player)
+    local value
+    local setting_name = arguments.setting_name
+    local success, message = pcall(function()
+        value = Settings.get(player.index, setting_name)
+    end)
+
+    if not success then
+        player.print(message)
+        return
+    end
+
+    player.print(format('Setting "%s" has a value of: "%s"', setting_name, value))
+end)

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -1,13 +1,13 @@
 local Game = require 'utils.game'
 local Timestamp = require 'utils.timestamp'
 local Command = require 'utils.command'
-local Settings = require 'utils.settings'
 local Utils = require 'utils.core'
 local Report = require 'features.report'
 local Server = require 'features.server'
 local UserGroups = require 'features.user_groups'
 local Walkabout = require 'features.walkabout'
 local PlayerStats = require 'features.player_stats'
+local Settings = require 'utils.redmew_settings'
 
 local format = string.format
 local ceil = math.ceil
@@ -386,44 +386,44 @@ Command.add(
     UserGroups.print_regulars
 )
 
-Command.add('setting-set', {
+Command.add('redmew-setting-set', {
     description = 'Set a setting for yourself',
     arguments = {'setting_name', 'new_value'},
     capture_excess_arguments = true,
 }, function (arguments, player)
     local value
     local setting_name = arguments.setting_name
-    local success, message = pcall(function()
+    local success, data = pcall(function()
         value = Settings.set(player.index, setting_name, arguments.new_value)
     end)
 
     if not success then
-        player.print(message)
+        player.print(data.message)
         return
     end
 
     player.print(format('Changed "%s" to: "%s"', setting_name, value))
 end)
 
-Command.add('setting-get', {
+Command.add('redmew-setting-get', {
     description = 'Display a setting value for yourself',
     arguments = {'setting_name'},
 }, function (arguments, player)
     local value
     local setting_name = arguments.setting_name
-    local success, message = pcall(function()
+    local success, data = pcall(function()
         value = Settings.get(player.index, setting_name)
     end)
 
     if not success then
-        player.print(message)
+        player.print(data.message)
         return
     end
 
     player.print(format('Setting "%s" has a value of: "%s"', setting_name, value))
 end)
 
-Command.add('setting-all', {
+Command.add('redmew-setting-all', {
     description = 'Display all settings for yourself',
 }, function (_, player)
     for name, value in pairs(Settings.all(player.index)) do

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -422,3 +422,11 @@ Command.add('setting-get', {
 
     player.print(format('Setting "%s" has a value of: "%s"', setting_name, value))
 end)
+
+Command.add('setting-all', {
+    description = 'Display all settings for yourself',
+}, function (_, player)
+    for name, value in pairs(Settings.all(player.index)) do
+        player.print(format('%s=%s', name, value))
+    end
+end)

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -398,7 +398,8 @@ Command.add('redmew-setting-set', {
     end)
 
     if not success then
-        player.print(data.message)
+        local i = data:find('%s')
+        player.print(data:sub(i + 1))
         return
     end
 
@@ -416,7 +417,8 @@ Command.add('redmew-setting-get', {
     end)
 
     if not success then
-        player.print(data.message)
+        local i = data:find('%s')
+        player.print(data:sub(i + 1))
         return
     end
 

--- a/map_gen/maps/diggy/feature/experience.lua
+++ b/map_gen/maps/diggy/feature/experience.lua
@@ -2,6 +2,7 @@
 local Event = require 'utils.event'
 local Game = require 'utils.game'
 local Global = require 'utils.global'
+local Toast = require 'features.gui.toast'
 local ForceControl = require 'features.force_control'
 local ScoreTable = require 'map_gen.maps.diggy.score_table'
 local Retailer = require 'features.retailer'
@@ -530,8 +531,7 @@ function Experience.register(cfg)
 
     --Adds a function that'll be executed at every level up
     ForceControlBuilder.register_on_every_level(function (level_reached, force)
-        force.print(format('%s Leveled up to %d!', '## - ', level_reached))
-        force.play_sound{path='utility/new_objective', volume_modifier = 1 }
+        Toast.toast_force(force, 10 , format('Your team has reached level %d!', level_reached))
         Experience.update_inventory_slots(force, level_reached)
         Experience.update_mining_speed(force, level_reached)
         Experience.update_health_bonus(force, level_reached)

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -74,6 +74,8 @@ Global.register(memory, function (tbl) memory = tbl end)
 
 local Public = {}
 
+Public.types = {fraction = 'fraction', string = 'string', boolean = 'boolean'}
+
 ---Register a specific setting with a sensitization setting type.
 ---
 --- Available setting types:
@@ -81,23 +83,23 @@ local Public = {}
 --- - string a string or anything that can be cast to a string
 --- - boolean, 1, 0, yes, no, true, false or an empty string for false
 ---
---- This function can only be called before the game is initialized.
+--- This function must be called in the control stage, i.e. not inside an event.
 ---
 ---@param name string
 ---@param setting_type string
 ---@param default mixed
 function Public.register(name, setting_type, default)
     if game then
-        error(format('You can only register setting names before the game is initialized. Tried setting "%s" with type "%s".', name, setting_type))
+        error(format('You can only register setting names in the control stage, i.e. not inside events. Tried setting "%s" with type "%s".', name, setting_type), 2)
     end
 
     if settings[name] then
-        error(format('Trying to register setting for "%s" while it has already been registered.', name))
+        error(format('Trying to register setting for "%s" while it has already been registered.', name), 2)
     end
 
     local callback = settings_type[setting_type]
     if not callback then
-        error(format('Trying to register setting for "%s" with type "%s" while this type does not exist.', name, setting_type))
+        error(format('Trying to register setting for "%s" with type "%s" while this type does not exist.', name, setting_type), 2)
     end
 
     local setting = {
@@ -120,13 +122,13 @@ end
 function Public.set(player_index, name, value)
     local setting = settings[name]
     if not setting then
-        return error({message = format('Setting "%s" does not exist.', name)})
+        return error(format('Setting "%s" does not exist.', name), 2)
     end
 
     local success, sanitized_value = setting.callback(value)
 
     if not success then
-        error({message = format('Setting "%s" failed: %s', name, sanitized_value)})
+        error(format('Setting "%s" failed: %s', name, sanitized_value), 2)
     end
 
     local player_settings = memory[player_index]
@@ -149,7 +151,7 @@ end
 function Public.get(player_index, name)
     local setting = settings[name]
     if not setting then
-        return error({message = format('Setting "%s" does not exist.', name)})
+        return error(format('Setting "%s" does not exist.', name), 2)
     end
 
     local player_settings = memory[player_index]

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -120,13 +120,13 @@ end
 function Public.set(player_index, name, value)
     local setting = settings[name]
     if not setting then
-        return error(format('Setting "%s" does not exist.', name))
+        return error({message = format('Setting "%s" does not exist.', name)})
     end
 
     local success, sanitized_value = setting.callback(value)
 
     if not success then
-        error(format('set("%s") failed: %s', name, sanitized_value))
+        error({message = format('Setting "%s" failed: %s', name, sanitized_value)})
     end
 
     local player_settings = memory[player_index]
@@ -149,7 +149,7 @@ end
 function Public.get(player_index, name)
     local setting = settings[name]
     if not setting then
-        return error(format('Setting "%s" does not exist.', name))
+        return error({message = format('Setting "%s" does not exist.', name)})
     end
 
     local player_settings = memory[player_index]

--- a/utils/settings.lua
+++ b/utils/settings.lua
@@ -3,6 +3,7 @@ local type = type
 local error = error
 local tonumber = tonumber
 local tostring = tostring
+local pairs = pairs
 local format = string.format
 
 --- Contains a set of callables that will attempt to sanitize and transform the input
@@ -158,6 +159,18 @@ function Public.get(player_index, name)
 
     local player_setting = player_settings[name]
     return player_setting ~= nil and player_setting or setting.default
+end
+
+---Returns a table of all settings for a given player in a key => value setup
+---@param player_index number
+function Public.all(player_index)
+    local player_settings = memory[player_index] or {}
+    local output = {}
+    for name, data in pairs(settings) do
+        output[name] = player_settings[name] or data.default
+    end
+
+    return output
 end
 
 return Public

--- a/utils/settings.lua
+++ b/utils/settings.lua
@@ -1,0 +1,163 @@
+local Global = require 'utils.global'
+local type = type
+local error = error
+local tonumber = tonumber
+local tostring = tostring
+local format = string.format
+
+--- Contains a set of callables that will attempt to sanitize and transform the input
+local settings_type = {
+    fraction = function (input)
+        input = tonumber(input)
+
+        if input == nil then
+            return false, 'fraction setting type requires the input to be a valid number between 0 and 1.'
+        end
+
+        if input < 0 then
+            input = 0
+        end
+
+        if input > 1 then
+            input = 1
+        end
+
+        return true, input
+    end,
+    string = function (input)
+        if input == nil then
+            return true, ''
+        end
+
+        local input_type = type(input)
+        if input_type == 'string' then
+            return true, input
+        end
+
+        if input_type == 'number' or input_type == 'boolean' then
+            return true, tostring(input)
+        end
+
+        return false, 'string setting type requires the input to be either a valid string or something that can be converted to a string.'
+    end,
+    boolean = function (input)
+        local input_type = type(input)
+
+        if input_type == 'boolean' then
+            return true, input
+        end
+
+        if input_type == 'string' then
+            if input == '0' or input == '' or input == 'false' or input == 'no' then
+                return true, false
+            end
+            if input == '1' or input == 'true' or input == 'yes' then
+                return true, true
+            end
+
+            return true, tonumber(input) ~= nil
+        end
+
+        if input_type == 'number' then
+            return true, input ~= 0
+        end
+
+        return false, 'boolean setting type requires the input to be either a boolean, number or string that can be transformed to a boolean.'
+    end,
+}
+
+local settings = {}
+local memory = {}
+
+Global.register(memory, function (tbl) memory = tbl end)
+
+local Public = {}
+
+---Register a specific setting with a sensitization setting type.
+---
+--- Available setting types:
+--- - fraction (number between 0 and 1) in either number or string form
+--- - string a string or anything that can be cast to a string
+--- - boolean, 1, 0, yes, no, true, false or an empty string for false
+---
+--- This function can only be called before the game is initialized.
+---
+---@param name string
+---@param setting_type string
+---@param default mixed
+function Public.register(name, setting_type, default)
+    if game then
+        error(format('You can only register setting names before the game is initialized. Tried setting "%s" with type "%s".', name, setting_type))
+    end
+
+    if settings[name] then
+        error(format('Trying to register setting for "%s" while it has already been registered.', name))
+    end
+
+    local callback = settings_type[setting_type]
+    if not callback then
+        error(format('Trying to register setting for "%s" with type "%s" while this type does not exist.', name, setting_type))
+    end
+
+    local setting = {
+        default = default,
+        callback = callback,
+    }
+
+    settings[name] = setting
+
+    return setting
+end
+
+---Sets a setting to a specific value for a player.
+---
+---In order to get a setting value, it has to be registered via the "register" function.
+---
+---@param player_index number
+---@param name string
+---@param value mixed
+function Public.set(player_index, name, value)
+    local setting = settings[name]
+    if not setting then
+        return error(format('Setting "%s" does not exist.', name))
+    end
+
+    local success, sanitized_value = setting.callback(value)
+
+    if not success then
+        error(format('set("%s") failed: %s', name, sanitized_value))
+    end
+
+    local player_settings = memory[player_index]
+    if not player_settings then
+        player_settings = {}
+        memory[player_index] = player_settings
+    end
+
+    player_settings[name] = sanitized_value
+
+    return sanitized_value
+end
+
+---Returns the value of a setting for this player.
+---
+---In order to set a setting value, it has to be registered via the "register" function.
+---
+---@param player_index number
+---@param name string
+function Public.get(player_index, name)
+    local setting = settings[name]
+    if not setting then
+        return error(format('Setting "%s" does not exist.', name))
+    end
+
+    local player_settings = memory[player_index]
+    if not player_settings then
+        return setting.default
+    end
+
+    local player_setting = player_settings[name]
+    return player_setting ~= nil and player_setting or setting.default
+end
+
+return Public


### PR DESCRIPTION
Adds the following features:
 - Game persistent setting storage
 - A sound notification for toast messages

To change the volume of the toast messages, a new command can be used:
```
/redmew-setting-set toast-volume 0.5
```

To show the current volume:
```
/redmew-setting-get toast-volume
```

To show all available settings:
```
/redmew-setting-all
```

To make use of the new Settings system
```lua
local Settings = require 'utils.redmew_settings'
local toast_volume_name = 'toast-volume'
Settings.register(toast_volume_name, 'fraction', 1.0)

-- somewhere when the game is running
player.play_sound({
    path = 'some-sound', 
    volume_modifier = Settings.get(player.index, toast_volume_name)
})
```

In the future this can be enhanced by syncing the settings from and to the server, and making it possible top change them via a gui for example.

![image](https://user-images.githubusercontent.com/1754678/52165821-f9c0e980-2705-11e9-99a3-c2454ee46985.png)
![image](https://user-images.githubusercontent.com/1754678/52165823-ffb6ca80-2705-11e9-9364-cdf8a000ec0b.png)
![image](https://user-images.githubusercontent.com/1754678/52165992-152cf400-2708-11e9-8066-fe91ef4a9d54.png)

