### PR TITLE
Add quick bar saving

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -357,6 +357,10 @@ global.config = {
             -- whether to only attack on the first launch
             first_launch_only = true
         }
+    },
+    -- allows the saving and automatic loading of quickbars between maps
+    player_quick_bars = {
+        enabled = true
     }
 }
 

--- a/control.lua
+++ b/control.lua
@@ -92,6 +92,9 @@ end
 if config.biter_attacks then
     require 'map_gen.shared.biter_attacks'
 end
+if config.player_quick_bars.enabled then
+    require 'features.player_quick_bars'
+end
 
 -- GUIs
 -- The order determines the order they appear from left to right.

--- a/features/player_quick_bars.lua
+++ b/features/player_quick_bars.lua
@@ -47,17 +47,6 @@ local function save_bars(_, player)
     Game.player_print({'player_quick_bars.save_bars'}, Color.success)
 end
 
---- Erases server-side data stored for this player's quickbar_slots
-local function reset_bars(_, player)
-    if not primitives.server_available then
-        Game.player_print({'common.server_unavailable'}, Color.fail)
-        return
-    end
-
-    Server.set_data(data_set_name, player.name, nil)
-    Game.player_print({'player_quick_bars.reset_bars'}, Color.success)
-end
-
 --- Returns a valid entity prototype string name or nil.
 -- For invalid items, a message will be printed to the player.
 local function validate_entry(item, proto_table, player)
@@ -109,7 +98,7 @@ local function load_bars(_, player)
     Game.player_print({'player_quick_bars.load_bars'})
 end
 
-local player_join =
+local player_created =
     Token.register(
     function(event)
         local p = game.get_player(event.player_index)
@@ -122,16 +111,27 @@ local player_join =
 )
 
 --- Registers the event only when the server is available.
-local function register_player_join()
+local function register_player_create()
     if not primitives.server_available then
-        Event.add_removable(defines.events.on_player_joined_game, player_join)
+        Event.add_removable(defines.events.on_player_created, player_created)
         primitives.server_available = true
     end
 end
 
+--- Erases server-side data stored for this player's quickbar_slots
+local function delete_bars(_, player)
+    if not primitives.server_available then
+        Game.player_print({'common.server_unavailable'}, Color.fail)
+        return
+    end
+
+    Server.set_data(data_set_name, player.name, nil)
+    Game.player_print({'player_quick_bars.delete_bars'}, Color.success)
+end
+
 -- Events
 
-Event.add(Server.events.on_server_started, register_player_join)
+Event.add(Server.events.on_server_started, register_player_create)
 
 -- Commands
 
@@ -159,5 +159,5 @@ Command.add(
         description = {'command_description.quick_bar_delete'},
         required_rank = Ranks.regular
     },
-    reset_bars
+    delete_bars
 )

--- a/features/player_quick_bars.lua
+++ b/features/player_quick_bars.lua
@@ -1,0 +1,163 @@
+-- This module saves players' action bars between maps
+-- Dependencies
+local Command = require 'utils.command'
+local Event = require 'utils.event'
+local Game = require 'utils.game'
+local Global = require 'utils.global'
+local Server = require 'features.server'
+local Token = require 'utils.token'
+local Color = require 'resources.color_presets'
+local Ranks = require 'resources.ranks'
+
+-- Constants
+local data_set_name = 'player_quick_bars'
+local quickbar_slots = 100
+
+-- Localized globals
+local primitives = {
+    server_available = nil
+}
+
+Global.register(
+    {
+        primitives = primitives
+    },
+    function(tbl)
+        primitives = tbl.primitives
+    end
+)
+
+--- Scans all quickbar_slots into a table, then saves that table server-side
+local function save_bars(_, player)
+    if not primitives.server_available then
+        Game.player_print({'common.server_unavailable'}, Color.fail)
+        return
+    end
+
+    local bars = {}
+
+    for i = 1, quickbar_slots do
+        local item_prot = player.get_quick_bar_slot(i)
+        if item_prot then
+            bars[i] = item_prot.name
+        end
+    end
+
+    Server.set_data(data_set_name, player.name, bars)
+    Game.player_print({'player_quick_bars.save_bars'}, Color.success)
+end
+
+--- Erases server-side data stored for this player's quickbar_slots
+local function reset_bars(_, player)
+    if not primitives.server_available then
+        Game.player_print({'common.server_unavailable'}, Color.fail)
+        return
+    end
+
+    Server.set_data(data_set_name, player.name, nil)
+    Game.player_print({'player_quick_bars.reset_bars'}, Color.success)
+end
+
+--- Returns a valid entity prototype string name or nil.
+-- For invalid items, a message will be printed to the player.
+local function validate_entry(item, proto_table, player)
+    if not item then
+        return
+    end
+
+    if proto_table[item] then
+        return item
+    end
+
+    player.print({'player_quick_bars.incompatible_item', item}, Color.warning)
+end
+
+--- Sets the quick bars of a player.
+local set_bars_callback =
+    Token.register(
+    function(data)
+        local bars = data.value -- will be nil if no data
+        if not bars then
+            return
+        end
+
+        local p_name = data.key
+        local player = game.get_player(p_name)
+        if not player or not player.valid then
+            return
+        end
+
+        local item_prototypes = game.item_prototypes
+        local item
+        for i = 1, quickbar_slots do
+            item = validate_entry(bars[i], item_prototypes, player)
+            if item then
+                player.set_quick_bar_slot(i, item)
+            end
+        end
+    end
+)
+
+--- Calls data from the server and sends it to the set_bars_callback
+local function load_bars(_, player)
+    if not primitives.server_available then
+        Game.player_print({'common.server_unavailable'}, Color.fail)
+        return
+    end
+
+    Server.try_get_data(data_set_name, player.name, set_bars_callback)
+    Game.player_print({'player_quick_bars.load_bars'})
+end
+
+local player_join =
+    Token.register(
+    function(event)
+        local p = game.get_player(event.player_index)
+        if not p or not p.valid then
+            return
+        end
+
+        Server.try_get_data(data_set_name, p.name, set_bars_callback)
+    end
+)
+
+--- Registers the event only when the server is available.
+local function register_player_join()
+    if not primitives.server_available then
+        Event.add_removable(defines.events.on_player_joined_game, player_join)
+        primitives.server_available = true
+    end
+end
+
+-- Events
+
+Event.add(Server.events.on_server_started, register_player_join)
+
+-- Commands
+
+Command.add(
+    'quick-bar-save',
+    {
+        description = {'command_description.quick_bar_save'},
+        required_rank = Ranks.regular
+    },
+    save_bars
+)
+
+Command.add(
+    'quick-bar-load',
+    {
+        description = {'command_description.quick_bar_load'},
+        required_rank = Ranks.regular
+    },
+    load_bars
+)
+
+Command.add(
+    'quick-bar-delete',
+    {
+        description = {'command_description.quick_bar_delete'},
+        required_rank = Ranks.regular
+    },
+    reset_bars
+)

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -61,6 +61,9 @@ invoke=Teleports the player to you.
 tp=If blank, teleport to selected entity. mode = toggle tp mode where you can teleport to a placed ghost. player = teleport to player.
 revive_ghosts=Revives the ghosts within the provided radius around you
 destroy=Destroys the entity under your cursor when you run this command
+quick_bar_save=Saves your action bars server-side for future maps.
+quick_bar_load=Loads your action bars server-side.
+quick_bar_delete=Erases your action bars saved server-side.
 
 [command_custom_help]
 tp=<blank|mode|player> 3 different uses: "/tp" to tp to selected entity. "/tp mode" to toggle tp mode. "/tp Newcott" to tp to Newcott.

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -61,9 +61,9 @@ invoke=Teleports the player to you.
 tp=If blank, teleport to selected entity. mode = toggle tp mode where you can teleport to a placed ghost. player = teleport to player.
 revive_ghosts=Revives the ghosts within the provided radius around you
 destroy=Destroys the entity under your cursor when you run this command
-quick_bar_save=Saves your action bars server-side for future maps.
-quick_bar_load=Loads your action bars server-side.
-quick_bar_delete=Erases your action bars saved server-side.
+quick_bar_save=Saves your quick bars server-side for future maps
+quick_bar_load=Loads your quick bars from the server (overwriting existing bars)
+quick_bar_delete=Erases your saved quick bars from the server
 
 [command_custom_help]
 tp=<blank|mode|player> 3 different uses: "/tp" to tp to selected entity. "/tp mode" to toggle tp mode. "/tp Newcott" to tp to Newcott.

--- a/locale/en/redmew_common.cfg
+++ b/locale/en/redmew_common.cfg
@@ -4,6 +4,7 @@
 fail_no_target=No player found with name: __1__
 warn_no_target=Warning: player __1__ is not found, but the command will still be executed.
 close_button=Close
+server_unavailable=The server is currently unavailable.
 
 [ranks]
 probation=Probation

--- a/locale/en/redmew_features.cfg
+++ b/locale/en/redmew_features.cfg
@@ -109,3 +109,9 @@ teach_chat=To chat with other players, press the __CONTROL__toggle-console__ key
 first_rocket_launch_attack=The ground rumbles as the first rocket is launched.. But there's more.. The rocket is out of sight but the ground continues to tremble. An attack is coming, bigger than any previous.
 rocket_launch_attack=The locals launch another attack as our next rocket takes off.
 biter_command_success=An attack against __1__ has been ordered.
+
+[player_quick_bars]
+save_bars=Your quick bars have been saved to the server.
+load_bars=Attempting to load bars from server...
+delete_bars=Saved data has been removed from the server.
+incompatible_item=Incompatible item found in saved date and will not be loaded: __1__


### PR DESCRIPTION
Restores quick bars between maps automatically.

Saves or removes quick bar storage via commands.

Only registers the event hook if the server is (or was ever) present.

Closes #822 