### PR TITLE
Validity check in paint

### DIFF
--- a/features/gui/paint.lua
+++ b/features/gui/paint.lua
@@ -200,6 +200,10 @@ Gui.on_click(
     filter_element_name,
     function(event)
         local element = event.element
+        if not element or not element.valid then
+            return
+        end
+
         local frame = Gui.get_data(element)
         local filter_button = Gui.get_data(frame)
 


### PR DESCRIPTION
In response to error:
```
(Server time: 2019-03-08 22:07:29)
Time of error: 1 hour 41 minutes
RedMew version: Time of map launch: 2019-03-08 20:25:23 UTC
LuaGuiElement API call when LuaGuiElement was invalid.
stack traceback:
	/factorio/2/temp/currently-playing/features/gui/paint.lua:207: in function 'handler'
	/factorio/2/temp/currently-playing/utils/gui.lua:97: in function </factorio/2/temp/currently-playing/utils/gui.lua:80>
	[C]: in function 'pcall'
	/factorio/2/temp/currently-playing/utils/event_core.lua:33: in function 'call_handlers'
	/factorio/2/temp/currently-playing/utils/event_core.lua:44: in function </factorio/2/temp/currently-playing/utils/event_core.lua:42>
```