### PR TITLE
Settings are now synced via Setting.set instead

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -365,6 +365,10 @@ global.config = {
     -- enables the redmew settings GUI
     redmew_settings = {
         enabled = true
+    },
+    -- enables syncing settings to the server
+    redmew_settings_sync = {
+        enabled = true
     }
 }
 

--- a/config.lua
+++ b/config.lua
@@ -365,10 +365,6 @@ global.config = {
     -- enables the redmew settings GUI
     redmew_settings = {
         enabled = true
-    },
-    -- enables syncing settings to the server
-    redmew_settings_sync = {
-        enabled = true
     }
 }
 

--- a/control.lua
+++ b/control.lua
@@ -95,6 +95,9 @@ end
 if config.player_quick_bars.enabled then
     require 'features.player_quick_bars'
 end
+if config.redmew_settings_sync.enabled then
+    require 'features.redmew_settings_sync'
+end
 
 -- GUIs
 -- The order determines the order they appear from left to right.

--- a/control.lua
+++ b/control.lua
@@ -26,6 +26,7 @@ require 'features.server_commands'
 -- If missing, will cause other feature modules to fail
 require 'features.player_create'
 require 'features.rank_system'
+require 'features.redmew_settings_sync'
 
 -- Feature modules
 -- Each can be disabled safely
@@ -94,9 +95,6 @@ if config.biter_attacks.enabled then
 end
 if config.player_quick_bars.enabled then
     require 'features.player_quick_bars'
-end
-if config.redmew_settings_sync.enabled then
-    require 'features.redmew_settings_sync'
 end
 
 -- GUIs

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -213,7 +213,6 @@ local function save_changes(event)
     end
 
     Toast.toast_player(player, 5, {'redmew_settings_gui.save_success_toast_message'})
-    Server.set_data('player_settings', player.name, Settings.all(player_index))
 
     local main_frame = player.gui.center[main_frame_name]
 

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -2,7 +2,6 @@ local Gui = require 'utils.gui'
 local Event = require 'utils.event'
 local Toast = require 'features.gui.toast'
 local Settings = require 'utils.redmew_settings'
-local SettingsSync = require 'features.redmew_settings_sync'
 local Color = require 'resources.color_presets'
 local pairs = pairs
 
@@ -22,8 +21,7 @@ local function player_created(event)
         type = 'sprite-button',
         name = main_button_name,
         sprite = 'item/iron-gear-wheel',
-        tooltip = {'redmew_settings_gui.tooltip_loading'},
-        enabled = false,
+        tooltip = {'redmew_settings_gui.tooltip'}
     })
 end
 
@@ -38,10 +36,6 @@ local function player_joined(event)
     if main_frame then
         Gui.destroy(main_frame)
     end
-
-    local button = player.gui.top[main_button_name]
-    button.tooltip = {'redmew_settings_gui.tooltip_loading'}
-    button.enabled = false
 end
 
 local function get_element_value(element)
@@ -53,6 +47,21 @@ local function get_element_value(element)
     end
     if element.type == 'checkbox' then
         return element.state
+    end
+end
+
+local function set_element_value(element, value)
+    if element.type == 'text-box' then
+        element.text = value
+        return
+    end
+    if element.type == 'slider' then
+        element.slider_value = value
+        return
+    end
+    if element.type == 'checkbox' then
+        element.state = value
+        return
     end
 end
 
@@ -128,6 +137,7 @@ local function draw_main_frame(center, player)
     save_button.style = 'confirm_button'
 
     Gui.set_data(save_button, data)
+    Gui.set_data(settings_frame, data)
 
     player.opened = settings_frame
 end
@@ -192,10 +202,41 @@ local function save_changes(event)
     end
 end
 
-local function synced_from_server(event)
-    local button = event.player.gui.top[main_button_name]
-    button.tooltip = {'redmew_settings_gui.tooltip'}
-    button.enabled = true
+local function setting_set(event)
+    local setting = event.setting
+    if not setting.value_changed then
+        return
+    end
+
+    local player = game.get_player(setting.player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    local main_frame = player.gui.center[main_frame_name]
+    if not main_frame or not main_frame.valid then
+        return
+    end
+
+    local data = Gui.get_data(main_frame)
+    if not data then
+        return
+    end
+
+    local setting_name = setting.name
+    local element_data = data[setting_name]
+
+    if not element_data then
+        return
+    end
+
+    local input = element_data.input
+    if not input or not input.valid then
+        -- for some reason it has been removed already
+        return
+    end
+    set_element_value(input, setting.new_value)
+    element_data.previous_value = setting.old_value
 end
 
 Gui.on_custom_close(main_frame_name, function(event)
@@ -208,6 +249,6 @@ Gui.on_click(main_button_name, toggle)
 Gui.on_click(save_changes_button_name, save_changes)
 Event.add(defines.events.on_player_created, player_created)
 Event.add(defines.events.on_player_joined_game, player_joined)
-Event.add(SettingsSync.events.on_synced_from_server, synced_from_server)
+Event.add(Settings.events.on_setting_set, setting_set)
 
 return Public

--- a/features/redmew_settings_sync.lua
+++ b/features/redmew_settings_sync.lua
@@ -5,11 +5,34 @@ local Schedule = require 'utils.task'
 local Server = require 'features.server'
 local Settings = require 'utils.redmew_settings'
 local set_timeout_in_ticks = Schedule.set_timeout_in_ticks
+local pairs = pairs
+local raise_event = script.raise_event
 
 local Public = {}
 
+Public.events = {
+    --- Triggered when the settings are synced back from the server
+    -- Event {
+    --     player = player
+    -- }
+    on_synced_to_server = Event.generate_event_name('on_synced_to_server'),
+
+    --- Triggered when the settings are synced back from the server
+    --- keeps track of whether or not it's cancelled
+    -- Event {
+    --     player = player
+    --     cancelled = cancelled
+    -- }
+    on_synced_from_server = Event.generate_event_name('on_synced_from_server'),
+}
+
+
 local memory = {
+    -- when already scheduled, no new schedules have to be added
     sync_scheduled = false,
+
+    -- when locked it won't schedule anything to prevent recursion syncing back to server
+    locked = false,
 }
 
 local do_sync_settings_to_server -- token
@@ -17,10 +40,6 @@ local do_sync_settings_to_server -- token
 Global.register(memory, function (tbl) memory = tbl end)
 
 local function schedule_sync_to_server(player_index)
-    if memory.sync_scheduled then
-        return
-    end
-
     set_timeout_in_ticks(1, do_sync_settings_to_server, {
         player_index = player_index
     })
@@ -39,11 +58,14 @@ do_sync_settings_to_server = Token.register(function(params)
 
     -- mark it as updated
     memory.sync_scheduled = false
+
+    raise_event(Public.events.on_synced_to_server, {
+        player = player
+    })
 end)
 
 local function setting_set(event)
-    if memory.sync_scheduled then
-        -- no need to determine if something should be set, already scheduled
+    if memory.locked or memory.sync_scheduled then
         return
     end
 
@@ -56,6 +78,49 @@ local function setting_set(event)
     schedule_sync_to_server(setting.player_index)
 end
 
+local on_player_settings_get = Token.register(function (data)
+    local player = game.get_player(data.key)
+    if not player or not player.valid then
+        return
+    end
+
+    if data.cancelled then
+        raise_event(Public.events.on_synced_from_server, {
+            player = player,
+            cancelled = true
+        })
+        return
+    end
+
+    local settings = data.value
+
+    if settings ~= nil then
+        -- temporarily lock the sync so it won't sync from server to client to server
+        -- as this would cause recursion
+        memory.locked = true
+        local player_index = player.index
+        for key, value in pairs(settings) do
+            Settings.set(player_index, key, value)
+        end
+        memory.locked = false
+    end
+
+    raise_event(Public.events.on_synced_from_server, {
+        player = player,
+        cancelled = false
+    })
+end)
+
+local function player_joined(event)
+    local player = game.get_player(event.player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    Server.try_get_data_timeout('player_settings', player.name, on_player_settings_get, 30)
+end
+
 Event.add(Settings.events.on_setting_set, setting_set);
+Event.add(defines.events.on_player_joined_game, player_joined)
 
 return Public

--- a/features/redmew_settings_sync.lua
+++ b/features/redmew_settings_sync.lua
@@ -1,0 +1,61 @@
+local Global = require 'utils.global'
+local Event = require 'utils.event'
+local Token = require 'utils.token'
+local Schedule = require 'utils.task'
+local Server = require 'features.server'
+local Settings = require 'utils.redmew_settings'
+local set_timeout_in_ticks = Schedule.set_timeout_in_ticks
+
+local Public = {}
+
+local memory = {
+    sync_scheduled = false,
+}
+
+local do_sync_settings_to_server -- token
+
+Global.register(memory, function (tbl) memory = tbl end)
+
+local function schedule_sync_to_server(player_index)
+    if memory.sync_scheduled then
+        return
+    end
+
+    set_timeout_in_ticks(1, do_sync_settings_to_server, {
+        player_index = player_index
+    })
+    memory.sync_scheduled = true
+end
+
+do_sync_settings_to_server = Token.register(function(params)
+    local player_index = params.player_index;
+    local player = game.get_player(player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    -- do update
+    Server.set_data('player_settings', player.name, Settings.all(player_index))
+
+    -- mark it as updated
+    memory.sync_scheduled = false
+end)
+
+local function setting_set(event)
+    if memory.sync_scheduled then
+        -- no need to determine if something should be set, already scheduled
+        return
+    end
+
+    local setting = event.setting
+    if setting.old_value == setting.new_value then
+        -- setting value has not been changed, ignore
+        return
+    end
+
+    schedule_sync_to_server(setting.player_index)
+end
+
+Event.add(Settings.events.on_setting_set, setting_set);
+
+return Public

--- a/features/redmew_settings_sync.lua
+++ b/features/redmew_settings_sync.lua
@@ -11,7 +11,7 @@ local raise_event = script.raise_event
 local Public = {}
 
 Public.events = {
-    --- Triggered when the settings are synced back from the server
+    --- Triggered when the settings are synced back to the server
     -- Event {
     --     player = player
     -- }
@@ -70,8 +70,7 @@ local function setting_set(event)
     end
 
     local setting = event.setting
-    if setting.old_value == setting.new_value then
-        -- setting value has not been changed, ignore
+    if not setting.value_changed then
         return
     end
 

--- a/locale/en/redmew_gui.cfg
+++ b/locale/en/redmew_gui.cfg
@@ -45,7 +45,6 @@ whats_new_button=What's New
 
 [redmew_settings_gui]
 tooltip=Your RedMew settings
-tooltip_loading=Loading your personal settings...
 save_success_toast_message=Your settings have been updated!
 frame_title=Redmew Settings
 button_cancel=Cancel

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -78,11 +78,13 @@ local Public = {}
 
 Public.events = {
     --- Triggered when a setting is set or updated. Old value may be null if never set before
+    --- if the value hasn't changed, value_changed = false
     -- Event {
     --        name = name,
     --        old_value = old_value,
     --        new_value = new_value,
     --        player_index = player_index,
+    --        value_changed = value_changed
     --    }
     on_setting_set = Event.generate_event_name('on_setting_set'),
 }
@@ -180,6 +182,7 @@ function Public.set(player_index, name, value)
             old_value = old_value,
             new_value = sanitized_value,
             player_index = player_index,
+            value_changed = old_value ~= sanitized_value
         }
     })
 


### PR DESCRIPTION
This change will introduce a setting syncer that is responsible for syncing settings in the background from and to the server (if available). This means no code will have to depend on the `Server` in order to act upon changed settings from a certain location.