### PR TITLE
Change from using the argument as the name to polling the LuaPlayer for the name

### DIFF
--- a/features/gui/camera.lua
+++ b/features/gui/camera.lua
@@ -71,7 +71,7 @@ local function create_camera(args, player)
         mainframe.add {type = 'frame', name = 'cameraframe', style = 'captionless_frame'}
     end
 
-    mainframe.add {type = 'label', caption = 'Following: ' .. args.target}
+    mainframe.add {type = 'label', caption = 'Following: ' .. target.name}
     local close_button = mainframe.add {type = 'button', name = main_button_name, caption = 'Close'}
     apply_button_style(close_button)
     local target_index = target.index

--- a/features/redmew_commands.lua
+++ b/features/redmew_commands.lua
@@ -244,7 +244,7 @@ local function print_player_info(args, player)
     local index = target.index
     local info_t = {
         'redmew_commands.whois_formatter',
-        {'format.1_colon_2', 'Name', name},
+        {'format.1_colon_2', 'Name', target.name},
         {'format.single_item', target.connected and 'Online: yes' or 'Online: no'},
         {'format.1_colon_2', 'Index', target.index},
         {'format.1_colon_2', 'Rank', Rank.get_player_rank_name(name)},


### PR DESCRIPTION
Since commands generally use `game.players[arg.whatever]` to get the `LuaPlayer` we shouldn't rely on the argument being a name as it can just as easily be their index. (There are probably plenty more cases of this)