### PR TITLE
Fix the toast color display

### DIFF
--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -93,8 +93,8 @@ local function toast_to(player, duration, sound)
     local progressbar = frame.add({type = 'progressbar', name = toast_progress_name})
     local style = progressbar.style
     style.width = 290
-    style.height = 3
-    style.color = Color.grey
+    style.height = 4
+    style.color = Color.orange
     progressbar.value = 1 -- it starts full
 
     local id = autoincrement()


### PR DESCRIPTION
The grey one wasn't obvious anymore after the style changes by 0.17

![image](https://user-images.githubusercontent.com/1754678/53659700-7c34be80-3c5c-11e9-9e00-a403be091ad5.png)
