### PR TITLE
Chunklist: Create new table instead of writing to and passing the old event table

### DIFF
--- a/map_gen/shared/chunklist.lua
+++ b/map_gen/shared/chunklist.lua
@@ -7,11 +7,9 @@
 local Global = require 'utils.global'
 local RS = require 'map_gen.shared.redmew_surface'
 local Event = require 'utils.event'
-local table = require 'utils.table'
 
 -- Localized functions
 local raise_event = script.raise_event
-local deep_copy = table.deep_copy
 
 -- Local vars
 local surface
@@ -26,7 +24,7 @@ local Public = {
             tick :: uint: Tick the event was generated.
             area :: BoundingBox: Area of the chunk
             surface :: LuaSurface: The surface the chunk is on
-            chunk_index :: the index of the chunk in the table
+            chunk_index :: the index of the chunk in Chunklist's table
         ]]
         on_chunk_registered = script.generate_event_name()
     }
@@ -51,12 +49,17 @@ local function on_chunk_generated(event)
 
     local chunk_list = Public.chunk_list
     local new_entry_index = #chunk_list + 1
+    local area = event.area
 
-    chunk_list[new_entry_index] = event.area.left_top
-
-    local custom_event = deep_copy(event)
-    custom_event.chunk_index = new_entry_index
-    raise_event(Public.events.on_chunk_registered, custom_event)
+    chunk_list[new_entry_index] = area.left_top
+    raise_event(
+        Public.events.on_chunk_registered,
+        {
+            area = area,
+            surface = surface,
+            chunk_index = new_entry_index
+        }
+    )
 end
 
 Event.add(defines.events.on_chunk_generated, on_chunk_generated)

--- a/map_gen/shared/chunklist.lua
+++ b/map_gen/shared/chunklist.lua
@@ -7,9 +7,11 @@
 local Global = require 'utils.global'
 local RS = require 'map_gen.shared.redmew_surface'
 local Event = require 'utils.event'
+local table = require 'utils.table'
 
 -- Localized functions
 local raise_event = script.raise_event
+local deep_copy = table.deep_copy
 
 -- Local vars
 local surface
@@ -52,8 +54,9 @@ local function on_chunk_generated(event)
 
     chunk_list[new_entry_index] = event.area.left_top
 
-    event.chunk_index = new_entry_index
-    raise_event(Public.events.on_chunk_registered, event)
+    local custom_event = deep_copy(event)
+    custom_event.chunk_index = new_entry_index
+    raise_event(Public.events.on_chunk_registered, custom_event)
 end
 
 Event.add(defines.events.on_chunk_generated, on_chunk_generated)


### PR DESCRIPTION
I never put 2 and 2 together: the event module passes refs to each handler, but those refs are all to the same `event` table. So *maybe* I shouldn't be writing into a table that other modules are relying on. Especially since passing it through `raise_event()` overwrites some of the existing data.