### PR TITLE
Expand debug warning

### DIFF
--- a/features/player_create.lua
+++ b/features/player_create.lua
@@ -62,7 +62,11 @@ local function player_created(event)
 
     if _DEBUG and player.admin then
         UserGroups.add_regular(player.name)
-        game.print("HEY GRILLED DON'T LAUNCH THIS MAP! DEBUG MODE IS ENABLED!!!")
+        if game.is_multiplayer then
+            game.print("THIS MULTIPLAYER MAP IS IN DEBUG!!!")
+        else
+            game.print("DON'T LAUNCH THIS MAP! DEBUG MODE IS ENABLED!!!")
+        end
     end
 
     if _CHEATS then


### PR DESCRIPTION
I was going to just commit this, but then I wouldn't get a chance to say that this is what I had originally written this as:

```lua
    if _DEBUG and player.admin then
        UserGroups.add_regular(player.name)
        if game.is_multiplayer then
            game.print("GRILLED MESSED UP REAL BAD! THIS MULTIPLAYER MAP IS IN DEBUG!!!")
        else
            game.print("HEY GRILLED DON'T LAUNCH THIS MAP! DEBUG MODE IS ENABLED!!!")
        end
    end
```