### PR TITLE
Schedule setting syncs per player, not globally

### DIFF
--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -71,6 +71,11 @@ local settings_type = {
 
 local settings = {}
 local memory = {}
+local raw_callback_setting = {
+    callback = function (input)
+        return true, input
+    end
+}
 
 Global.register(memory, function (tbl) memory = tbl end)
 
@@ -158,11 +163,7 @@ end
 function Public.set(player_index, name, value)
     local setting = settings[name]
     if not setting then
-        setting = {
-            callback = function (input)
-                return true, input
-            end
-        }
+        setting = raw_callback_setting
     end
 
     local success, sanitized_value = setting.callback(value)


### PR DESCRIPTION
Previously if multiple players had their settings updated in a single update, only the first would get updated. Also fixes a backwards compatibility issue where never settings would get overwritten and made it possible to unset a setting, which would otherwise be kept in storage until eternity. The added benefit of this would be a "reset" button for settings, putting everything back to the game defaults.