### PR TITLE
Retaining gui size for popups

### DIFF
--- a/features/gui/popup.lua
+++ b/features/gui/popup.lua
@@ -86,7 +86,7 @@ local function show_popup(player, message, title_text, sprite_path, popup_name)
     label.style.font = 'default-large-bold'
 
     local ok_button_flow = frame.add {type = 'flow'}
-    ok_button_flow.style.horizontally_stretchable = false
+    ok_button_flow.style.horizontally_stretchable = true
     ok_button_flow.style.horizontal_align  = 'center'
 
     local ok_button = ok_button_flow.add {type = 'button', name = close_name, caption = 'OK'}

--- a/features/gui/popup.lua
+++ b/features/gui/popup.lua
@@ -47,12 +47,14 @@ local function show_popup(player, message, title_text, sprite_path, popup_name)
     frame.style.minimal_width = 300
 
     local top_flow = frame.add {type = 'flow', direction = 'horizontal'}
+    top_flow.style.horizontal_align = 'center'
+    top_flow.style.horizontally_stretchable = true
 
     local title_flow = top_flow.add {type = 'flow'}
     title_flow.style.horizontal_align  = 'center'
     title_flow.style.left_padding = 32
     title_flow.style.top_padding = 8
-    title_flow.style.horizontally_stretchable = true
+    title_flow.style.horizontally_stretchable = false
 
     local title = title_flow.add {type = 'label', caption = title_text}
     title.style.font = 'default-large-bold'
@@ -65,11 +67,11 @@ local function show_popup(player, message, title_text, sprite_path, popup_name)
     content_flow.style.bottom_padding = 16
     content_flow.style.left_padding = 24
     content_flow.style.right_padding = 24
-    content_flow.style.horizontally_stretchable = true
+    content_flow.style.horizontally_stretchable = false
 
     local sprite_flow = content_flow.add {type = 'flow'}
     sprite_flow.style.vertical_align = 'center'
-    sprite_flow.style.vertically_stretchable = true
+    sprite_flow.style.vertically_stretchable = false
 
     sprite_flow.add {type = 'sprite', sprite = sprite_path}
 
@@ -78,13 +80,13 @@ local function show_popup(player, message, title_text, sprite_path, popup_name)
     label_flow.style.top_padding = 10
     label_flow.style.left_padding = 24
 
-    label_flow.style.horizontally_stretchable = true
+    label_flow.style.horizontally_stretchable = false
     local label = label_flow.add {type = 'label', caption = message}
     label.style.single_line = false
     label.style.font = 'default-large-bold'
 
     local ok_button_flow = frame.add {type = 'flow'}
-    ok_button_flow.style.horizontally_stretchable = true
+    ok_button_flow.style.horizontally_stretchable = false
     ok_button_flow.style.horizontal_align  = 'center'
 
     local ok_button = ok_button_flow.add {type = 'button', name = close_name, caption = 'OK'}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44922798/53498812-603bec00-3aa7-11e9-99ba-7c46d61a3177.png)
Instead of:
![image](https://user-images.githubusercontent.com/44922798/53498862-7e095100-3aa7-11e9-932c-7881a6a10264.png)

The highlight on the first popup is because of gui debug mode.