### PR TITLE
Add scenario_data_manipulation

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -125,6 +125,10 @@ if config.popup.enabled then
     require 'features.gui.popup'
 end
 
+-- Debug-only modules
+if _DEBUG then
+    require 'features.scenario_data_manipulation'
+end
 -- Needs to be at bottom so tokens are registered last.
 if _DUMP_ENV then
     require 'utils.dump_env'

--- a/features/scenario_data_manipulation.lua
+++ b/features/scenario_data_manipulation.lua
@@ -1,0 +1,298 @@
+local Server = require 'features.server'
+local Token = require 'utils.token'
+local Command = require 'utils.command'
+local Global = require 'utils.global'
+local Ranks = require 'resources.ranks'
+local table = require 'utils.table'
+
+local primitives = {
+    copy = nil,
+    delete = nil,
+    new_dataset = nil,
+    lockout = nil
+}
+
+Global.register(
+    {
+        primitives = primitives
+    },
+    function(tbl)
+        primitives = tbl.primitives
+    end
+)
+
+--- Clears primitives
+local function clear_primitives()
+    primitives.copy = nil
+    primitives.delete = nil
+    primitives.new_dataset = nil
+    primitives.lockout = nil
+end
+
+--- Writes entries to datasets
+local function write_dataset(dataset, entries)
+    if not dataset or not entries then
+        game.print('Empty entries or dataset (This is usually due to calling the wrong data_set)')
+        clear_primitives()
+        return
+    end
+
+    for k, v in pairs(entries) do
+        Server.set_data(dataset, k, v)
+    end
+end
+
+--- Nils a dataset
+local function nil_dataset(dataset, entries)
+    if not dataset or not entries then
+        game.print('Empty entries or dataset (This is usually due to calling the wrong data_set)')
+        clear_primitives()
+        return
+    end
+
+    for k in pairs(entries) do
+        Server.set_data(dataset, k, nil)
+    end
+end
+
+--- Callback token
+local data_callback =
+    Token.register(
+    function(data)
+        local old_dataset = data.data_set
+        if not old_dataset then
+            game.print('Empty entries (This is usually due to calling the wrong data_set)')
+            clear_primitives()
+            return
+        end
+
+        local entries = data.entries
+        if not entries then
+            game.print('Empty entries (This is usually due to calling the wrong data_set)')
+            clear_primitives()
+            return
+        end
+
+        if primitives.copy then
+            write_dataset(primitives.new_dataset, entries)
+        end
+
+        if primitives.delete then
+            nil_dataset(old_dataset, entries)
+        end
+
+        clear_primitives()
+        game.print('Dataset operation complete.')
+    end
+)
+
+--- Sets parameters to have a dataset copied
+local function copy_dataset(args)
+    if primitives.lockout then
+        game.print('Data processing already in progress.')
+        return
+    end
+
+    local dataset = args.dataset
+    local destination = args.destination
+    game.print('Copying: ' .. dataset .. ' to ' .. destination)
+
+    primitives.new_dataset = destination
+    primitives.copy = true
+    primitives.delete = false
+    primitives.lockout = true
+
+    Server.try_get_all_data(dataset, data_callback)
+end
+
+--- Sets parameters to have a dataset moved
+local function move_dataset(args)
+    if primitives.lockout then
+        game.print('Data processing already in progress.')
+        return
+    end
+
+    local dataset = args.dataset
+    local destination = args.destination
+    game.print('Moving: ' .. dataset .. ' to ' .. destination)
+
+    primitives.new_dataset = destination
+    primitives.copy = true
+    primitives.delete = true
+    primitives.lockout = true
+
+    Server.try_get_all_data(dataset, data_callback)
+end
+
+--- Sets parameters to have a dataset deleted
+local function delete_dataset(args)
+    if primitives.lockout then
+        game.print('Data processing already in progress.')
+        return
+    end
+
+    local dataset = args.dataset
+    game.print('Deleting: ' .. dataset)
+
+    primitives.new_dataset = nil
+    primitives.copy = false
+    primitives.delete = true
+    primitives.lockout = true
+
+    Server.try_get_all_data(dataset, data_callback)
+end
+
+Command.add(
+    'dataset-copy',
+    {
+        description = 'Copies a dataset',
+        arguments = {'dataset', 'destination'},
+        required_rank = Ranks.admin,
+        debug_only = true,
+        allowed_by_server = true
+    },
+    copy_dataset
+)
+
+Command.add(
+    'dataset-move',
+    {
+        description = 'Moves a dataset',
+        arguments = {'dataset', 'destination'},
+        required_rank = Ranks.admin,
+        debug_only = true,
+        allowed_by_server = true
+    },
+    move_dataset
+)
+
+Command.add(
+    'dataset-delete',
+    {
+        description = 'Deletes a dataset',
+        arguments = {'dataset'},
+        required_rank = Ranks.admin,
+        debug_only = true,
+        allowed_by_server = true
+    },
+    delete_dataset
+)
+
+--- Callback token
+local transform_callback =
+    Token.register(
+    function(data)
+        local entries = data.entries
+        if not entries then
+            game.print('Empty entries (This is usually due to calling the wrong data_set)')
+            clear_primitives()
+            return
+        end
+
+        local returned_entries = global.transform_function(entries)
+
+        write_dataset(primitives.new_dataset, returned_entries)
+
+        clear_primitives()
+        game.print('Transform complete.')
+    end
+)
+
+--- Takes a data set, transforms it, then copies it.
+local function transform_data(args)
+    if primitives.lockout then
+        game.print('Data processing already in progress.')
+        clear_primitives()
+        return
+    end
+
+    local transform_function = global.transform_function
+    if not transform_function then
+        game.print('No transform function set')
+        clear_primitives()
+        return
+    end
+
+    if type(transform_function) ~= 'function' then
+        game.print('global.transform_function does not contain a function')
+        clear_primitives()
+        return
+    end
+
+    local destination = args.destination
+    local dataset = args.dataset
+    if destination == dataset then
+        game.print('For transforms, you must copy the output to a different dataset')
+        clear_primitives()
+        return
+    end
+
+    game.print('Beginning transform...')
+    primitives.new_dataset = args.destination
+    primitives.lockout = true
+    Server.try_get_all_data(args.dataset, transform_callback)
+end
+
+local transform_test_callback =
+    Token.register(
+    function(data)
+        local entries = data.entries
+        if not entries then
+            game.print('Empty entries (This is usually due to calling the wrong data_set).')
+            clear_primitives()
+            return
+        end
+
+        local transform_function = global.transform_function
+        if not transform_function then
+            game.print('No transform function set.')
+            clear_primitives()
+            return
+        end
+
+        if type(transform_function) ~= 'function' then
+            game.print('global.transform_function does not contain a function.')
+            clear_primitives()
+            return
+        end
+
+        local returned_entries = global.transform_function(entries)
+
+        clear_primitives()
+
+        global.transform_results = returned_entries
+        local result_str = table.inspect(returned_entries)
+        game.print(result_str)
+        log(result_str)
+        game.print('Test complete. The results can be better seen in the log or in global.transform_results')
+    end
+)
+
+local function transform_data_test(args)
+    game.print('Testing transform...')
+    Server.try_get_all_data(args.dataset, transform_test_callback)
+end
+
+Command.add(
+    'dataset-transform',
+    {
+        description = 'Transforms a dataset and writes it to the target dataset. Calls global.transform_function and sends the table of entries while expecting a table to return.',
+        arguments = {'dataset', 'destination'},
+        required_rank = Ranks.admin,
+        debug_only = true,
+        allowed_by_server = true
+    },
+    transform_data
+)
+
+Command.add(
+    'dataset-transform-test',
+    {
+        description = 'Shows the resulting data set from a transform operation. See /help dataset-transform for more information.',
+        arguments = {'dataset'},
+        required_rank = Ranks.admin,
+        debug_only = true,
+        allowed_by_server = true
+    },
+    transform_data_test
+)


### PR DESCRIPTION
Adds a number of debug-only commands and functions for manipulating scenario data.
`dataset-copy` takes a dataset and a destination
`dataset-move` takes a dataset and a destination
`dataset-delete` takes a dataset
All 3 do exactly what you would expect.

`dataset-transform` takes a dataset and a destination as arguments and applies the function located in `global.transform_function` to the entries.

The transformation function is given the table of dataset entries as an argument and a table of entries is expected as a return. Those entries will then be written to the destination (which must not be the same as the original data set). The reason for unique source and destination is strictly paternalistic: because if you make a mistake you lose all your original data. You can always `dataset-move` the output from the transform.

Lastly `dataset-transform-test` runs the entries through the transform function and provides the output in the log as well as `global.transform_results` (and does not copy the results to a dataset).