### PR TITLE
print override to own module

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -3,6 +3,9 @@
 -- Info on the data lifecycle and how we use it: https://github.com/Refactorio/RedMew/wiki/The-data-lifecycle
 _LIFECYCLE = 4 -- Control stage
 
+-- Overrides the _G.print function
+require 'utils.print_override'
+
 -- Omitting the math library is a very bad idea
 require 'utils.math'
 

--- a/features/server.lua
+++ b/features/server.lua
@@ -5,20 +5,17 @@ local Global = require 'utils.global'
 local Event = require 'utils.event'
 local Game = require 'utils.game'
 local Timestamp = require 'utils.timestamp'
+local Print = require('utils.print_override')
 
 local serialize = serpent.serialize
 local concat = table.concat
 local remove = table.remove
 local tostring = tostring
+local raw_print = Print.raw_print
 
 local serialize_options = {sparse = true, compact = true}
 
 local Public = {}
-
-local raw_print = print
-function print(str)
-    raw_print('[PRINT] ' .. str)
-end
 
 local server_time = {secs = nil, tick = 0}
 

--- a/utils/print_override.lua
+++ b/utils/print_override.lua
@@ -1,0 +1,12 @@
+local Public = {}
+
+local tostring = tostring
+
+local raw_print = print
+function print(str)
+    raw_print('[PRINT] ' .. tostring(str))
+end
+
+Public.raw_print = raw_print
+
+return Public

--- a/utils/print_override.lua
+++ b/utils/print_override.lua
@@ -1,10 +1,11 @@
 local Public = {}
 
-local tostring = tostring
-
+local locale_string = {'', '[PRINT] ', nil}
 local raw_print = print
+
 function print(str)
-    raw_print('[PRINT] ' .. tostring(str))
+    locale_string[3] = str
+    log(locale_string)
 end
 
 Public.raw_print = raw_print


### PR DESCRIPTION
This moves the print override into it's own module, so that print can be overridden before any other module is loaded.

I have tested this on the server and it appears to be fine.