### PR TITLE
Add everyone is regular option

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -284,7 +284,11 @@ global.config = {
         -- brightness is a number between 0.15 and 1
         use_fixed_brightness = false,
         fixed_brightness = 0.5
-    }
+    },
+	-- makes every player a regular so they can do the full range of actions
+	everyone_is_regular = {
+		enabled = true
+	}
 }
 
 return global.config

--- a/config.lua
+++ b/config.lua
@@ -287,7 +287,7 @@ global.config = {
     },
 	-- makes every player a regular so they can do the full range of actions
 	everyone_is_regular = {
-		enabled = true
+		enabled = false
 	}
 }
 

--- a/features/user_groups.lua
+++ b/features/user_groups.lua
@@ -10,9 +10,12 @@ global.donators = Donators.donators
 
 local Module = {}
 
-Module.is_regular =
-    function(player_name)
-    return Utils.cast_bool(global.regulars[player_name])
+Module.is_regular = function(player_name)
+	if global.config.everyone_is_regular.enabled then
+		return true
+    else
+		return Utils.cast_bool(global.regulars[player_name])
+	end
 end
 
 Module.add_regular = function(player_name)


### PR DESCRIPTION
Adds a config option so that all players are deemed to be regulars. This way on private servers all players can do all actions. The default value is off as per current scenario behaviour.