### PR TITLE
Added more controls to refine evolution config

### DIFF
--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -82,7 +82,6 @@ Retailer.item_types = {
     item_package = 'item_package',
 }
 
-local market_gui_close_distance_squared = 6 * 6 + 6 * 6
 local do_update_market_gui -- token
 
 ---Global storage
@@ -704,7 +703,8 @@ Event.on_nth_tick(37, function()
             local delta_x = player_position.x - market_position.x
             local delta_y = player_position.y - market_position.y
 
-            if delta_x * delta_x + delta_y * delta_y > market_gui_close_distance_squared then
+            local reach_distance = player.reach_distance * 1.05
+            if delta_x * delta_x + delta_y * delta_y > reach_distance * reach_distance then
                 close_market_gui(player)
             end
         else

--- a/map_gen/maps/diggy/config.lua
+++ b/map_gen/maps/diggy/config.lua
@@ -276,10 +276,22 @@ local Config = {
         -- controls the alien spawning mechanic
         alien_spawner = {
             enabled = true,
+
             -- minimum distance from spawn before aliens can spawn
             alien_minimum_distance = 40,
+
             -- chance of spawning aliens when mining from 0 to 1
             alien_probability = 0.05,
+
+            -- each tile of void removed increases alien evolution by
+            evolution_per_void_removed = 0.0000024,
+
+            -- initial evolution percentage, recommended to set to 0 for non-multiplayer setups
+            initial_evolution = 10,
+
+            -- evolution over time value, leave nil to use vanilla settings
+            evolution_over_time_factor = 0.000008,
+
             -- spawns the following units when they die. To disable, remove the contents
             -- any non-rounded number will turn into a chance to spawn an additional alien
             -- example: 2.5 would spawn 2 for sure and 50% chance to spawn one additionally

--- a/map_gen/maps/diggy/feature/alien_spawner.lua
+++ b/map_gen/maps/diggy/feature/alien_spawner.lua
@@ -12,6 +12,7 @@ local AlienEvolutionProgress = require 'utils.alien_evolution_progress'
 local Debug = require 'map_gen.maps.diggy.debug'
 local Template = require 'map_gen.maps.diggy.template'
 local CreateParticles = require 'features.create_particles'
+local format_number = require 'util'.format_number
 local random = math.random
 local floor = math.floor
 local ceil = math.ceil
@@ -25,6 +26,8 @@ local destroy_rock = CreateParticles.destroy_rock
 
 -- this
 local AlienSpawner = {}
+
+local config
 
 local memory = {
     alien_collision_boxes = {},
@@ -155,10 +158,12 @@ end
 --[[--
     Registers all event handlers.
 ]]
-function AlienSpawner.register(config)
-    local alien_minimum_distance_square = config.alien_minimum_distance ^ 2
-    local alien_probability = config.alien_probability
-    local hail_hydra = config.hail_hydra
+function AlienSpawner.register(cfg)
+    config = cfg
+    local alien_minimum_distance_square = cfg.alien_minimum_distance ^ 2
+    local alien_probability = cfg.alien_probability
+    local hail_hydra = cfg.hail_hydra
+    local evolution_per_void_removed = cfg.evolution_per_void_removed
 
     if size(hail_hydra) > 0 then
         global.config.hail_hydra.enabled = true
@@ -168,7 +173,7 @@ function AlienSpawner.register(config)
     Event.add(Template.events.on_void_removed, function (event)
         local force = game.forces.enemy
         local evolution_factor = force.evolution_factor
-        force.evolution_factor = evolution_factor + 0.0000024
+        force.evolution_factor = evolution_factor + evolution_per_void_removed
 
         local position = event.position
         local x = position.x
@@ -182,16 +187,21 @@ function AlienSpawner.register(config)
     end)
 end
 
-function AlienSpawner.get_extra_map_info(config)
+function AlienSpawner.get_extra_map_info(cfg)
+    local multiplier = 10000
+
     return [[Alien Spawner, aliens might spawn when mining!
-Spawn chance: ]] .. (config.alien_probability * 100) .. [[%
-Minimum spawn distance: ]] .. config.alien_minimum_distance .. ' tiles'
+Spawn chance: ]] .. (cfg.alien_probability * 100) .. [[%
+Minimum spawn distance: ]] .. cfg.alien_minimum_distance .. [[ tiles
+Evolution is increased by ]] ..(multiplier * cfg.evolution_per_void_removed * 100)  .. '% per ' .. format_number(multiplier, true) .. [[ mine size
+]]
 end
 
 function AlienSpawner.on_init()
-    -- base factorio =                time_factor = 0.000004
-    game.map_settings.enemy_evolution.time_factor = 0.000008
-    game.forces.enemy.evolution_factor = 0.1
+    if config.evolution_over_time_factor then
+        game.map_settings.enemy_evolution.time_factor = config.evolution_over_time_factor
+    end
+    game.forces.enemy.evolution_factor = config.initial_evolution * 0.01
     game.map_settings.pollution.enabled = false
 end
 

--- a/map_gen/maps/diggy/feature/setup_player.lua
+++ b/map_gen/maps/diggy/feature/setup_player.lua
@@ -23,6 +23,7 @@ end
 
 function SetupPlayer.on_init()
     game.forces.player.manual_mining_speed_modifier = config.initial_mining_speed_bonus
+    game.forces.player.character_resource_reach_distance_bonus = 1
 end
 
 return SetupPlayer


### PR DESCRIPTION
Added 3 new options to add more control over evolution:
 - `evolution_per_void_removed` 
 - `initial_evolution`
 - `evolution_over_time_factor`

Mine size can be found in the score menu as of recently:
![image](https://user-images.githubusercontent.com/1754678/58749804-db3be680-848a-11e9-97bb-2f2ffc076a71.png)

Starting with `initial_evolution of `1` instead of `10` (test config, MP will stay at 10)
![image](https://user-images.githubusercontent.com/1754678/58749803-c7908000-848a-11e9-9dd7-f61b397a4996.png)

More map info:
![image](https://user-images.githubusercontent.com/1754678/58749788-8f893d00-848a-11e9-8aed-35c5198cc681.png)
