### PR TITLE
Added improved hydra scaling

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -217,18 +217,18 @@ global.config = {
         -- At evolution 0.60 it would spawn with a chance of min + max * (percentage of max) = 1.1
         hydras = {
             -- spitters
-            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = 0}},
-            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = 0}},
-            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = 0}},
-            ['behemoth-spitter'] = {['big-worm-turret'] = {min = 0.4, max = 0}},
+            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = -1}},
+            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = -1}},
+            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = -1}},
+            ['behemoth-spitter'] = {['big-worm-turret'] = {min = 0.4, max = -1}},
             -- biters
             ['medium-biter'] = {['small-biter'] = {min = 1.2, max = 2}},
             ['big-biter'] = {['medium-biter'] = {min = 1.2, max = 2}},
             ['behemoth-biter'] = {['big-biter'] = {min = 1.2, max = 2}},
             -- worms
-            ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}},
-            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}, ['medium-biter'] = {min = 0.6, max = 0}},
-            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = 0}, ['medium-biter'] = {min = 1.3, max = 0}, ['big-biter'] = {min = 1.1, max = 0}, ['behemoth-biter'] = {min = 0.1, max = 0, trigger = 0.99}}
+            ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}},
+            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}, ['medium-biter'] = {min = 0.6, max = -1}},
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99}}
         }
     },
     -- grants reward coins for certain actions

--- a/config.lua
+++ b/config.lua
@@ -197,6 +197,7 @@ global.config = {
     hail_hydra = {
         enabled = false,
         -- enables difficulty scaling with number of online players
+        -- if enabled you can disable it for individual spawns by setting {locked = true}
         online_player_scale_enabled = true,
         -- the number of players required for regular values.
         -- less online players than this number decreases the spawn chances
@@ -215,6 +216,8 @@ global.config = {
         -- eg. {min = 0.2, max = 2, trigger = 0.3} means that after evolution 0.3 this hydra spawns with a chance of at least 0.2
         -- and at evolution = 1.00 it spawns with a chance of 2.
         -- At evolution 0.60 it would spawn with a chance of min + max * (percentage of max) = 1.1
+        -- Example of all available options (only min is required):
+        -- ['behemoth-biter'] = {min = 0.1, max = 0.5, trigger = 0.90, locked = true}}
         hydras = {
             -- spitters
             ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = -1}},
@@ -228,7 +231,7 @@ global.config = {
             -- worms
             ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}},
             ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}, ['medium-biter'] = {min = 0.6, max = -1}},
-            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99}}
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99, locked = true}}
         }
     },
     -- grants reward coins for certain actions

--- a/config.lua
+++ b/config.lua
@@ -188,27 +188,39 @@ global.config = {
     -- spawns more units when one dies
     hail_hydra = {
         enabled = false,
-        -- at which scale the evolution will increase the additional hydra spawns
-        -- to disable scaling with evolution, set to 0.
-        -- the formula: chance = hydra_chance + (evolution_factor * evolution_scale)
-        -- example: small spitter has 0.2, which is 20% at 0% and 120% at an evolution_factor of 1
-        evolution_scale = 1,
+        -- enables difficulty scaling with number of online players
+        online_player_scale_enabled = true,
+        -- the number of players required for regular values.
+        -- less online players than this number decreases the spawn chances
+        -- more online players than this number increases the spawn chances
+        -- the spawn chance is increased or decreased with 0.01 * (#connected_players - online_player_scale)
+        online_player_scale = 20,
         -- any non-rounded number will turn into a chance to spawn an additional alien
         -- example: 2.5 would spawn 2 for sure and 50% chance to spawn one additionally
+        -- min defines the lowest chance, max defines the max chance at evolution 1.
+        -- trigger defines when the chance is active
+        -- setting max to less than min or nil will ignore set the max = min
+        -- Hail Hydra scales between min and max with a custom formula.
+        -- Key values shown in evolution = (percentage of max):
+        -- | 0.25 evolution = 10% | 0.50 evolution = 29% | 0.60 evolution = 45% | 0.75 evolution = 58% |
+        -- | 0.80 evolution = 65% | 0.90 evolution = 81% | 1.00 evolution = 100% |
+        -- eg. {min = 0.2, max = 2, trigger = 0.3} means that after evolution 0.3 this hydra spawns with a chance of at least 0.2
+        -- and at evolution = 1.00 it spawns with a chance of 2.
+        -- At evolution 0.60 it would spawn with a chance of min + max * (percentage of max) = 1.1
         hydras = {
             -- spitters
-            ['small-spitter'] = {['small-worm-turret'] = 0.2},
-            ['medium-spitter'] = {['medium-worm-turret'] = 0.2},
-            ['big-spitter'] = {['big-worm-turret'] = 0.2},
-            ['behemoth-spitter'] = {['big-worm-turret'] = 0.4},
+            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = 0}},
+            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = 0}},
+            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = 0}},
+            ['behemoth-spitter'] = {['big-worm-turret'] = {min = 0.4, max = 0}},
             -- biters
-            ['medium-biter'] = {['small-biter'] = 1.2},
-            ['big-biter'] = {['medium-biter'] = 1.2},
-            ['behemoth-biter'] = {['big-biter'] = 1.2},
+            ['medium-biter'] = {['small-biter'] = {min = 1.2, max = 2}},
+            ['big-biter'] = {['medium-biter'] = {min = 1.2, max = 2}},
+            ['behemoth-biter'] = {['big-biter'] = {min = 1.2, max = 2}},
             -- worms
-            ['small-worm-turret'] = {['small-biter'] = 2.5},
-            ['medium-worm-turret'] = {['small-biter'] = 2.5, ['medium-biter'] = 0.6},
-            ['big-worm-turret'] = {['small-biter'] = 3.8, ['medium-biter'] = 1.3, ['big-biter'] = 1.1}
+            ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}},
+            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}, ['medium-biter'] = {min = 0.6, max = 0}},
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = 0}, ['medium-biter'] = {min = 1.3, max = 0}, ['big-biter'] = {min = 1.1, max = 0}, ['behemoth-biter'] = {min = 0.1, max = 0, trigger = 0.99}}
         }
     },
     -- grants reward coins for certain actions

--- a/config.lua
+++ b/config.lua
@@ -220,19 +220,28 @@ global.config = {
         -- ['behemoth-biter'] = {min = 0.1, max = 0.5, trigger = 0.90, locked = true}}
         hydras = {
             -- spitters
-            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = -1}},
-            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = -1}},
-            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = -1}},
-            ['behemoth-spitter'] = {['behemoth-worm-turret'] = {min = 0.2, max = -1}},
+            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = 1}},
+            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = 1}},
+            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = 1}},
+            ['behemoth-spitter'] = {['behemoth-worm-turret'] = {min = 0.2, max = 1}},
             -- biters
-            ['medium-biter'] = {['small-biter'] = {min = 1.2, max = 2}},
-            ['big-biter'] = {['medium-biter'] = {min = 1.2, max = 2}},
-            ['behemoth-biter'] = {['big-biter'] = {min = 1.2, max = 2}},
+            ['medium-biter'] = {['small-biter'] = {min = 1, max = 2}},
+            ['big-biter'] = {['medium-biter'] = {min = 1, max = 2}},
+            ['behemoth-biter'] = {['big-biter'] = {min = 1, max = 2}},
             -- worms
-            ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}},
-            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}, ['medium-biter'] = {min = 0.6, max = -1}},
-            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}},
-            ['behemoth-worm-turret'] = {['small-biter'] = {min = 4.5, max = -1}, ['medium-biter'] = {min = 2.5, max = -1}, ['big-biter'] = {min = 2, max = -1}, ['behemoth-biter'] = {min = 0.8, max = -1}}
+            ['small-worm-turret'] = {['small-biter'] = {min = 1.5, max = 2.5}},
+            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = 3.5}, ['medium-biter'] = {min = 1.0, max = 2}},
+            ['big-worm-turret'] = {
+                ['small-biter'] = {min = 2.5, max = 4},
+                ['medium-biter'] = {min = 1.5, max = 2.2},
+                ['big-biter'] = {min = 0.7, max = 1.5}
+            },
+            ['behemoth-worm-turret'] = {
+                ['small-biter'] = {min = 4, max = 5.2},
+                ['medium-biter'] = {min = 2.5, max = 3.8},
+                ['big-biter'] = {min = 1.2, max = 2.4},
+                ['behemoth-biter'] = {min = 0.8, max = -1}
+            }
         }
     },
     -- grants reward coins for certain actions

--- a/config.lua
+++ b/config.lua
@@ -209,18 +209,18 @@ global.config = {
         -- At evolution 0.60 it would spawn with a chance of min + max * (percentage of max) = 1.1
         hydras = {
             -- spitters
-            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = 0}},
-            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = 0}},
-            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = 0}},
-            ['behemoth-spitter'] = {['big-worm-turret'] = {min = 0.4, max = 0}},
+            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = -1}},
+            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = -1}},
+            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = -1}},
+            ['behemoth-spitter'] = {['big-worm-turret'] = {min = 0.4, max = -1}},
             -- biters
             ['medium-biter'] = {['small-biter'] = {min = 1.2, max = 2}},
             ['big-biter'] = {['medium-biter'] = {min = 1.2, max = 2}},
             ['behemoth-biter'] = {['big-biter'] = {min = 1.2, max = 2}},
             -- worms
-            ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}},
-            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}, ['medium-biter'] = {min = 0.6, max = 0}},
-            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = 0}, ['medium-biter'] = {min = 1.3, max = 0}, ['big-biter'] = {min = 1.1, max = 0}, ['behemoth-biter'] = {min = 0.1, max = 0, trigger = 0.99}}
+            ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}},
+            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}, ['medium-biter'] = {min = 0.6, max = -1}},
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99}}
         }
     },
     -- grants reward coins for certain actions

--- a/config.lua
+++ b/config.lua
@@ -189,6 +189,7 @@ global.config = {
     hail_hydra = {
         enabled = false,
         -- enables difficulty scaling with number of online players
+        -- if enabled you can disable it for individual spawns by setting {locked = true}
         online_player_scale_enabled = true,
         -- the number of players required for regular values.
         -- less online players than this number decreases the spawn chances
@@ -207,6 +208,8 @@ global.config = {
         -- eg. {min = 0.2, max = 2, trigger = 0.3} means that after evolution 0.3 this hydra spawns with a chance of at least 0.2
         -- and at evolution = 1.00 it spawns with a chance of 2.
         -- At evolution 0.60 it would spawn with a chance of min + max * (percentage of max) = 1.1
+        -- Example of all available options (only min is required):
+        -- ['behemoth-biter'] = {min = 0.1, max = 0.5, trigger = 0.90, locked = true}}
         hydras = {
             -- spitters
             ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = -1}},
@@ -220,7 +223,7 @@ global.config = {
             -- worms
             ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}},
             ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}, ['medium-biter'] = {min = 0.6, max = -1}},
-            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99}}
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99, locked = true}}
         }
     },
     -- grants reward coins for certain actions

--- a/config.lua
+++ b/config.lua
@@ -196,27 +196,39 @@ global.config = {
     -- spawns more units when one dies
     hail_hydra = {
         enabled = false,
-        -- at which scale the evolution will increase the additional hydra spawns
-        -- to disable scaling with evolution, set to 0.
-        -- the formula: chance = hydra_chance + (evolution_factor * evolution_scale)
-        -- example: small spitter has 0.2, which is 20% at 0% and 120% at an evolution_factor of 1
-        evolution_scale = 1,
+        -- enables difficulty scaling with number of online players
+        online_player_scale_enabled = true,
+        -- the number of players required for regular values.
+        -- less online players than this number decreases the spawn chances
+        -- more online players than this number increases the spawn chances
+        -- the spawn chance is increased or decreased with 0.01 * (#connected_players - online_player_scale)
+        online_player_scale = 20,
         -- any non-rounded number will turn into a chance to spawn an additional alien
         -- example: 2.5 would spawn 2 for sure and 50% chance to spawn one additionally
+        -- min defines the lowest chance, max defines the max chance at evolution 1.
+        -- trigger defines when the chance is active
+        -- setting max to less than min or nil will ignore set the max = min
+        -- Hail Hydra scales between min and max with a custom formula.
+        -- Key values shown in evolution = (percentage of max):
+        -- | 0.25 evolution = 10% | 0.50 evolution = 29% | 0.60 evolution = 45% | 0.75 evolution = 58% |
+        -- | 0.80 evolution = 65% | 0.90 evolution = 81% | 1.00 evolution = 100% |
+        -- eg. {min = 0.2, max = 2, trigger = 0.3} means that after evolution 0.3 this hydra spawns with a chance of at least 0.2
+        -- and at evolution = 1.00 it spawns with a chance of 2.
+        -- At evolution 0.60 it would spawn with a chance of min + max * (percentage of max) = 1.1
         hydras = {
             -- spitters
-            ['small-spitter'] = {['small-worm-turret'] = 0.2},
-            ['medium-spitter'] = {['medium-worm-turret'] = 0.2},
-            ['big-spitter'] = {['big-worm-turret'] = 0.2},
-            ['behemoth-spitter'] = {['big-worm-turret'] = 0.4},
+            ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = 0}},
+            ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = 0}},
+            ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = 0}},
+            ['behemoth-spitter'] = {['big-worm-turret'] = {min = 0.4, max = 0}},
             -- biters
-            ['medium-biter'] = {['small-biter'] = 1.2},
-            ['big-biter'] = {['medium-biter'] = 1.2},
-            ['behemoth-biter'] = {['big-biter'] = 1.2},
+            ['medium-biter'] = {['small-biter'] = {min = 1.2, max = 2}},
+            ['big-biter'] = {['medium-biter'] = {min = 1.2, max = 2}},
+            ['behemoth-biter'] = {['big-biter'] = {min = 1.2, max = 2}},
             -- worms
-            ['small-worm-turret'] = {['small-biter'] = 2.5},
-            ['medium-worm-turret'] = {['small-biter'] = 2.5, ['medium-biter'] = 0.6},
-            ['big-worm-turret'] = {['small-biter'] = 3.8, ['medium-biter'] = 1.3, ['big-biter'] = 1.1}
+            ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}},
+            ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = 0}, ['medium-biter'] = {min = 0.6, max = 0}},
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = 0}, ['medium-biter'] = {min = 1.3, max = 0}, ['big-biter'] = {min = 1.1, max = 0}, ['behemoth-biter'] = {min = 0.1, max = 0, trigger = 0.99}}
         }
     },
     -- grants reward coins for certain actions

--- a/config.lua
+++ b/config.lua
@@ -231,7 +231,7 @@ global.config = {
             -- worms
             ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}},
             ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}, ['medium-biter'] = {min = 0.6, max = -1}},
-            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99, locked = true}},
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}},
             ['behemoth-worm-turret'] = {['small-biter'] = {min = 4.5, max = -1}, ['medium-biter'] = {min = 2.5, max = -1}, ['big-biter'] = {min = 2, max = -1}, ['behemoth-biter'] = {min = 0.8, max = -1}}
         }
     },

--- a/config.lua
+++ b/config.lua
@@ -223,7 +223,7 @@ global.config = {
             ['small-spitter'] = {['small-worm-turret'] = {min = 0.2, max = -1}},
             ['medium-spitter'] = {['medium-worm-turret'] = {min = 0.2, max = -1}},
             ['big-spitter'] = {['big-worm-turret'] = {min = 0.2, max = -1}},
-            ['behemoth-spitter'] = {['big-worm-turret'] = {min = 0.4, max = -1}},
+            ['behemoth-spitter'] = {['behemoth-worm-turret'] = {min = 0.2, max = -1}},
             -- biters
             ['medium-biter'] = {['small-biter'] = {min = 1.2, max = 2}},
             ['big-biter'] = {['medium-biter'] = {min = 1.2, max = 2}},
@@ -231,7 +231,8 @@ global.config = {
             -- worms
             ['small-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}},
             ['medium-worm-turret'] = {['small-biter'] = {min = 2.5, max = -1}, ['medium-biter'] = {min = 0.6, max = -1}},
-            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99, locked = true}}
+            ['big-worm-turret'] = {['small-biter'] = {min = 3.8, max = -1}, ['medium-biter'] = {min = 1.3, max = -1}, ['big-biter'] = {min = 1.1, max = -1}, ['behemoth-biter'] = {min = 0.1, max = -1, trigger = 0.99, locked = true}},
+            ['behemoth-worm-turret'] = {['small-biter'] = {min = 4.5, max = -1}, ['medium-biter'] = {min = 2.5, max = -1}, ['big-biter'] = {min = 2, max = -1}, ['behemoth-biter'] = {min = 0.8, max = -1}}
         }
     },
     -- grants reward coins for certain actions

--- a/map_gen/shared/hail_hydra.lua
+++ b/map_gen/shared/hail_hydra.lua
@@ -104,15 +104,9 @@ local on_died =
                     amount = min
                 end
             else
-                game.print('Trigger: '..trigger .. ' Evolution: '..force.evolution_factor)
-                game.print(tostring(trigger == nil))
-                game.print(tostring(trigger < force.evolution_factor))
                 amount = 0
             end
             amount = (amount > 0) and amount or 0
-            if hydra_spawn == 'behemoth-biter' then
-                game.print(hydra_spawn .. ' < biter | amount > ' .. amount)
-            end
 
             local extra_chance = amount % 1
             if extra_chance > 0 then

--- a/map_gen/shared/hail_hydra.lua
+++ b/map_gen/shared/hail_hydra.lua
@@ -88,8 +88,8 @@ local on_died =
             player_scale = (num_online_players - primitives.online_player_scale) * 0.01
         end
 
-        local evolution_factor = primitives.evolution_scale_formula(force.evolution_factor)
-        evolution_factor = evolution_factor + evolution_factor * player_scale
+        local evolution_scaled = primitives.evolution_scale_formula(force.evolution_factor)
+        local evolution_factor = evolution_scaled + evolution_scaled * player_scale
 
         local cause = event.cause
         local surface = entity.surface
@@ -104,6 +104,10 @@ local on_died =
             end
             local trigger = amount.trigger
             if trigger == nil or trigger < force.evolution_factor then
+                if amount.locked then
+                    evolution_factor = evolution_scaled
+                    game.print('Locked!')
+                end
                 local min = amount.min
                 local max = amount.max
                 max = (max ~= nil and max >= min) and max or min

--- a/map_gen/shared/hail_hydra.lua
+++ b/map_gen/shared/hail_hydra.lua
@@ -106,7 +106,6 @@ local on_died =
             if trigger == nil or trigger < force.evolution_factor then
                 if amount.locked then
                     evolution_factor = evolution_scaled
-                    game.print('Locked!')
                 end
                 local min = amount.min
                 local max = amount.max

--- a/map_gen/shared/hail_hydra.lua
+++ b/map_gen/shared/hail_hydra.lua
@@ -14,6 +14,7 @@ local compound = defines.command.compound
 local logical_or = defines.compound_command.logical_or
 local attack = defines.command.attack
 local attack_area = defines.command.attack_area
+local hail_hydra_conf = global.config.hail_hydra
 
 local spawn_table = {}
 for k, v in pairs(global.config.hail_hydra.hydras) do
@@ -27,9 +28,10 @@ local function formula(evo)
 end
 
 local primitives = {
-    evolution_scale = formula,
-    online_player_scale_enabled = global.config.hail_hydra.online_player_scale_enabled,
-    online_player_scale = global.config.hail_hydra.online_player_scale,
+    evolution_scale = (hail_hydra_conf.evolution_scale ~= nil) and hail_hydra_conf.evolution_scale or 1,
+    evolution_scale_formula = formula,
+    online_player_scale_enabled = hail_hydra_conf.online_player_scale_enabled,
+    online_player_scale = hail_hydra_conf.online_player_scale,
     enabled = nil
 }
 
@@ -45,6 +47,10 @@ Global.register(
 )
 
 local Public = {}
+
+local function backwards_compatibility(amount)
+    return {min = amount, max = amount + primitives.evolution_scale}
+end
 
 local function create_attack_command(position, target)
     local command = {type = attack_area, destination = position, radius = 10}
@@ -82,7 +88,7 @@ local on_died =
             player_scale = (num_online_players - primitives.online_player_scale) * 0.01
         end
 
-        local evolution_factor = primitives.evolution_scale(force.evolution_factor)
+        local evolution_factor = primitives.evolution_scale_formula(force.evolution_factor)
         evolution_factor = evolution_factor + evolution_factor * player_scale
 
         local cause = event.cause
@@ -93,13 +99,16 @@ local on_died =
         local command = create_attack_command(position, cause)
 
         for hydra_spawn, amount in pairs(hydra) do
+            if (type(amount) == 'number') then
+                amount = backwards_compatibility(amount)
+            end
             local trigger = amount.trigger
             if trigger == nil or trigger < force.evolution_factor then
-                local max = amount.max
                 local min = amount.min
+                local max = amount.max
                 max = (max ~= nil and max >= min) and max or min
                 if max ~= min then
-                    amount = (max - min) * (evolution_factor / primitives.evolution_scale(1)) + min
+                    amount = (max - min) * (evolution_factor / primitives.evolution_scale_formula(1)) + min
                 else
                     amount = min
                 end
@@ -163,6 +172,18 @@ end
 -- @param scale <number>
 function Public.set_evolution_scale(scale)
     primitives.evolution_scale = scale
+end
+
+--- Sets the online player scale
+-- @param scale <number>
+function Public.set_evolution_scale(scale)
+    primitives.online_player_scale = scale
+end
+
+--- Toggles the online player scale feature
+-- @param enable <boolean>
+function Public.set_evolution_scale(enabled)
+    primitives.online_player_scale_enabled = enabled
 end
 
 --- Sets the hydra spawning table


### PR DESCRIPTION
**Change log**
Added min, max and trigger to config
Added online_player_scale to config

Made hail hydra chances a variable of: 
- number of online players (toggle)
- evolution based on a custom formula that has a slow scaling until evolution 0.8

Current config is in need of balancing, what is shown is just an example to illustrate the changes.

**What is this?**
These changes would make hail hydra better suit all kinds of maps with increased customization.

**What is new?**
We can now customize:
- Hydras minimum chance
- Hydras maximum chance
- Toggle whether player count should affect these chances
- Amount of players needed for configured chances to be true.
  - Above this number further increase the chances
  - Below this number decrease the chances
  - Each player increases or decreases the chance with 1%

**What have been removed**
Evolution_scale didn't do much towards customizing the spawn chances. The equivalent in these changes are:
`{min = 0.2, max = min + evolution_scale}`

**Technical changes**
The formula for calculating the chance is:
`(0.00003*(E*100)^3 + 0.004 * (E*100)^2 + 0.3 * (E*100))*0.01` where `E = force.evolution_factor`

Approx values shown in evolution = (percentage of max):
| 0.25 evolution = 10% | 0.50 evolution = 29% | 0.60 evolution = 45% | 0.75 evolution = 58% |
| 0.80 evolution = 65% | 0.90 evolution = 81% | 1.00 evolution = 100% |

**Yet to do**
- [x] Create public functions to change these settings runtime
- [x] Implement compatibility with the old config using the conversion in `What have been removed`
- [x] Balance the default configuration
- [x] Ensure current maps aren't broken from these changes
- [x] Set max to -1 in config if it's unused
- [x] Make overriding the online_player_scale for a single hydra spawn possible