### PR TITLE
hail_hydra

### DIFF
--- a/map_gen/shared/hail_hydra.lua
+++ b/map_gen/shared/hail_hydra.lua
@@ -143,7 +143,7 @@ local on_died =
                 local spawned = create_entity({name = hydra_spawn, force = force, position = position})
                 if spawned and spawned.type == 'unit' then
                     spawned.set_command(command)
-                elseif spawned and cause and cause.valid and cause.force then
+                elseif spawned and spawned.type == 'turret' and cause and cause.valid and cause.force then
                     spawned.shooting_target = cause
                 end
             end


### PR DESCRIPTION
validity check on type == "turret" for spawned entities

I'm sorry - I made a booboo when renaming my local dev branches.