### PR TITLE
Change command feedback and help text to use locale

### DIFF
--- a/features/rank_system.lua
+++ b/features/rank_system.lua
@@ -166,7 +166,7 @@ end
 
 --- Returns the player's rank as a name.
 -- @param player_name <string>
--- @return <string>
+-- @return <LocalisedString>
 function Public.get_player_rank_name(player_name)
     return rank_name_lookup[get_player_rank(player_name)]
 end
@@ -182,7 +182,7 @@ end
 
 --- Returns the rank's name.
 -- @param rank <number>
--- @return <string>
+-- @return <LocalisedString>
 function Public.get_rank_name(rank)
     return rank_name_lookup[rank]
 end
@@ -250,7 +250,7 @@ end
 
 --- Take a player and attempts to increase their rank by 1
 -- @param player_name <string>
--- @return <string|nil> new rank name or nil if already at highest rank
+-- @return <LocalisedString|nil> new rank name or nil if already at highest rank
 function Public.increase_player_rank(player_name)
     local current_rank = (get_player_rank(player_name))
     local new_rank = change_rank_by_number(current_rank, 1)
@@ -271,7 +271,7 @@ end
 -- Fails if player is already higher rank
 -- @param player_name <string>
 -- @param rank <number>
--- @return <boolean> <string> success/failure, and string name of the player's rank
+-- @return <boolean> <LocalisedString> success/failure, and LocalisedString of the player's rank
 function Public.increase_player_rank_to(player_name, rank)
     if Public.less_than(player_name, rank) then
         Public.set_player_rank(player_name, rank)
@@ -283,7 +283,7 @@ end
 
 --- Take a player and attempts to decrease their rank by 1
 -- @param player_name <string>
--- @return <string|nil> new rank name or nil if already at lowest rank
+-- @return <LocalisedString|nil> new rank name or nil if already at lowest rank
 function Public.decrease_player_rank(player_name)
     local current_rank = (get_player_rank(player_name))
     local new_rank = change_rank_by_number(current_rank, -1)
@@ -304,7 +304,7 @@ end
 -- Fails if player is already lower rank
 -- @param player_name <string>
 -- @param rank <number>
--- @return <boolean> <string> success/failure, and string name of the player's rank
+-- @return <boolean> <LocalisedString> success/failure, and LocalisedString of the player's rank
 function Public.decrease_player_rank_to(player_name, rank)
     if Public.greater_than(player_name, rank) then
         Public.set_player_rank(player_name, rank)
@@ -340,7 +340,7 @@ end
 
 --- Resets a player's rank to guest (or higher if a user meets the criteria for automatic rank)
 -- @param player_name <string>
--- @return <boolean> <string> boolean for success/failure, string as name of rank
+-- @return <boolean> <LocalisedString> boolean for success/failure, LocalisedString of rank name
 function Public.reset_player_rank(player_name)
     local guest_rank = Ranks.guest
     local auto_trusted = Ranks.auto_trusted

--- a/locale/en/redmew.cfg
+++ b/locale/en/redmew.cfg
@@ -20,3 +20,8 @@ regular_remove_fail=__1__ is rank __2__ their regular status cannot be removed.
 
 [redmew_commands]
 whois_formatter=__1__\n__2__\n__3__\n__4__\n__5__\n__6__\n__7__\n__8__\n__9__\n__10__\n__11__\n__12__\n__13__\n__14__\n__15__\n__16__\n
+
+[command]
+help_text_format=__1__ __2__ __3__
+higher_rank_needed=The command __1__ requires __2__ rank or higher to be be executed.
+required_rank= (Rank __1__ or above only)

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -137,12 +137,12 @@ function Command.add(command_name, options, callback)
     if allowed_by_server and not allowed_by_player then
         extra = ' (Server only)'
     elseif allowed_by_player and (required_rank > Ranks.guest) then
-        extra = format(' (Rank %s or above only)', get_rank_name(required_rank))
+        extra = {'command.required_rank', get_rank_name(required_rank)}
     elseif allowed_by_player and donator_only then
         extra = ' (Donator only)'
     end
 
-    local help_text = custom_help_text or argument_list .. description .. extra
+    local help_text = {'command.help_text_format',(custom_help_text or argument_list), description, extra}
 
     commands.add_command(command_name, help_text, function (command)
         local print -- custom print reference in case no player is present
@@ -164,7 +164,7 @@ function Command.add(command_name, options, callback)
             end
 
             if Rank.less_than(player_name, required_rank) then
-                print(format("The command '%s' requires %s rank or higher to be be executed.", command_name, get_rank_name(required_rank)))
+                print({'command.higher_rank_needed', command_name, get_rank_name(required_rank)})
                 return
             end
 


### PR DESCRIPTION
This isn't a change to all of `command`, but just a hack to get the parts accessing rank working properly.

Below: feedback from `/help tp` and `/tp` (used after demoting myself)
![image](https://user-images.githubusercontent.com/10162554/52812619-e3038680-3065-11e9-9d3d-a06d2f79d6d1.png)
