### PR TITLE
Fix bug preventing jailing of a player in a train

### DIFF
--- a/features/report.lua
+++ b/features/report.lua
@@ -198,7 +198,13 @@ function Module.jail(target_player, player)
     -- If in vehicle, kick them out and set the speed to 0.
     local vehicle = target_player.vehicle
     if vehicle then
-        vehicle.speed = 0
+        local train = vehicle.train
+        -- Trains can't have their speed set via ent.speed and instead need ent.train.speed
+        if train then
+            train.speed = 0
+        else
+            vehicle.speed = 0
+        end
         target_player.driving = false
     end
 


### PR DESCRIPTION
Came up during the testing of #702: Trains cannot have their speed set via `LuaEntity.speed`