### PR TITLE
Fix walking_state in walkabout

### DIFF
--- a/features/walkabout.lua
+++ b/features/walkabout.lua
@@ -130,7 +130,7 @@ local function walkabout(args)
 
     local character = player.character
     if character and character.valid then
-        character.walking_state = {walking = false}
+        character.walking_state = {walking = false, direction = defines.direction.north}
     end
 
     if non_colliding_pos then


### PR DESCRIPTION
Maybe it's time to get rid of walkabout and tempban. I'm not sure what purpose they serve.