### PR TITLE
Replaced settings commands with a GUI

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -367,6 +367,11 @@ global.config = {
         enabled = true,
         use_remote_server = true,
     },
+    -- enables the redmew settings GUI
+    redmew_settings = {
+        enabled = true,
+        use_remote_server = true,
+    }
 }
 
 return global.config

--- a/config.lua
+++ b/config.lua
@@ -369,8 +369,7 @@ global.config = {
     },
     -- enables the redmew settings GUI
     redmew_settings = {
-        enabled = true,
-        use_remote_server = true,
+        enabled = true
     }
 }
 

--- a/config.lua
+++ b/config.lua
@@ -361,7 +361,12 @@ global.config = {
     -- allows the saving and automatic loading of quickbars between maps
     player_quick_bars = {
         enabled = true
-    }
+    },
+    -- enables the redmew settings GUI
+    redmew_settings = {
+        enabled = true,
+        use_remote_server = true,
+    },
 }
 
 return global.config

--- a/config.lua
+++ b/config.lua
@@ -364,11 +364,6 @@ global.config = {
     },
     -- enables the redmew settings GUI
     redmew_settings = {
-        enabled = true,
-        use_remote_server = true,
-    },
-    -- enables the redmew settings GUI
-    redmew_settings = {
         enabled = true
     }
 }

--- a/control.lua
+++ b/control.lua
@@ -133,6 +133,9 @@ end
 if config.rich_text_gui.enabled then
     require 'features.gui.rich_text'
 end
+if config.redmew_settings.enabled then
+    require 'features.gui.redmew_settings'
+end
 
 -- Debug-only modules
 if _DEBUG then

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -9,7 +9,6 @@ local Settings = require 'utils.redmew_settings'
 local Color = require 'resources.color_presets'
 
 local pairs = pairs
-local table_size = table.size
 
 local main_button_name = Gui.uid_name()
 local save_changes_button_name = Gui.uid_name()
@@ -122,8 +121,8 @@ local function draw_main_frame(center, player)
 
     local scroll_pane = settings_frame.add({type = 'scroll-pane'})
     local scroll_style = scroll_pane.style
+    scroll_style.vertically_squashable = true
     scroll_style.maximal_height = 800
-    scroll_style.minimal_height = 35 * table_size(settings)
     scroll_style.bottom_padding = 5
     scroll_style.left_padding = 5
     scroll_style.right_padding = 5
@@ -135,17 +134,12 @@ local function draw_main_frame(center, player)
     local data = {}
 
     for name, setting in pairs(settings) do
-        local caption = name
-
-        if setting.localisation_key then
-            caption = {setting.localisation_key}
-        end
-
         local label = setting_grid.add({
             type = 'label',
-            caption = caption,
+            caption = setting.localised_string,
         })
         label.style.horizontally_stretchable = true
+        label.style.height = 35
 
         local value = Settings.get(player_index, name)
         local input = create_input_element(setting_grid, setting.type, value)

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -30,7 +30,7 @@ Global.register(
 )
 
 local on_player_settings_get = Token.register(function (data)
-    local player = game.players[data.key]
+    local player = game.get_player(data.key)
 
     if not player or not player.valid then
         return
@@ -51,7 +51,7 @@ local on_player_settings_get = Token.register(function (data)
 end)
 
 local function player_created(event)
-    local player = game.players[event.player_index]
+    local player = game.get_player(event.player_index)
     if not player or not player.valid then
         return
     end
@@ -75,7 +75,7 @@ local function player_joined(event)
         return
     end
 
-    local player = game.players[event.player_index]
+    local player = game.get_player(event.player_index)
     if not player or not player.valid then
         return
     end

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -60,6 +60,12 @@ local function player_joined(event)
         return
     end
 
+    local main_frame = player.gui.center[main_frame_name]
+
+    if main_frame then
+        Gui.destroy(main_frame)
+    end
+
     Server.try_get_data_timeout('player_settings', player.name, on_player_settings_get, 30)
 end
 

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -47,7 +47,7 @@ local on_player_settings_get = Token.register(function (data)
 
     local button = player.gui.top[main_button_name]
     button.enabled = true
-    button.tooltip = {'redmew_settings_gui.menu_item_tooltip'}
+    button.tooltip = {'redmew_settings_gui.tooltip'}
 end)
 
 local function player_created(event)
@@ -60,13 +60,13 @@ local function player_created(event)
         type = 'sprite-button',
         name = main_button_name,
         sprite = 'item/iron-gear-wheel',
-        tooltip = {'redmew_settings_gui.menu_item_tooltip'}
+        tooltip = {'redmew_settings_gui.tooltip'}
     })
 
     -- disable the button if the remote server is used, won't be available until the settings are loaded
     if primitives.remote_server then
         button.enabled = false
-        button.tooltip = {'redmew_settings_gui.menu_item_tooltip_loading'}
+        button.tooltip = {'redmew_settings_gui.tooltip_loading'}
     end
 end
 

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -66,6 +66,10 @@ local function player_joined(event)
         Gui.destroy(main_frame)
     end
 
+    local button = player.gui.top[main_button_name]
+    button.tooltip = {'redmew_settings_gui.tooltip_loading'}
+    button.enabled = false
+
     Server.try_get_data_timeout('player_settings', player.name, on_player_settings_get, 30)
 end
 

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -1,0 +1,241 @@
+local Gui = require 'utils.gui'
+local Token = require 'utils.token'
+local Event = require 'utils.event'
+local Game = require 'utils.game'
+local Server = require 'features.server'
+local Toast = require 'features.gui.toast'
+local Settings = require 'utils.redmew_settings'
+local Color = require 'resources.color_presets'
+
+local pairs = pairs
+local table_size = table.size
+
+local main_button_name = Gui.uid_name()
+local save_changes_button_name = Gui.uid_name()
+local main_frame_name = Gui.uid_name()
+
+local Public = {}
+
+local on_player_settings_get = Token.register(function (data)
+    local player = game.players[data.key]
+
+    if not player or not player.valid then
+        return
+    end
+
+    local settings = data.value
+
+    if settings ~= nil then
+        local player_index = player.index
+        for key, value in pairs(settings) do
+            Settings.set(player_index, key, value)
+        end
+    end
+
+    local button = player.gui.top[main_button_name]
+    button.enabled = true
+    button.tooltip = {'redmew_settings.menu_item_tooltip'}
+end)
+
+local function player_created(event)
+    local player = Game.get_player_by_index(event.player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    local button = player.gui.top.add({
+        type = 'sprite-button',
+        name = main_button_name,
+        sprite = 'item/iron-gear-wheel',
+        tooltip = {'redmew_settings.menu_item_tooltip'}
+    })
+
+    -- disable the button if the remote server is used, won't be available until the settings are loaded
+    if global.config.redmew_settings.use_remote_server then
+        button.enabled = false
+        button.tooltip = {'redmew_settings.menu_item_tooltip_loading'}
+    end
+end
+
+local function player_joined(event)
+    if not global.config.redmew_settings.use_remote_server then
+        return
+    end
+
+    local player = Game.get_player_by_index(event.player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    Server.try_get_data('player_settings', player.name, on_player_settings_get);
+end
+
+local function get_element_value(element)
+    if element.type == 'text-box' then
+        return element.text
+    end
+    if element.type == 'slider' then
+        return element.slider_value
+    end
+    if element.type == 'checkbox' then
+        return element.state
+    end
+end
+
+local function create_input_element(frame, type, value)
+    if type == 'fraction' then
+        return frame.add({type = 'slider', value = value, minimum_value = 0, maximum_value = 1})
+    end
+    if type == 'boolean' then
+        return frame.add({type = 'checkbox', state = value})
+    end
+
+    -- ensure something is always added to prevent errors
+    return frame.add({type = 'text-box', text = value})
+end
+
+local function draw_main_frame(center, player)
+    local settings = Settings.get_setting_metadata()
+    local settings_frame = center.add({
+        type = 'frame',
+        name = main_frame_name,
+        direction = 'vertical',
+        caption = {'redmew_settings.frame_title'},
+    })
+
+    local settings_frame_style = settings_frame.style
+    settings_frame_style.width = 400
+
+    local scroll_pane = settings_frame.add({type = 'scroll-pane'})
+    local scroll_style = scroll_pane.style
+    scroll_style.maximal_height = 800
+    scroll_style.minimal_height = 35 * table_size(settings)
+    scroll_style.bottom_padding = 5
+    scroll_style.left_padding = 5
+    scroll_style.right_padding = 5
+    scroll_style.top_padding = 5
+
+    local setting_grid = scroll_pane.add({type = 'table', column_count = 2})
+    local player_index = player.index
+
+    local data = {}
+
+    for name, setting in pairs(settings) do
+        local caption = name
+
+        if setting.localisation_key then
+            caption = {setting.localisation_key}
+        end
+
+        local label = setting_grid.add({
+            type = 'label',
+            caption = caption,
+        })
+        label.style.horizontally_stretchable = true
+
+        local value = Settings.get(player_index, name)
+        local input = create_input_element(setting_grid, setting.type, value)
+
+        data[name] = {
+            label = label,
+            input = input,
+            previous_value = value,
+        }
+    end
+
+    local bottom_flow = settings_frame.add({type = 'flow', direction = 'horizontal'})
+
+    local left_flow = bottom_flow.add({type = 'flow'})
+    left_flow.style.horizontal_align = 'left'
+    left_flow.style.horizontally_stretchable = true
+
+    local close_button = left_flow.add({type = 'button', name = main_button_name, caption = {'redmew_settings.button_cancel'}})
+    close_button.style = 'back_button'
+
+    local right_flow = bottom_flow.add({type = 'flow'})
+    right_flow.style.horizontal_align = 'right'
+
+    local save_button = right_flow.add({type = 'button', name = save_changes_button_name, caption = {'redmew_settings.button_save_changes'}})
+    save_button.style = 'confirm_button'
+
+    Gui.set_data(save_button, data)
+
+    player.opened = settings_frame
+end
+
+local function toggle(event)
+    local player = event.player
+    local center = player.gui.center
+    local main_frame = center[main_frame_name]
+
+    if main_frame then
+        Gui.destroy(main_frame)
+    else
+        draw_main_frame(center, player)
+    end
+end
+
+local function save_changes(event)
+    local data = Gui.get_data(event.element)
+    local player_index = event.player_index
+    local player = event.player
+
+    local errors_count = 0
+    local values = {}
+
+    for name, element_data in pairs(data) do
+        local input = element_data.input
+        local label = element_data.label
+        local value = get_element_value(input)
+        local validated = Settings.validate(name, value)
+
+        if nil ~= validated then
+            errors_count = errors_count + 1
+            label.style.font_color = Color.red
+            label.tooltip = validated
+            label.parent.tooltip = validated
+            input.tooltip = validated
+            input.parent.tooltip = validated
+        else
+            label.style.font_color = Color.white
+            label.tooltip = ''
+            label.parent.tooltip = ''
+            input.tooltip = ''
+            input.parent.tooltip = ''
+        end
+        values[name] = value
+    end
+
+    if errors_count > 0 then
+        return
+    end
+
+    for name, value in pairs (values) do
+        Settings.set(player_index, name, value)
+    end
+
+    Toast.toast_player(player, 5, {'redmew_settings.save_success_toast_message'})
+
+    if global.config.redmew_settings.use_remote_server then
+        Server.set_data('player_settings', player.name, Settings.all(player_index));
+    end
+
+    local main_frame = player.gui.center[main_frame_name]
+
+    if main_frame then
+        Gui.destroy(main_frame)
+    end
+end
+
+Gui.on_custom_close(main_frame_name, function(event)
+    Gui.destroy(event.element)
+end)
+
+Gui.allow_player_to_toggle_top_element_visibility(main_button_name)
+
+Gui.on_click(main_button_name, toggle)
+Gui.on_click(save_changes_button_name, save_changes)
+Event.add(defines.events.on_player_created, player_created)
+Event.add(defines.events.on_player_joined_game, player_joined)
+
+return Public

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -34,7 +34,7 @@ local on_player_settings_get = Token.register(function (data)
 
     local button = player.gui.top[main_button_name]
     button.enabled = true
-    button.tooltip = {'redmew_settings.menu_item_tooltip'}
+    button.tooltip = {'redmew_settings_gui.menu_item_tooltip'}
 end)
 
 local function player_created(event)
@@ -47,13 +47,13 @@ local function player_created(event)
         type = 'sprite-button',
         name = main_button_name,
         sprite = 'item/iron-gear-wheel',
-        tooltip = {'redmew_settings.menu_item_tooltip'}
+        tooltip = {'redmew_settings_gui.menu_item_tooltip'}
     })
 
     -- disable the button if the remote server is used, won't be available until the settings are loaded
     if global.config.redmew_settings.use_remote_server then
         button.enabled = false
-        button.tooltip = {'redmew_settings.menu_item_tooltip_loading'}
+        button.tooltip = {'redmew_settings_gui.menu_item_tooltip_loading'}
     end
 end
 
@@ -100,7 +100,7 @@ local function draw_main_frame(center, player)
         type = 'frame',
         name = main_frame_name,
         direction = 'vertical',
-        caption = {'redmew_settings.frame_title'},
+        caption = {'redmew_settings_gui.frame_title'},
     })
 
     local settings_frame_style = settings_frame.style
@@ -149,13 +149,13 @@ local function draw_main_frame(center, player)
     left_flow.style.horizontal_align = 'left'
     left_flow.style.horizontally_stretchable = true
 
-    local close_button = left_flow.add({type = 'button', name = main_button_name, caption = {'redmew_settings.button_cancel'}})
+    local close_button = left_flow.add({type = 'button', name = main_button_name, caption = {'redmew_settings_gui.button_cancel'}})
     close_button.style = 'back_button'
 
     local right_flow = bottom_flow.add({type = 'flow'})
     right_flow.style.horizontal_align = 'right'
 
-    local save_button = right_flow.add({type = 'button', name = save_changes_button_name, caption = {'redmew_settings.button_save_changes'}})
+    local save_button = right_flow.add({type = 'button', name = save_changes_button_name, caption = {'redmew_settings_gui.button_save_changes'}})
     save_button.style = 'confirm_button'
 
     Gui.set_data(save_button, data)
@@ -214,7 +214,7 @@ local function save_changes(event)
         Settings.set(player_index, name, value)
     end
 
-    Toast.toast_player(player, 5, {'redmew_settings.save_success_toast_message'})
+    Toast.toast_player(player, 5, {'redmew_settings_gui.save_success_toast_message'})
 
     if global.config.redmew_settings.use_remote_server then
         Server.set_data('player_settings', player.name, Settings.all(player_index));

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -51,7 +51,7 @@ local on_player_settings_get = Token.register(function (data)
 end)
 
 local function player_created(event)
-    local player = Game.get_player_by_index(event.player_index)
+    local player = game.players[event.player_index]
     if not player or not player.valid then
         return
     end
@@ -75,7 +75,7 @@ local function player_joined(event)
         return
     end
 
-    local player = Game.get_player_by_index(event.player_index)
+    local player = game.players[event.player_index]
     if not player or not player.valid then
         return
     end

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -13,7 +13,7 @@ local pairs = pairs
 local next = next
 
 local toast_volume_name = 'toast-volume'
-Settings.register(toast_volume_name, 'fraction', 1.0)
+Settings.register(toast_volume_name, Settings.types.fraction, 1.0, 'toast.toast_volume_setting_label')
 
 local Public = {}
 

--- a/features/server.lua
+++ b/features/server.lua
@@ -322,7 +322,7 @@ end
 
 --- Same Server.try_get_data but the request can be cancelled by calling
 -- Server.cancel_try_get_data(data_set, key, callback_token)
--- If the request is cancelled before it is complete the callback will be called with nil.
+-- If the request is cancelled before it is complete the callback will be called with data.cancelled = true.
 -- It is safe to cancel a non-existent or completed request, in either case the callback will not be called.
 -- There can only be one request per data_set, key, callback_token combo. If there is already an ongoing request
 -- an attempt to make a new one will be ignored.
@@ -350,7 +350,8 @@ local function cancel_try_get_data(data_set, key, callback_token)
         callbacks[callback_token] = nil
 
         local func = Token.get(callback_token)
-        func()
+        local data = {data_set = data_set, key = key, cancelled = true}
+        func(data)
 
         return true
     else
@@ -360,7 +361,7 @@ end
 
 --- Cancels the request. Returns false if the request could not be cnacled, either because there is no request
 -- to cancel or it has been completed or cancled already. Otherwise returns true.
--- If the request is cancelled before it is complete the callback will be called with nil.
+-- If the request is cancelled before it is complete the callback will be called with data.cancelled = true.
 -- It is safe to cancel a non-existent or completed request, in either case the callback will not be called.
 -- @param  data_set<string>
 -- @param  key<string>
@@ -379,7 +380,7 @@ local timeout_token =
 )
 
 --- Same as Server.try_get_data but the request is cancelled if the timeout expires before the request is complete.
--- If the request is cancelled before it is complete the callback will be called with nil.
+-- If the request is cancelled before it is complete the callback will be called with data.cancelled = true.
 -- There can only be one request per data_set, key, callback_token combo. If there is already an ongoing request
 -- an attempt to make a new one will be ignored.
 -- @param  data_set<string>
@@ -392,15 +393,19 @@ local timeout_token =
 -- local callback =
 --     Token.register(
 --     function(data)
---         if not data then
---             return -- The request timed out.
---         end
---
 --         local data_set = data.data_set
 --         local key = data.key
+--
+--          game.print('data_set: ' .. data_set .. ', key: ' .. key)
+--
+--         if data.cancelled then
+--             game.print('Timed out')
+--             return
+--         end
+--
 --         local value = data.value -- will be nil if no data
 --
---         game.print(data_set .. ':' .. key .. ':' .. tostring(value))
+--         game.print('value: ' .. tostring(value))
 --     end
 -- )
 --

--- a/locale/en/redmew_gui.cfg
+++ b/locale/en/redmew_gui.cfg
@@ -48,11 +48,16 @@ toast_all=__1__ sent a toast to all players.
 toast_player=__1__ sent a toast to __2__.
 toast_volume_setting_label=Toast message volume
 
-[redmew_settings]
+[redmew_settings_gui]
 menu_item_tooltip=Your RedMew settings
 menu_item_tooltip_loading=Loading your personal settings...
 save_success_toast_message=Your settings have been updated!
 frame_title=Redmew Settings
+button_cancel=Cancel
+button_save_changes=Save changes
+
+[toast]
+toast_volume_setting_label=Toast message volume
 
 [player_list]
 tooltip=Player list

--- a/locale/en/redmew_gui.cfg
+++ b/locale/en/redmew_gui.cfg
@@ -76,12 +76,6 @@ close_caption=Close
 poke_notify_caption=Notify me when pokes happen.
 poke_notify_tooltip=Receive a message when a player pokes another player.
 
-[redmew_settings]
-menu_item_tooltip=Your RedMew settings
-menu_item_tooltip_loading=Loading your personal settings...
-save_success_toast_message=Your settings have been updated!
-frame_title=Redmew Settings
-
 [toast]
 toast_volume_setting_label=Toast message volume
 

--- a/locale/en/redmew_gui.cfg
+++ b/locale/en/redmew_gui.cfg
@@ -46,6 +46,13 @@ whats_new_button=What's New
 [toast]
 toast_all=__1__ sent a toast to all players.
 toast_player=__1__ sent a toast to __2__.
+toast_volume_setting_label=Toast message volume
+
+[redmew_settings]
+menu_item_tooltip=Your RedMew settings
+menu_item_tooltip_loading=Loading your personal settings...
+save_success_toast_message=Your settings have been updated!
+frame_title=Redmew Settings
 
 [player_list]
 tooltip=Player list

--- a/locale/en/redmew_gui.cfg
+++ b/locale/en/redmew_gui.cfg
@@ -64,6 +64,15 @@ close_caption=Close
 poke_notify_caption=Notify me when pokes happen.
 poke_notify_tooltip=Receive a message when a player pokes another player.
 
+[redmew_settings]
+menu_item_tooltip=Your RedMew settings
+menu_item_tooltip_loading=Loading your personal settings...
+save_success_toast_message=Your settings have been updated!
+frame_title=Redmew Settings
+
+[toast]
+toast_volume_setting_label=Toast message volume
+
 [evolution_progress]
 tooltip=Alien evolution progress
 

--- a/locale/en/redmew_gui.cfg
+++ b/locale/en/redmew_gui.cfg
@@ -43,11 +43,6 @@ softmods_score_label=Score
 softmods_score_text=Shows number of rockets launched and biters liberated.
 whats_new_button=What's New
 
-[toast]
-toast_all=__1__ sent a toast to all players.
-toast_player=__1__ sent a toast to __2__.
-toast_volume_setting_label=Toast message volume
-
 [redmew_settings_gui]
 menu_item_tooltip=Your RedMew settings
 menu_item_tooltip_loading=Loading your personal settings...
@@ -55,9 +50,6 @@ save_success_toast_message=Your settings have been updated!
 frame_title=Redmew Settings
 button_cancel=Cancel
 button_save_changes=Save changes
-
-[toast]
-toast_volume_setting_label=Toast message volume
 
 [player_list]
 tooltip=Player list
@@ -77,6 +69,8 @@ poke_notify_caption=Notify me when pokes happen.
 poke_notify_tooltip=Receive a message when a player pokes another player.
 
 [toast]
+toast_all=__1__ sent a toast to all players.
+toast_player=__1__ sent a toast to __2__.
 toast_volume_setting_label=Toast message volume
 
 [evolution_progress]

--- a/locale/en/redmew_gui.cfg
+++ b/locale/en/redmew_gui.cfg
@@ -44,8 +44,8 @@ softmods_score_text=Shows number of rockets launched and biters liberated.
 whats_new_button=What's New
 
 [redmew_settings_gui]
-menu_item_tooltip=Your RedMew settings
-menu_item_tooltip_loading=Loading your personal settings...
+tooltip=Your RedMew settings
+tooltip_loading=Loading your personal settings...
 save_success_toast_message=Your settings have been updated!
 frame_title=Redmew Settings
 button_cancel=Cancel

--- a/locale/en/redmew_utils.cfg
+++ b/locale/en/redmew_utils.cfg
@@ -1,6 +1,5 @@
 # This file holds all the locale strings for the utils
 
-<<<<<<< HEAD
 [command]
 help_text_format=__1__ __2__ __3__
 log_entry=__1__(Map time: __2__) [__3__ Command] __4__, used: __5__ __6__

--- a/locale/en/redmew_utils.cfg
+++ b/locale/en/redmew_utils.cfg
@@ -28,3 +28,10 @@ print_admins=__1__(ADMIN) __2__: __3__
 
 [gui_util]
 button_tooltip=Shows / hides the Redmew Gui buttons.
+
+[redmew_settings]
+fraction_invalid_value=fraction setting type requires the input to be a valid number between 0 and 1.
+string_invalid_value=string setting type requires the input to be either a valid string or something that can be converted to a string.
+boolean_invalid_value=boolean setting type requires the input to be either a boolean, number or string that can be transformed to a boolean.
+button_cancel=Cancel
+button_save_changes=Save changes

--- a/locale/en/redmew_utils.cfg
+++ b/locale/en/redmew_utils.cfg
@@ -1,5 +1,6 @@
 # This file holds all the locale strings for the utils
 
+<<<<<<< HEAD
 [command]
 help_text_format=__1__ __2__ __3__
 log_entry=__1__(Map time: __2__) [__3__ Command] __4__, used: __5__ __6__
@@ -29,9 +30,8 @@ print_admins=__1__(ADMIN) __2__: __3__
 [gui_util]
 button_tooltip=Shows / hides the Redmew Gui buttons.
 
-[redmew_settings]
+
+[redmew_settings_util]
 fraction_invalid_value=fraction setting type requires the input to be a valid number between 0 and 1.
 string_invalid_value=string setting type requires the input to be either a valid string or something that can be converted to a string.
 boolean_invalid_value=boolean setting type requires the input to be either a boolean, number or string that can be transformed to a boolean.
-button_cancel=Cancel
-button_save_changes=Save changes

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -12,7 +12,7 @@ local settings_type = {
         input = tonumber(input)
 
         if input == nil then
-            return false, 'fraction setting type requires the input to be a valid number between 0 and 1.'
+            return false, {'redmew_settings.fraction_invalid_value'}
         end
 
         if input < 0 then
@@ -39,7 +39,7 @@ local settings_type = {
             return true, tostring(input)
         end
 
-        return false, 'string setting type requires the input to be either a valid string or something that can be converted to a string.'
+        return false, {'redmew_settings.string_invalid_value'}
     end,
     boolean = function (input)
         local input_type = type(input)
@@ -63,7 +63,7 @@ local settings_type = {
             return true, input ~= 0
         end
 
-        return false, 'boolean setting type requires the input to be either a boolean, number or string that can be transformed to a boolean.'
+        return false, {'redmew_settings.boolean_invalid_value'}
     end,
 }
 
@@ -87,8 +87,8 @@ Public.types = {fraction = 'fraction', string = 'string', boolean = 'boolean'}
 ---
 ---@param name string
 ---@param setting_type string
----@param default mixed
-function Public.register(name, setting_type, default)
+---@param default any
+function Public.register(name, setting_type, default, localisation_key)
     if _LIFECYCLE ~= _STAGE.control then
         error(format('You can only register setting names in the control stage, i.e. not inside events. Tried setting "%s" with type "%s".', name, setting_type), 2)
     end
@@ -103,13 +103,33 @@ function Public.register(name, setting_type, default)
     end
 
     local setting = {
+        type = setting_type,
         default = default,
         callback = callback,
+        localisation_key = localisation_key,
     }
 
     settings[name] = setting
 
     return setting
+end
+
+---Validates whether a given value is valid for a given setting.
+---@param name string
+---@param value any
+function Public.validate(name, value)
+    local setting = settings[name]
+    if not setting then
+        return format('Setting "%s" does not exist.', name)
+    end
+
+    local success, sanitized_value = setting.callback(value)
+
+    if not success then
+        return sanitized_value
+    end
+
+    return nil
 end
 
 ---Sets a setting to a specific value for a player.
@@ -118,11 +138,11 @@ end
 ---
 ---@param player_index number
 ---@param name string
----@param value mixed
+---@param value any
 function Public.set(player_index, name, value)
     local setting = settings[name]
     if not setting then
-        return error(format('Setting "%s" does not exist.', name), 2)
+        error(format('Setting "%s" does not exist.', name), 2)
     end
 
     local success, sanitized_value = setting.callback(value)
@@ -173,6 +193,12 @@ function Public.all(player_index)
     end
 
     return output
+end
+
+---Returns the full settings data, note that this is a reference, do not modify
+---this data unless you know what you're doing!
+function Public.get_setting_metadata()
+    return settings
 end
 
 return Public

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -106,7 +106,7 @@ function Public.register(name, setting_type, default, localisation_key)
         type = setting_type,
         default = default,
         callback = callback,
-        localisation_key = localisation_key,
+        localised_string = localisation_key and {localisation_key} or name,
     }
 
     settings[name] = setting

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -88,6 +88,7 @@ Public.types = {fraction = 'fraction', string = 'string', boolean = 'boolean'}
 ---@param name string
 ---@param setting_type string
 ---@param default any
+---@param localisation_key|table
 function Public.register(name, setting_type, default, localisation_key)
     if _LIFECYCLE ~= _STAGE.control then
         error(format('You can only register setting names in the control stage, i.e. not inside events. Tried setting "%s" with type "%s".', name, setting_type), 2)

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -12,7 +12,7 @@ local settings_type = {
         input = tonumber(input)
 
         if input == nil then
-            return false, {'redmew_settings.fraction_invalid_value'}
+            return false, {'redmew_settings_util.fraction_invalid_value'}
         end
 
         if input < 0 then
@@ -39,7 +39,7 @@ local settings_type = {
             return true, tostring(input)
         end
 
-        return false, {'redmew_settings.string_invalid_value'}
+        return false, {'redmew_settings_util.string_invalid_value'}
     end,
     boolean = function (input)
         local input_type = type(input)
@@ -63,7 +63,7 @@ local settings_type = {
             return true, input ~= 0
         end
 
-        return false, {'redmew_settings.boolean_invalid_value'}
+        return false, {'redmew_settings_util.boolean_invalid_value'}
     end,
 }
 


### PR DESCRIPTION
While waiting for the data from the server:
![image](https://user-images.githubusercontent.com/1754678/53701649-8cd16a00-3dff-11e9-962c-aa04f40dd6c6.png)

When loaded:
![image](https://user-images.githubusercontent.com/1754678/53701654-9c50b300-3dff-11e9-86a1-8ae5dde0c537.png)

![image](https://user-images.githubusercontent.com/1754678/53701656-a2df2a80-3dff-11e9-80be-44930d1c5e74.png)

![image](https://user-images.githubusercontent.com/1754678/53701660-abcffc00-3dff-11e9-87f3-3fa766704fb3.png)

With some dummy fields and error message:
![image](https://user-images.githubusercontent.com/1754678/53701672-bf7b6280-3dff-11e9-87b9-b3c9ba9c38a3.png)

Messages send to and from the server:
```
[DATA-GET]31 {data_set:"player_settings",key:"plague006"}
[DATA-SET]{data_set:"player_settings",key:"plague006",value:'{["toast-volume"]=0}'}
```

