### PR TITLE
setting set should not nest the setting in the event

### DIFF
--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -203,12 +203,11 @@ local function save_changes(event)
 end
 
 local function setting_set(event)
-    local setting = event.setting
-    if not setting.value_changed then
+    if not event.value_changed then
         return
     end
 
-    local player = game.get_player(setting.player_index)
+    local player = game.get_player(event.player_index)
     if not player or not player.valid then
         return
     end
@@ -223,8 +222,7 @@ local function setting_set(event)
         return
     end
 
-    local setting_name = setting.name
-    local element_data = data[setting_name]
+    local element_data = data[event.setting_name]
 
     if not element_data then
         return
@@ -235,8 +233,8 @@ local function setting_set(event)
         -- for some reason it has been removed already
         return
     end
-    set_element_value(input, setting.new_value)
-    element_data.previous_value = setting.old_value
+    set_element_value(input, event.new_value)
+    element_data.previous_value = event.old_value
 end
 
 Gui.on_custom_close(main_frame_name, function(event)

--- a/features/redmew_settings_sync.lua
+++ b/features/redmew_settings_sync.lua
@@ -69,12 +69,11 @@ local function setting_set(event)
         return
     end
 
-    local setting = event.setting
-    if not setting.value_changed then
+    if not event.value_changed then
         return
     end
 
-    schedule_sync_to_server(setting.player_index)
+    schedule_sync_to_server(event.player_index)
 end
 
 local on_player_settings_get = Token.register(function (data)

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -205,7 +205,11 @@ function Public.get(player_index, name)
     end
 
     local player_setting = player_settings[name]
-    return player_setting ~= nil and player_setting or setting.default
+    if player_setting == nil then
+        return setting.default
+    end
+
+    return player_setting
 end
 
 ---Returns a table of all settings for a given player in a key => value setup
@@ -214,7 +218,12 @@ function Public.all(player_index)
     local player_settings = memory[player_index] or {}
     local output = {}
     for name, data in pairs(settings) do
-        output[name] = player_settings[name] or data.default
+        local setting_value = player_settings[name]
+        if setting_value == nil then
+            output[name] = data.default
+        else
+            output[name] = setting_value
+        end
     end
 
     return output

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -80,7 +80,7 @@ Public.events = {
     --- Triggered when a setting is set or updated. Old value may be null if never set before
     --- if the value hasn't changed, value_changed = false
     -- Event {
-    --        name = name,
+    --        setting_name = setting_name,
     --        old_value = old_value,
     --        new_value = new_value,
     --        player_index = player_index,
@@ -177,13 +177,11 @@ function Public.set(player_index, name, value)
     player_settings[name] = sanitized_value
 
     raise_event(Public.events.on_setting_set, {
-        setting = {
-            name = name,
-            old_value = old_value,
-            new_value = sanitized_value,
-            player_index = player_index,
-            value_changed = old_value ~= sanitized_value
-        }
+        setting_name = name,
+        old_value = old_value,
+        new_value = sanitized_value,
+        player_index = player_index,
+        value_changed = old_value ~= sanitized_value
     })
 
     return sanitized_value


### PR DESCRIPTION
`event.settings` values are now integrated into `event` directly and `event.setting.name` is now `event.setting_name`