### PR TITLE
Recursive event_name for Event

### DIFF
--- a/utils/game.lua
+++ b/utils/game.lua
@@ -50,7 +50,7 @@ end
 function Game.get_player_from_any(obj)
     local o_type = type(obj)
     local p
-    if type == 'number' then
+    if o_type == 'number' then
         p = Game.get_player_by_index(obj)
     elseif o_type == 'string' then
         p = game.players[obj]


### PR DESCRIPTION
Some context: while switching over to use the Redmew utils I found a feature that is very useful but was not yet implemented so I made this pull request.

Changes:
- All functions in Event which accept event_name as a parameter will now accept an array of event names.
- All functions in Event which accept event_name as a parameter will now accept the name of an event `'on_tick'` as well as the define of the event `defines.events.on_tick`.
- When a non number value (or a string that resolves to a number see above) is given as the event_name then an error will be thrown.

Note: No changes have been made to event_core; and changes have only been made to function which accept event_name as a parameter within the Event module.

Test Code:
```lua
local Event = require 'utils.event'
-- Test for recursion
Event.add({
        defines.events.on_built_entity,
        defines.events.on_robot_built_entity,
        defines.events.script_raised_built
    },
    function(event)
        game.print(serpent.block(event)) -- prints the content of the event table to console.
    end
)
-- Test for string as event_name
Event.add({
        'on_built_entity',
        'on_robot_built_entity',
        'script_raised_built'
    },
    function(event)
        game.print(serpent.block(event)) -- prints the content of the event table to console.
    end
)
```