### PR TITLE
Replaced command for player and chat colors

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -44,6 +44,11 @@ global.config = {
         time_for_trust = 3 * 60 * 60 * 60, -- 3 hours
         everyone_is_regular = false
     },
+    -- allows syncing player colors from and to the server. Disable this if you want to enforce custom colors
+    -- when enabled, /color will also be synced to the player settings
+    player_colors = {
+        enabled = true,
+    },
     -- saves players' lives if they have a small-plane in their inventory, also adds the small-plane to the market and must therefor be loaded first
     train_saviour = {
         enabled = true

--- a/config.lua
+++ b/config.lua
@@ -276,9 +276,6 @@ global.config = {
     donator_commands = {
         enabled = true
     },
-    player_colors = {
-        enabled = true
-    },
     -- adds a command to generate a popup dialog box for players to see, useful for important announcements
     popup = {
         enabled = true

--- a/control.lua
+++ b/control.lua
@@ -27,7 +27,10 @@ require 'features.server_commands'
 require 'features.player_create'
 require 'features.rank_system'
 require 'features.redmew_settings_sync'
-require 'features.player_colors'
+
+if config.player_colors.enabled then
+    require 'features.player_colors'
+end
 
 -- Feature modules
 -- Each can be disabled safely

--- a/control.lua
+++ b/control.lua
@@ -27,6 +27,7 @@ require 'features.server_commands'
 require 'features.player_create'
 require 'features.rank_system'
 require 'features.redmew_settings_sync'
+require 'features.player_colors'
 
 -- Feature modules
 -- Each can be disabled safely
@@ -59,9 +60,6 @@ if config.market.enabled then
 end
 if config.nuke_control.enabled then
     require 'features.nuke_control'
-end
-if config.player_colors.enabled then
-    require 'features.player_colors'
 end
 if config.reactor_meltdown.enabled then
     require 'features.reactor_meltdown'

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -123,7 +123,7 @@ local function draw_main_frame(center, player)
         label_style.height = 35
         label_style.vertical_align = 'center'
 
-        local value = Settings.get(player_index, name)
+        local value = Settings.toScalar(name, Settings.get(player_index, name))
         local input_container = setting_grid.add({type = 'flow'})
         local input_container_style = input_container.style
         input_container_style.height = 35
@@ -238,7 +238,8 @@ local function setting_set(event)
         return
     end
 
-    local element_data = data[event.setting_name]
+    local setting_name = event.setting_name
+    local element_data = data[setting_name]
 
     if not element_data then
         return
@@ -249,8 +250,8 @@ local function setting_set(event)
         -- for some reason it has been removed already
         return
     end
-    set_element_value(input, event.new_value)
-    element_data.previous_value = event.old_value
+    set_element_value(input, Settings.toScalar(setting_name, event.new_value))
+    element_data.previous_value = Settings.toScalar(setting_name, event.old_value)
 end
 
 Gui.on_custom_close(main_frame_name, function(event)

--- a/features/player_colors.lua
+++ b/features/player_colors.lua
@@ -81,16 +81,13 @@ local function on_command(event)
         return
     end
 
-    local color = event.parameters
-    local error = Settings.validate(player_color_name, color)
-    if error then
-        player.print(error, Color.fail)
-        return
-    end
-
     player.print({'player_colors.gui_setting_reference_message'}, Color.success)
-    Settings.set(player_index, player_color_name, color)
-    Settings.set(player_index, player_chat_color_name, color)
+    Settings.set(player_index, player_color_name, player.color)
+
+    local error = Settings.validate(player_chat_color_name, player.chat_color)
+    if not error then
+        Settings.set(player_index, player_chat_color_name, player.chat_color)
+    end
 end
 
 Event.add(defines.events.on_player_joined_game, player_joined_game)

--- a/features/player_colors.lua
+++ b/features/player_colors.lua
@@ -2,6 +2,7 @@ local Event = require 'utils.event'
 local Server = require 'features.server'
 local Token = require 'utils.token'
 local Settings = require 'utils.redmew_settings'
+local Color = require 'resources.color_presets'
 
 local player_color_name = 'player-color'
 local player_chat_color_name = 'player-chat-color'
@@ -69,7 +70,31 @@ local function player_joined_game(event)
     Server.try_get_data('colors', player.name, color_callback)
 end
 
+local function on_command(event)
+    local player_index = event.player_index
+    if not player_index or event.command ~= 'color' then
+        return
+    end
+
+    local player = game.get_player(player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    local color = event.parameters
+    local error = Settings.validate(player_color_name, color)
+    if error then
+        player.print(error, Color.fail)
+        return
+    end
+
+    player.print({'player_colors.gui_setting_reference_message'}, Color.success)
+    Settings.set(player_index, player_color_name, color)
+    Settings.set(player_index, player_chat_color_name, color)
+end
+
 Event.add(defines.events.on_player_joined_game, player_joined_game)
 Event.add(Settings.events.on_setting_set, setting_set)
+Event.add(defines.events.on_console_command, on_command)
 
 return Public

--- a/features/player_colors.lua
+++ b/features/player_colors.lua
@@ -7,7 +7,7 @@ local Color = require 'resources.color_presets'
 local player_color_name = 'player-color'
 local player_chat_color_name = 'player-chat-color'
 Settings.register(player_color_name, Settings.types.color, nil, 'player_colors.player_color_setting_label')
-Settings.register(player_chat_color_name, Settings.types.color, nil, 'player_colors.player_chat_color_setting_label')
+Settings.register(player_chat_color_name, Settings.types.chat_color, nil, 'player_colors.player_chat_color_setting_label')
 
 local Public = {}
 

--- a/locale/en/redmew_features.cfg
+++ b/locale/en/redmew_features.cfg
@@ -82,6 +82,7 @@ color_random=Your color has been changed to: __1__
 fail_wrong_argument=Only set, reset, and random are accepted arguments
 player_color_setting_label=Character color
 player_chat_color_setting_label=Chat color
+gui_setting_reference_message=Color saved and synchronized to Redmew. You can also use the Redmew Settings (gear icon) to set the character and chat colors.
 
 [performance]
 fail_wrong_argument=Scale must be a valid number ranging from 0.05 to 1

--- a/locale/en/redmew_features.cfg
+++ b/locale/en/redmew_features.cfg
@@ -80,6 +80,8 @@ color_saved_advert=__1__ has saved their color server-side for future maps. You 
 color_reset=Your saved color (if you had one) has been removed.
 color_random=Your color has been changed to: __1__
 fail_wrong_argument=Only set, reset, and random are accepted arguments
+player_color_setting_label=Character color
+player_chat_color_setting_label=Chat color
 
 [performance]
 fail_wrong_argument=Scale must be a valid number ranging from 0.05 to 1

--- a/locale/en/redmew_utils.cfg
+++ b/locale/en/redmew_utils.cfg
@@ -29,8 +29,10 @@ print_admins=__1__(ADMIN) __2__: __3__
 [gui_util]
 button_tooltip=Shows / hides the Redmew Gui buttons.
 
-
 [redmew_settings_util]
 fraction_invalid_value=fraction setting type requires the input to be a valid number between 0 and 1.
 string_invalid_value=string setting type requires the input to be either a valid string or something that can be converted to a string.
 boolean_invalid_value=boolean setting type requires the input to be either a boolean, number or string that can be transformed to a boolean.
+color_invalid_string_value=color setting type requires the input to be either a valid preset such as "red" or "green", or a valid "r g b" or "r g b a" value.
+color_invalid_table_value=color setting type with a table requires a valid {r, g, b} or {r, g, b, a} table with these keys.
+invalid_color_value=color setting type only supports strings or tables as value type.

--- a/locale/en/redmew_utils.cfg
+++ b/locale/en/redmew_utils.cfg
@@ -36,3 +36,4 @@ boolean_invalid_value=boolean setting type requires the input to be either a boo
 color_invalid_string_value=color setting type requires the input to be either a valid preset such as "red" or "green", or a valid "r g b" or "r g b a" value.
 color_invalid_table_value=color setting type with a table requires a valid {r, g, b} or {r, g, b, a} table with these keys.
 invalid_color_value=color setting type only supports strings or tables as value type.
+chat_color_too_dark=chat color is too dark.

--- a/resources/setting_types.lua
+++ b/resources/setting_types.lua
@@ -54,11 +54,17 @@ local function color_sanitizer(input)
             index = index + 1
             if index < 5 then
                 value = tonumber(value)
-                if value == nil or value < 0 or value > 255 then
+                if value == nil then
                     return false, {'redmew_settings_util.color_invalid_string_value'}
                 end
+                if value < 0 then
+                    value = 0
+                end
+                if value > 255 then
+                    value = 255
+                end
 
-                data[color_key_table[index]] = value
+                data[color_key_table[index]] = floor(value * 1000) * 0.001
             end
         end
 
@@ -75,12 +81,12 @@ local function color_sanitizer(input)
         end
 
         local data = {
-            r = input.r,
-            g = input.g,
-            b = input.b
+            r = floor(input.r * 1000) * 0.001,
+            g = floor(input.g * 1000) * 0.001,
+            b = floor(input.b * 1000) * 0.001,
         }
         if input.a then
-            data.a = input.a
+            data.a = floor(input.a * 1000) * 0.001
         end
 
         return true, data

--- a/resources/setting_types.lua
+++ b/resources/setting_types.lua
@@ -6,11 +6,88 @@ local gmatch = string.gmatch
 local pairs = pairs
 local concat = table.concat
 local size = table.size
+local sqrt = math.sqrt
+local floor = math.floor
 
 local color_key_table = {'r', 'g', 'b', 'a'}
 
 local function raw(input)
     return input
+end
+
+local function color_toScalar(input)
+    if type(input) ~= 'table' then
+        return ''
+    end
+
+    local out = {}
+    local i = 0
+    for _, value in pairs(input) do
+        i = i + 1
+        out[i] = value
+    end
+
+    return concat(out, ' ')
+end
+
+--- accepts either a table or a string
+--- string must be in an "r g b" or "r g b a" format
+--- optionally a preset name may be given instead (from resources/color_presets.lua)
+--- table must contain the "r", "g" and "b" keys and may optionally contain an "a" key
+--- the output will always be a valid color table for Factorio
+local function color_sanitizer(input)
+    if input == nil or input == '' then
+        return true, nil
+    end
+
+    local input_type = type(input)
+
+    if input_type == 'string' then
+        local color = Color[input]
+        if color and tonumber(input) == nil then
+            -- we have some numeric keys in there
+            return true, color
+        end
+
+        local data = {}
+        local index = 0
+        for value in gmatch(input, '%S+') do
+            index = index + 1
+            if index < 5 then
+                value = tonumber(value)
+                if value == nil or value < 0 or value > 255 then
+                    return false, {'redmew_settings_util.color_invalid_string_value'}
+                end
+
+                data[color_key_table[index]] = value
+            end
+        end
+
+        if size(data) < 3 then
+            return false, {'redmew_settings_util.color_invalid_string_value'}
+        end
+
+        return true, data
+    end
+
+    if input_type == 'table' then
+        if size(input) > 4 or not input.r or not input.g or not input.b then
+            return false, {'redmew_settings_util.color_invalid_table_value'}
+        end
+
+        local data = {
+            r = input.r,
+            g = input.g,
+            b = input.b
+        }
+        if input.a then
+            data.a = input.a
+        end
+
+        return true, data
+    end
+
+    return false, {'redmew_settings_util.invalid_color_value'}
 end
 
 --- Contains a set of callables that will attempt to sanitize and transform the input
@@ -19,7 +96,7 @@ end
 return {
     fraction = {
         toScalar = raw,
-        sanitizer = function (input)
+        sanitizer = function(input)
             input = tonumber(input)
 
             if input == nil then
@@ -39,7 +116,7 @@ return {
     },
     string = {
         toScalar = raw,
-        sanitizer = function (input)
+        sanitizer = function(input)
             if input == nil then
                 return true, ''
             end
@@ -58,7 +135,7 @@ return {
     },
     boolean = {
         toScalar = raw,
-        sanitizer = function (input)
+        sanitizer = function(input)
             local input_type = type(input)
 
             if input_type == 'boolean' then
@@ -84,77 +161,26 @@ return {
         end
     },
     color = {
-        toScalar = function (input)
-            if type(input) ~= 'table' then
-                return ''
-            end
-
-            local out = {}
-            local i = 0
-            for _, value in pairs(input) do
-                i = i + 1
-                out[i] = value
-            end
-
-            return concat(out, ' ')
-        end,
-        --- accepts either a table or a string
-        --- string must be in an "r g b" or "r g b a" format
-        --- optionally a preset name may be given instead (from resources/color_presets.lua)
-        --- table must contain the "r", "g" and "b" keys and may optionally contain an "a" key
-        --- the output will always be a valid color table for Factorio
-        sanitizer = function (input)
-            if input == nil or input == '' then
-                return true, nil
-            end
-
-            local input_type = type(input)
-
-            if input_type == 'string' then
-                local color = Color[input]
-                if color then
-                    return true, color
-                end
-
-                local data = {}
-                local index = 0
-                for value in gmatch(input, '%S+') do
-                    index = index + 1
-                    if index < 5 then
-                        value = tonumber(value)
-                        if value == nil or value < 0 or value > 255 then
-                            return false, {'redmew_settings_util.color_invalid_string_value'}
-                        end
-
-                        data[color_key_table[index]] = value
-                    end
-                end
-
-                if size(data) < 3 then
-                    return false, {'redmew_settings_util.color_invalid_string_value'}
-                end
-
-                return true, data
-            end
-
-            if input_type == 'table' then
-                if size(input) > 4 or not input.r or not input.g or not input.b then
-                    return false, {'redmew_settings_util.color_invalid_table_value'}
-                end
-
-                local data = {
-                    r = input.r,
-                    g = input.g,
-                    b = input.b
-                }
-                if input.a then
-                    data.a = input.a
-                end
-
-                return true, data
-            end
-
-            return false, {'redmew_settings_util.invalid_color_value'}
-        end
+        toScalar = color_toScalar,
+        sanitizer = color_sanitizer
     },
+    chat_color = {
+        toScalar = color_toScalar,
+        sanitizer = function(input)
+            local suc, value = color_sanitizer(input)
+            if not suc then
+                return false, value
+            end
+
+            local r, g, b = value.r, value.g, value.b
+            local brightness = sqrt(0.241 * r * r + 0.691 * g * g, 0.068 * b * b)
+            brightness = floor(brightness)
+
+            if brightness < 50 then
+                return false, {'redmew_settings_util.chat_color_too_dark'}
+            end
+
+            return true, value
+        end
+    }
 }

--- a/resources/setting_types.lua
+++ b/resources/setting_types.lua
@@ -44,8 +44,7 @@ local function color_sanitizer(input)
 
     if input_type == 'string' then
         local color = Color[input]
-        if color and tonumber(input) == nil then
-            -- we have some numeric keys in there
+        if color then
             return true, color
         end
 

--- a/resources/setting_types.lua
+++ b/resources/setting_types.lua
@@ -112,8 +112,7 @@ return {
 
             if input_type == 'string' then
                 local color = Color[input]
-                if color and tonumber(input) == nil then
-                    -- we have some numeric keys in there
+                if color then
                     return true, color
                 end
 

--- a/resources/setting_types.lua
+++ b/resources/setting_types.lua
@@ -1,0 +1,161 @@
+local Color = require 'resources.color_presets'
+local type = type
+local tonumber = tonumber
+local tostring = tostring
+local gmatch = string.gmatch
+local pairs = pairs
+local concat = table.concat
+local size = table.size
+
+local color_key_table = {'r', 'g', 'b', 'a'}
+
+local function raw(input)
+    return input
+end
+
+--- Contains a set of callables that will attempt to sanitize and transform the input
+--- sanitizer = takes any raw input and converts it to the final value used and stored
+--- to_string = takes stored input and converts it to its string representation
+return {
+    fraction = {
+        toScalar = raw,
+        sanitizer = function (input)
+            input = tonumber(input)
+
+            if input == nil then
+                return false, {'redmew_settings_util.fraction_invalid_value'}
+            end
+
+            if input < 0 then
+                input = 0
+            end
+
+            if input > 1 then
+                input = 1
+            end
+
+            return true, input
+        end
+    },
+    string = {
+        toScalar = raw,
+        sanitizer = function (input)
+            if input == nil then
+                return true, ''
+            end
+
+            local input_type = type(input)
+            if input_type == 'string' then
+                return true, input
+            end
+
+            if input_type == 'number' or input_type == 'boolean' then
+                return true, tostring(input)
+            end
+
+            return false, {'redmew_settings_util.string_invalid_value'}
+        end
+    },
+    boolean = {
+        toScalar = raw,
+        sanitizer = function (input)
+            local input_type = type(input)
+
+            if input_type == 'boolean' then
+                return true, input
+            end
+
+            if input_type == 'string' then
+                if input == '0' or input == '' or input == 'false' or input == 'no' then
+                    return true, false
+                end
+                if input == '1' or input == 'true' or input == 'yes' then
+                    return true, true
+                end
+
+                return true, tonumber(input) ~= nil
+            end
+
+            if input_type == 'number' then
+                return true, input ~= 0
+            end
+
+            return false, {'redmew_settings_util.boolean_invalid_value'}
+        end
+    },
+    color = {
+        toScalar = function (input)
+            if type(input) ~= 'table' then
+                return ''
+            end
+
+            local out = {}
+            local i = 0
+            for _, value in pairs(input) do
+                i = i + 1
+                out[i] = value
+            end
+
+            return concat(out, ' ')
+        end,
+        --- accepts either a table or a string
+        --- string must be in an "r g b" or "r g b a" format
+        --- optionally a preset name may be given instead (from resources/color_presets.lua)
+        --- table must contain the "r", "g" and "b" keys and may optionally contain an "a" key
+        --- the output will always be a valid color table for Factorio
+        sanitizer = function (input)
+            if input == nil or input == '' then
+                return true, nil
+            end
+
+            local input_type = type(input)
+
+            if input_type == 'string' then
+                local color = Color[input]
+                if color and tonumber(input) == nil then
+                    -- we have some numeric keys in there
+                    return true, color
+                end
+
+                local data = {}
+                local index = 0
+                for value in gmatch(input, '%S+') do
+                    index = index + 1
+                    if index < 5 then
+                        value = tonumber(value)
+                        if value == nil or value < 0 or value > 255 then
+                            return false, {'redmew_settings_util.color_invalid_string_value'}
+                        end
+
+                        data[color_key_table[index]] = value
+                    end
+                end
+
+                if size(data) < 3 then
+                    return false, {'redmew_settings_util.color_invalid_string_value'}
+                end
+
+                return true, data
+            end
+
+            if input_type == 'table' then
+                if size(input) > 4 or not input.r or not input.g or not input.b then
+                    return false, {'redmew_settings_util.color_invalid_table_value'}
+                end
+
+                local data = {
+                    r = input.r,
+                    g = input.g,
+                    b = input.b
+                }
+                if input.a then
+                    data.a = input.a
+                end
+
+                return true, data
+            end
+
+            return false, {'redmew_settings_util.invalid_color_value'}
+        end
+    },
+}

--- a/resources/setting_types.lua
+++ b/resources/setting_types.lua
@@ -36,6 +36,36 @@ local function raw(input)
     return input
 end
 
+local function equals_by_value(a, b)
+    return a == b
+end
+
+local function equals_by_table_values(a, b)
+    if type(a) ~= 'table' or type(b) ~= 'table' then
+        return a == b
+    end
+
+    if size(a) ~= size(b) then
+        return false
+    end
+
+    for index, value in pairs(a) do
+        local value_b = b[index]
+        if value_b == nil or value ~= value_b then
+            return false
+        end
+    end
+
+    for index, value in pairs(b) do
+        local value_a = a[index]
+        if value_a == nil or value ~= value_a then
+            return false
+        end
+    end
+
+    return true
+end
+
 local function color_to_scalar(input)
     if type(input) ~= 'table' then
         return ''
@@ -118,6 +148,7 @@ end
 --- to_string = takes stored input and converts it to its string representation
 return {
     fraction = {
+        equals = equals_by_value,
         toScalar = raw,
         sanitizer = function(input)
             input = tonumber(input)
@@ -138,6 +169,7 @@ return {
         end
     },
     string = {
+        equals = equals_by_value,
         toScalar = raw,
         sanitizer = function(input)
             if input == nil then
@@ -157,6 +189,7 @@ return {
         end
     },
     boolean = {
+        equals = equals_by_value,
         toScalar = raw,
         sanitizer = function(input)
             local input_type = type(input)
@@ -184,10 +217,12 @@ return {
         end
     },
     color = {
+        equals = equals_by_table_values,
         toScalar = color_to_scalar,
         sanitizer = color_sanitizer
     },
     chat_color = {
+        equals = equals_by_table_values,
         toScalar = color_to_scalar,
         sanitizer = function(input)
             local suc, value = color_sanitizer(input)

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -15,6 +15,8 @@ local next = next
 local serialize = serpent.line
 local gmatch = string.gmatch
 local get_rank_name = Rank.get_rank_name
+local pairs = pairs
+local pcall = pcall
 
 local Command = {}
 
@@ -24,12 +26,11 @@ local deprecated_command_alternatives = {
     ['tpplayer'] = 'tp <player>',
     ['tppos'] = 'tp',
     ['tpmode'] = 'tp mode',
-    ['color-redmew'] = 'redmew-color'
 }
 
 local notify_on_commands = {
     ['version'] = 'RedMew has a version as well, accessible via /redmew-version',
-    ['color'] = 'RedMew allows color saving and a color randomizer: check out /redmew-color',
+    ['color'] = 'You can also use the Redmew Settings (gear icon) to set the character and chat colors, this will be synchronized to all Redmew servers',
     ['ban'] = 'In case your forgot: please remember to include a message on how to appeal a ban'
 }
 

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -30,7 +30,6 @@ local deprecated_command_alternatives = {
 
 local notify_on_commands = {
     ['version'] = 'RedMew has a version as well, accessible via /redmew-version',
-    ['color'] = 'You can also use the Redmew Settings (gear icon) to set the character and chat colors, this will be synchronized to all Redmew servers',
     ['ban'] = 'In case your forgot: please remember to include a message on how to appeal a ban'
 }
 

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -121,7 +121,8 @@ function Public.set(player_index, name, value)
         setting = missing_setting
     end
 
-    local success, sanitized_value = setting.data_transformation.sanitizer(value)
+    local data_transformation = setting.data_transformation
+    local success, sanitized_value = data_transformation.sanitizer(value)
 
     if not success then
         error(format('Setting "%s" failed: %s', name, sanitized_value), 2)
@@ -141,7 +142,7 @@ function Public.set(player_index, name, value)
         old_value = old_value,
         new_value = sanitized_value,
         player_index = player_index,
-        value_changed = old_value ~= sanitized_value
+        value_changed = not data_transformation.equals(old_value, sanitized_value)
     })
 
     return sanitized_value

--- a/utils/redmew_settings.lua
+++ b/utils/redmew_settings.lua
@@ -43,7 +43,13 @@ Public.events = {
     on_setting_set = Event.generate_event_name('on_setting_set'),
 }
 
-Public.types = {fraction = 'fraction', string = 'string', boolean = 'boolean', color = 'color'}
+Public.types = {
+    fraction = 'fraction',
+    string = 'string',
+    boolean = 'boolean',
+    color = 'color',
+    chat_color = 'chat_color'
+}
 
 ---Register a specific setting with a sensitization setting type.
 ---


### PR DESCRIPTION
This PR adds a new setting in the GUI for player colors and chat colors. This replaces the `/redmew-color` command. The randomizer has been removed as it's fairly easy to fill in a random color via the GUI for both chat and player color. I've also added a migration system which we can leave in there for a while, which will read the settings from the current colors and copy it to the new player settings storage, explicitly leaving the old values to makes sure old scenarios will still work.

The only thing left to fix is limiting the darkness of colors, which I'm not sure how to fix yet. Setting your chat color to `0 0 0` would make it unreadable. I do not consider this important to fix for this PR as we can moderate this if needed for now (which I highly doubt will happen).

Summary of changes:
 - introduced a `Settings.toScalar` which is used to make a setting value stored as table (for example) compatible with the input forms
 - moved the settings to resources so they don't clutter the logic file
 - `/redmew-color` is removed, syncing is now done by setting it in the GUI, changing the player color with `/color` is still possible and won't sync to the server
 - Settings can now be stored in a different structure than represented in the front-end (color tables in this case)

![image](https://user-images.githubusercontent.com/1754678/58505517-6bc5ae80-818d-11e9-90ca-b9226af5f837.png)

![image](https://user-images.githubusercontent.com/1754678/58505535-75e7ad00-818d-11e9-901d-581c056e6701.png)

![image](https://user-images.githubusercontent.com/1754678/58505552-7d0ebb00-818d-11e9-9650-d49934ccc21a.png)

The above will be saved as:
![image](https://user-images.githubusercontent.com/1754678/58505567-86982300-818d-11e9-9a8e-21683b963341.png)

![image](https://user-images.githubusercontent.com/1754678/58505589-931c7b80-818d-11e9-8b22-3da82f73222a.png)
![image](https://user-images.githubusercontent.com/1754678/58505596-97489900-818d-11e9-91fb-af4cc41f4b54.png)
![image](https://user-images.githubusercontent.com/1754678/58505612-a29bc480-818d-11e9-870a-6ac690f90e64.png)

Saved with alpha:
![image](https://user-images.githubusercontent.com/1754678/58505649-bc3d0c00-818d-11e9-8247-913be8b41b35.png)
![image](https://user-images.githubusercontent.com/1754678/58505662-c5c67400-818d-11e9-8490-9fe2c8a7556b.png)
