### PR TITLE
Change digit to string to prevent error (and desyncs)

### DIFF
--- a/features/force_control.lua
+++ b/features/force_control.lua
@@ -322,7 +322,7 @@ function ForceControl.get_formatted_force_data(lua_force_or_name)
     end
 
     return format(
-        'Current experience: %d Total experience: %d Current level: %d  Next level at: %d Percentage to level up: %d%%',
+        'Current experience: %s Total experience: %s Current level: %d  Next level at: %s Percentage to level up: %d%%',
         force_config.current_experience,
         force_config.total_experience,
         force_config.current_level,

--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -298,11 +298,11 @@ local function redraw_market_items(data)
         if disabled then
             insert(tooltip, '\n\n' .. (item.disabled_reason or 'Not available'))
         elseif is_missing_coins then
-            insert(tooltip, '\n\n' .. format('Missing %d coins to buy %d', missing_coins, stack_count))
+            insert(tooltip, '\n\n' .. format('Missing %s coins to buy %s', missing_coins, stack_count))
         end
 
         if has_player_limit then
-            insert(tooltip, '\n\n' .. format('You have bought this item %d out of %d times', item.player_limit - player_limit, item.player_limit))
+            insert(tooltip, '\n\n' .. format('You have bought this item %s out of %s times', item.player_limit - player_limit, item.player_limit))
         end
 
         local button = grid.add({type = 'flow'}).add({

--- a/map_gen/maps/diggy/feature/experience.lua
+++ b/map_gen/maps/diggy/feature/experience.lua
@@ -212,7 +212,7 @@ local function on_research_finished(event)
         award_xp = award_xp + reward
     end
     local exp = award_xp * research.research_unit_count
-    local text = format('Research completed! +s XP', exp)
+    local text = format('Research completed! +%s XP', exp)
     for _, p in pairs(game.connected_players) do
         local player_index = p.index
         print_player_floating_text_position(player_index, text, gain_xp_color, -1, -0.5)

--- a/map_gen/maps/diggy/feature/experience.lua
+++ b/map_gen/maps/diggy/feature/experience.lua
@@ -195,7 +195,7 @@ local function on_player_mined_entity(event)
         return
     end
 
-    print_player_floating_text_position(player_index, format('+%d XP', exp), gain_xp_color,0, -0.5)
+    print_player_floating_text_position(player_index, format('+%s XP', exp), gain_xp_color,0, -0.5)
     add_experience(force, exp)
 end
 
@@ -212,7 +212,7 @@ local function on_research_finished(event)
         award_xp = award_xp + reward
     end
     local exp = award_xp * research.research_unit_count
-    local text = format('Research completed! +%d XP', exp)
+    local text = format('Research completed! +s XP', exp)
     for _, p in pairs(game.connected_players) do
         local player_index = p.index
         print_player_floating_text_position(player_index, text, gain_xp_color, -1, -0.5)
@@ -281,7 +281,7 @@ local function on_entity_died(event)
         end
 
         if exp > 0 then
-            Game.print_floating_text(entity.surface, floating_text_position, format('+%d XP', exp), gain_xp_color)
+            Game.print_floating_text(entity.surface, floating_text_position, format('+%s XP', exp), gain_xp_color)
             add_experience(force, exp)
         end
 
@@ -302,8 +302,8 @@ end
 local function on_player_respawned(event)
     local player = get_player_by_index(event.player_index)
     local exp = remove_experience_percentage(player.force, config.XP['death-penalty'], 50)
-    local text = format('-%d XP', exp)
-    game.print(format('%s drained %d experience.', player.name, exp), lose_xp_color)
+    local text = format('-%s XP', exp)
+    game.print(format('%s drained %s experience.', player.name, exp), lose_xp_color)
     for _, p in pairs(game.connected_players) do
         print_player_floating_text_position(p.index, text, lose_xp_color, -1, -0.5)
     end

--- a/map_gen/maps/diggy/feature/experience.lua
+++ b/map_gen/maps/diggy/feature/experience.lua
@@ -242,7 +242,7 @@ end
 local function on_rocket_launched(event)
     local force = event.rocket.force
     local exp = add_experience_percentage(force, config.XP['rocket_launch'])
-    local text = format('Rocket launched! +%d XP', exp)
+    local text = format('Rocket launched! +%s XP', exp)
     for _, p in pairs(game.connected_players) do
         local player_index = p.index
         print_player_floating_text_position(player_index, text, gain_xp_color, -1, -0.5)


### PR DESCRIPTION
Turns out windows systems use a signed 32 bit int for digits, so they error out while unix-based systems do not, leading to desyncs.

```
613.005 Checksum for script C:/Users/Matthew/AppData/Roaming/Factorio/temp/currently-playing/control.lua: 1680941011
 635.706 Script @C:/Users/Matthew/AppData/Roaming/Factorio/temp/currently-playing/utils/debug.lua:68: [1] 2237966395 - Traceback -> [function: handler file: /feature/experience line number: 244]
 635.706 Error MainLoop.cpp:1035: Exception at tick 29846574: Error while running event level::on_rocket_launched (ID 10)
...rently-playing/map_gen/maps/diggy/feature/experience.lua:245: bad argument #2 to 'format' (not a number in proper range)
```

```
 700.671 Loading map C:\Users\Matthew\AppData\Roaming\Factorio\saves\pre-xp
 701.821 Loading Level.dat: 117958002 bytes.
 701.822 Info Scenario.cpp:136: Map version 0.16.51-0
 707.378 Loading script.dat: 11475632 bytes.
 707.448 Checksum for script C:/Users/Matthew/AppData/Roaming/Factorio/temp/currently-playing/control.lua: 1596643594
 729.899 Script @C:/Users/Matthew/AppData/Roaming/Factorio/temp/currently-playing/utils/debug.lua:68: [1] 2237966395 - Traceback -> [function: handler file: /feature/experience line number: 244]
1079.447 DSound: Stopping voice
```