### PR TITLE
Debugger/event view global fix

### DIFF
--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -1,5 +1,4 @@
 local Event = require 'utils.event'
-local Global = require 'utils.global'
 local table = require 'utils.table'
 local Gui = require 'utils.gui'
 local Model = require 'features.gui.debug.model'

--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -21,16 +21,16 @@ local name_lookup = {}
 -- GUI names
 local checkbox_name = Gui.uid_name()
 
--- Global tables
+-- global tables
 local enabled = {}
 local last_events = {}
-global.event_view = {
+global.debug_event_view = {
     enabled = enabled,
     last_events = last_events
 }
 
-local function setup_globals()
-    local tbl = global.event_view
+function Public.on_open_debug()
+    local tbl = global.debug_event_view
     if tbl then
         enabled = tbl.enabled
         last_events = tbl.last_events
@@ -38,11 +38,13 @@ local function setup_globals()
         enabled = {}
         last_events = {}
 
-        global.event_view = {
+        global.debug_event_view = {
             enabled = enabled,
             last_events = last_events
         }
     end
+
+    Public.on_open_debug = nil
 end
 
 -- Local functions
@@ -91,8 +93,6 @@ grid_builder[0] = nil
 table.sort(grid_builder)
 
 function Public.show(container)
-    setup_globals()
-
     local main_frame_flow = container.add({type = 'flow', direction = 'vertical'})
     local scroll_pane = main_frame_flow.add({type = 'scroll-pane'})
     local gui_table = scroll_pane.add({type = 'table', column_count = 3, draw_horizontal_lines = true})

--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -24,17 +24,26 @@ local checkbox_name = Gui.uid_name()
 -- Global tables
 local enabled = {}
 local last_events = {}
+global.event_view = {
+    enabled = enabled,
+    last_events = last_events
+}
 
-Global.register(
-    {
-        enabled = enabled,
-        last_events = last_events
-    },
-    function(tbl)
+local function setup_globals()
+    local tbl = global.event_view
+    if tbl then
         enabled = tbl.enabled
         last_events = tbl.last_events
+    else
+        enabled = {}
+        last_events = {}
+
+        global.event_view = {
+            enabled = enabled,
+            last_events = last_events
+        }
     end
-)
+end
 
 -- Local functions
 local function event_callback(event)
@@ -82,6 +91,8 @@ grid_builder[0] = nil
 table.sort(grid_builder)
 
 function Public.show(container)
+    setup_globals()
+
     local main_frame_flow = container.add({type = 'flow', direction = 'vertical'})
     local scroll_pane = main_frame_flow.add({type = 'scroll-pane'})
     local gui_table = scroll_pane.add({type = 'table', column_count = 3, draw_horizontal_lines = true})

--- a/features/gui/debug/main_view.lua
+++ b/features/gui/debug/main_view.lua
@@ -16,6 +16,14 @@ local close_name = Gui.uid_name()
 local tab_name = Gui.uid_name()
 
 function Public.open_dubug(player)
+    for i = 1, #pages do
+        local page = pages[i]
+        local callback = page.on_open_debug
+        if callback then
+            callback()
+        end
+    end
+
     local center = player.gui.center
     local frame = center[main_frame_name]
     if frame then


### PR DESCRIPTION
Currently if you start the scenario with `_DEBUG = false` and then save and change `_DEBUG = true`, on load you will get this error
![image](https://user-images.githubusercontent.com/10003572/53287392-66625d80-3773-11e9-8f06-3811653e2398.png)

I changed the way globals are stored in the event_view to fix this.

This does mean the event_view's globals are now stored in global.debug_event_view instead.
![image](https://user-images.githubusercontent.com/10003572/53287411-a590ae80-3773-11e9-8ede-3f659b03e93b.png)
