### PR TITLE
Fixed typo in peaceful_mode_on setting

### DIFF
--- a/resources/map_gen_settings.lua
+++ b/resources/map_gen_settings.lua
@@ -249,7 +249,7 @@ return {
     },
     -- peaceful mode on
     peaceful_mode_on = {
-        peaceful_mode = false
+        peaceful_mode = true
     },
     -- random seed, in case you need/want the seed to be unique from nauvis
     unique_seed = {


### PR DESCRIPTION
Fixed typo for peaceful_mode_on that accidentally turned it off.