### PR TITLE
Fix/apocalypse hail hydra desync

### DIFF
--- a/features/admin_commands.lua
+++ b/features/admin_commands.lua
@@ -503,9 +503,7 @@ Command.add(
 Command.add(
     'apocalypse',
     {
-        description = "Calls for the endtimes. This really ends the map, so you must use '/apocalypse end this map'",
-        arguments = {'confirmation'},
-        capture_excess_arguments = true,
+        description = "This really ends the map. When you first run it, the game will save. When run a second time, the apocalypse will begin.",
         required_rank = Ranks.admin,
     },
     Apocalypse.begin_apocalypse

--- a/features/apocalypse.lua
+++ b/features/apocalypse.lua
@@ -1,4 +1,3 @@
-local table = require 'utils.table'
 local Task = require 'utils.task'
 local Token = require 'utils.token'
 local Game = require 'utils.game'
@@ -6,21 +5,29 @@ local Toast = require 'features.gui.toast'
 local RS = require 'map_gen.shared.redmew_surface'
 local HailHydra = require 'map_gen.shared.hail_hydra'
 
-local clear_table = table.clear_table
-
 local Public = {}
 
-local hydra_config = {
+local hail_hydra_data = {
     ['behemoth-spitter'] = {['behemoth-spitter'] = 0.01},
     ['behemoth-biter'] = {['behemoth-biter'] = 0.01}
 }
 
 local biter_spawn_token =
     Token.register(
-    function(data)
-        local surface = data.surface
-        local group = data.group
-        local p_spawn = data.p_spawn
+    function()
+        local surface
+        local player_force
+        local enemy_force = game.forces.enemy
+
+        surface = RS.get_surface()
+        player_force = game.forces.player
+
+        HailHydra.set_hydras(hail_hydra_data)
+        HailHydra.enable_hail_hydra()
+        enemy_force.evolution_factor = 1
+
+        local p_spawn = player_force.get_spawn_position(surface)
+        local group = surface.create_unit_group {position = p_spawn}
 
         local create_entity = surface.create_entity
 
@@ -34,7 +41,7 @@ local biter_spawn_token =
         for i = 1, #aliens do
             local spawn_pos = surface.find_non_colliding_position('behemoth-biter', p_spawn, 300, 1)
             if spawn_pos then
-                local biter = create_entity {name = aliens[i], position = spawn_pos}
+                local biter = create_entity({name = aliens[i], position = spawn_pos})
                 group.add_member(biter)
             end
         end
@@ -44,7 +51,7 @@ local biter_spawn_token =
     end
 )
 
-function Public.begin_apocalypse(args, player)
+function Public.begin_apocalypse(args)
     if args.confirmation ~= 'end this map' then
         Game.player_print('You must use /apocalypse end this map')
         return
@@ -55,40 +62,10 @@ function Public.begin_apocalypse(args, player)
     end
     game.server_save('pre-apocalypse')
     global.apocalypse_now = true
-    local surface
-    local player_force
-    local enemy_force = game.forces.enemy
-
-    if player and player.valid then
-        surface = player.surface
-        player_force = player.force
-    else
-        surface = RS.get_surface()
-        player_force = game.forces.player
-    end
-
-    local hydras = global.config.hail_hydra.hydras
-    clear_table(hydras)
-    for k, v in pairs(hydra_config) do
-        hydras[k] = v
-    end
-    HailHydra.enable_hail_hydra()
-    enemy_force.evolution_factor = 1
-
-    local p_spawn = player_force.get_spawn_position(surface)
-    local group = surface.create_unit_group {position = p_spawn}
 
     game.print('The ground begins to rumble. It seems as if the world itself is coming to an end.')
 
-    Task.set_timeout(
-        60,
-        biter_spawn_token,
-        {
-            p_spawn = p_spawn,
-            group = group,
-            surface = surface
-        }
-    )
+    Task.set_timeout(60, biter_spawn_token, {})
 end
 
 return Public

--- a/features/apocalypse.lua
+++ b/features/apocalypse.lua
@@ -81,21 +81,20 @@ function Public.begin_apocalypse(_, player)
         index = 0
     end
 
-    -- Make them run it twice to ensure no accidental apocalypse
-    if not second_run[index] then
+    -- Check if the apocalypse is happening or if it's the first run of the command.
+    if primitives.apocalypse_now then
+        Game.player_print({'apocalypse.apocalypse_already_running'}, Color.yellow)
+        return
+    elseif not second_run[index] then
         second_run[index] = true
         game.server_save('pre-apocalypse-' .. index)
         Game.player_print({'apocalypse.run_twice'})
         return
     end
 
-    if primitives.apocalypse_now then
-        return
-    end
     primitives.apocalypse_now = true
-
     game.print({'apocalypse.apocalypse_begins'}, Color.pink)
-    Task.set_timeout(60, biter_spawn_token, {})
+    Task.set_timeout(15, biter_spawn_token, {})
 end
 
 return Public

--- a/locale/en/redmew.cfg
+++ b/locale/en/redmew.cfg
@@ -20,3 +20,8 @@ regular_remove_fail=__1__ is rank __2__ their regular status cannot be removed.
 
 [redmew_commands]
 whois_formatter=__1__\n__2__\n__3__\n__4__\n__5__\n__6__\n__7__\n__8__\n__9__\n__10__\n__11__\n__12__\n__13__\n__14__\n__15__\n__16__\n
+
+[apocalypse]
+run_twice=The game has been saved, run the command again to commence the apocalypse.
+apocalypse_begins=The ground begins to rumble. It seems as if the world itself is coming to an end.
+toast_message=The end times are here. The four biters of the apocalypse have been summoned. Repent as the aliens take back what is theirs.

--- a/locale/en/redmew.cfg
+++ b/locale/en/redmew.cfg
@@ -24,4 +24,5 @@ whois_formatter=__1__\n__2__\n__3__\n__4__\n__5__\n__6__\n__7__\n__8__\n__9__\n_
 [apocalypse]
 run_twice=The game has been saved, run the command again to commence the apocalypse.
 apocalypse_begins=The ground begins to rumble. It seems as if the world itself is coming to an end.
+apocalypse_already_running=The apocalypse has already begun. There is nothing more to do in this world.
 toast_message=The end times are here. The four biters of the apocalypse have been summoned. Repent as the aliens take back what is theirs.


### PR DESCRIPTION
apoc: set data in token rather than passing data, move to Global, change command from some silly string to running it twice. This also gives us a chance to create a save that can be reverted to. Move strings to localised strings

hydra: move data into Global to allow changes during runtime (that don't cause desyncs)

Mostly tested in SP with heavy mode. Would benefit from re-testing as I only tested https://github.com/Refactorio/RedMew/commit/41c88ec682d3f59c5f8dae6f814379b377fb3f12 without heavy mode.