### PR TITLE
Add event toggles to debugger

### DIFF
--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -2,6 +2,7 @@ local Event = require 'utils.event'
 local Global = require 'utils.global'
 local table = require 'utils.table'
 local Gui = require 'utils.gui'
+local Model = require 'features.gui.debug.model'
 
 local format = string.format
 local insert = table.insert
@@ -51,29 +52,7 @@ local function event_callback(event)
     last_events[name][events_to_keep + 1] = nil
     event.name = nil
 
-    local str = format('%s (id = %s): ', name, id)
-    for k, v in pairs(event) do
-        if type(v) ~= 'table' then
-            str = format('%s %s = %s,', str, k, v)
-        elseif v.__self then
-            str = format('%s %s :: %s', str, k, Debug.object_type(v))
-            if v.valid then
-                str = format('%s (name = %s),', str, v.name)
-            else
-                str = str .. ','
-            end
-        else
-            str = format('%s %s = {', str, k)
-            for k2, v2 in pairs(v) do
-                if type(v2) == 'table' then
-                    str = format('%s %s = <table>,', str, k2)
-                else
-                    str = format('%s %s = %s,', str, k2, v2)
-                end
-            end
-            str = format('%s},', str)
-        end
-    end
+    local str = format('%s (id = %s): %s', name, id, Model.dump(event))
     game.print(str)
     log(str)
 end

--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -1,0 +1,136 @@
+--[[
+    Create table of tables, each holding the last event of a particular type:
+    last_triggers = {
+        on_player_joined = {event},
+        on_player_left = {event}
+    }
+]]
+local Event = require 'utils.event'
+local Global = require 'utils.global'
+local table = require 'utils.table'
+local Gui = require 'utils.gui'
+
+local format = string.format
+local insert = table.insert
+
+local events = defines.events
+
+-- Constants
+local events_to_keep = 10
+
+-- Local vars
+local Public = {
+    name = 'Events'
+}
+local name_lookup = {}
+
+-- GUI names
+local checkbox_name = Gui.uid_name()
+
+-- Global tables
+local enabled = {}
+local last_events = {}
+
+Global.register(
+    {
+        enabled = enabled,
+        last_events = last_events
+    },
+    function(tbl)
+        enabled = tbl.enabled
+        last_events = tbl.last_events
+    end
+)
+
+-- Local functions
+local function event_callback(event)
+    local id = event.name
+    if not enabled[id] then
+        return
+    end
+    local name = name_lookup[id]
+
+    if not last_events[name] then
+        last_events[name] = {}
+    end
+
+    insert(last_events[name], 1, event)
+    last_events[name][events_to_keep + 1] = nil
+    event.name = nil
+
+    local str = format('%s (id = %s): ', name, id)
+    for k, v in pairs(event) do
+        if type(v) ~= 'table' then
+            str = format('%s %s = %s,', str, k, v)
+        elseif v.__self then
+            str = format('%s %s :: %s', str, k, Debug.object_type(v))
+            if v.valid then
+                str = format('%s (name = %s),', str, v.name)
+            else
+                str = str .. ','
+            end
+        else
+            str = format('%s %s = {', str, k)
+            for k2, v2 in pairs(v) do
+                if type(v2) == 'table' then
+                    str = format('%s %s = <table>,', str, k2)
+                else
+                    str = format('%s %s = %s,', str, k2, v2)
+                end
+            end
+            str = format('%s},', str)
+        end
+    end
+    game.print(str)
+    log(str)
+end
+
+local function on_gui_checked_state_changed(event)
+    local element = event.element
+    local name = element.caption
+    local id = events[name]
+    local state = element.state and true or false
+    element.state = state
+    if state then
+        enabled[id] = true
+    else
+        enabled[id] = false
+    end
+end
+
+-- GUI
+
+-- Create a table with events sorted by their names
+local grid_builder = {}
+for name, id in pairs(events) do
+    grid_builder[id] = name
+end
+grid_builder[#grid_builder + 1] = grid_builder[0]
+grid_builder[0] = nil
+table.sort(grid_builder)
+
+function Public.show(container)
+    local main_frame_flow = container.add({type = 'flow', direction = 'vertical'})
+    local scroll_pane = main_frame_flow.add({type = 'scroll-pane'})
+    local gui_table = scroll_pane.add({type = 'table', column_count = 3, draw_horizontal_lines = true})
+
+    for _, event_name in pairs(grid_builder) do
+        local index = events[event_name]
+        gui_table.add({type = 'flow'}).add {
+            name = checkbox_name,
+            type = 'checkbox',
+            state = enabled[index] or false,
+            caption = event_name
+        }
+    end
+end
+
+Event.add(events.on_gui_checked_state_changed, on_gui_checked_state_changed)
+
+-- Event registers (TODO: turn to removable hooks.. maybe)
+for name, id in pairs(events) do
+    name_lookup[id] = name
+    Event.add(id, event_callback)
+end
+
+return Public

--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -1,10 +1,3 @@
---[[
-    Create table of tables, each holding the last event of a particular type:
-    last_triggers = {
-        on_player_joined = {event},
-        on_player_left = {event}
-    }
-]]
 local Event = require 'utils.event'
 local Global = require 'utils.global'
 local table = require 'utils.table'

--- a/features/gui/debug/main_view.lua
+++ b/features/gui/debug/main_view.lua
@@ -7,7 +7,8 @@ local pages = {
     require 'features.gui.debug.redmew_global_view',
     require 'features.gui.debug.global_view',
     require 'features.gui.debug.package_view',
-    require 'features.gui.debug._g_view'
+    require 'features.gui.debug._g_view',
+    require 'features.gui.debug.event_view'
 }
 
 local main_frame_name = Gui.uid_name()
@@ -21,7 +22,7 @@ function Public.open_dubug(player)
         return
     end
 
-    frame = center.add {type = 'frame', name = main_frame_name, caption = 'Debuggertron 3000', direction = 'vertical'}
+    frame = center.add {type = 'frame', name = main_frame_name, caption = 'Debuggertron 3001', direction = 'vertical'}
     local frame_style = frame.style
     frame_style.height = 600
     frame_style.width = 900

--- a/map_gen/shared/map_loader.lua
+++ b/map_gen/shared/map_loader.lua
@@ -38,8 +38,7 @@ if #config.terrain_modules > 0 then
         shape = b.overlay_tile_land(shape, m)
     end
 end
-Debug.print(shape)
-Debug.print(shape_type)
+
 --- If shape is a function, initialize the generator
 if shape_type == 'function' then
     local surfaces = {

--- a/utils/debug.lua
+++ b/utils/debug.lua
@@ -82,10 +82,30 @@ local function get_lua_object_type_safe(obj)
     return r():match('Lua%a+')
 end
 
+--- Returns the value of the key inside the object
+-- or 'InvalidLuaObject' if the LuaObject is invalid.
+-- or 'InvalidLuaObjectKey' if the LuaObject does not have an entry at that key
+-- @param object <table> LuaObject or metatable
+-- @param key <string>
+-- @return <any>
+function Debug.get_meta_value(object, key)
+    if Debug.object_type(object) == 'InvalidLuaObject' then
+        return 'InvalidLuaObject'
+    end
+
+    local suc, value = pcall(get, object, key)
+    if not suc then
+        return 'InvalidLuaObjectKey'
+    end
+
+    return value
+end
+
 --- Returns the Lua data type or the factorio LuaObject type
 -- or 'NoHelpLuaObject' if the LuaObject does not have a help function
 -- or 'InvalidLuaObject' if the LuaObject is invalid.
 -- @param object <any>
+-- @return string
 function Debug.object_type(object)
     local obj_type = type(object)
 


### PR DESCRIPTION
This adds a page to the Debugger 3001 called "Events".
In it you can toggle any of the game's baked-in events. Toggling the events will trigger prints and log entries detailing the event details/package. From LuaObjects it will also try to display the `name` of the object.

![image](https://user-images.githubusercontent.com/10162554/53194399-426f1280-35e1-11e9-8d1f-bf34faefddcb.png)


In addition to that, it will keep a table in Global with the last 10 event packages of each event type.
![image](https://user-images.githubusercontent.com/10162554/53194480-71858400-35e1-11e9-86f3-54a63c148ac8.png)


In that event table, the `name` listed for LuaObjects is sometimes a little.. "weird" and seems to contain more than just the name. As this is a debug tool and still fulfills its purpose: I can personally live with it.

Tested in SP and MP with great success.