### PR TITLE
Check if the cause is valid and has a force for hydra spawns

### DIFF
--- a/map_gen/shared/hail_hydra.lua
+++ b/map_gen/shared/hail_hydra.lua
@@ -72,7 +72,7 @@ Event.add(defines.events.on_entity_died, function (event)
             local spawned = create_entity({name = hydra_spawn, force = force, position = position})
             if spawned and spawned.type == 'unit' then
                 spawned.set_command(command)
-            elseif spawned and cause then
+            elseif spawned and cause and cause.valid and cause.force then
                 spawned.shooting_target = cause
             end
         end


### PR DESCRIPTION
```
17263.076 Script @/factorio/3/temp/currently-playing/utils/event_core.lua:25: Target must be entity with force.
stack traceback:
/factorio/3/temp/currently-playing/features/hail_hydra.lua:76: in function </factorio/3/temp/currently-playing/features/hail_hydra.lua:29>
[C]: in function 'pcall'
/factorio/3/temp/currently-playing/utils/event_core.lua:23: in function 'call_handlers'
/factorio/3/temp/currently-playing/utils/event_core.lua:33: in function </factorio/3/temp/currently-playing/utils/event_core.lua:31>
```
Hopefully this is enough to fix it as I don't know what caused this error.