### PR TITLE
First shot at #608 Corpse Cleanup

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -391,7 +391,7 @@ global.config = {
         enabled = true
     },
     -- when biter corpses in an area are above a threshold, remove the desired amount
-    biter_corpse_util = {
+    biter_corpse_remover = {
         enabled = true,
         chunk_size = 3, -- size of chunk in tiles
         corpse_threshold = 3 -- number of corpses allowed on surface inside chunk

--- a/config.lua
+++ b/config.lua
@@ -394,8 +394,7 @@ global.config = {
     biter_corpse_util = {
         enabled = true,
         radius = 3, -- radius to search around dying entities
-        corpse_threshold = 10, -- number of corpses allowed on surface inside radius
-        cleanup_chance_percent = 10 -- 100 means check on every biter death, 50 means every second death, etc.
+        corpse_threshold = 10 -- number of corpses allowed on surface inside radius
     }
 }
 

--- a/config.lua
+++ b/config.lua
@@ -394,7 +394,7 @@ global.config = {
     biter_corpse_util = {
         enabled = true,
         chunk_size = 3, -- size of chunk in tiles
-        corpse_threshold = 10 -- number of corpses allowed on surface inside chunk
+        corpse_threshold = 3 -- number of corpses allowed on surface inside chunk
     }
 }
 

--- a/config.lua
+++ b/config.lua
@@ -394,7 +394,8 @@ global.config = {
     biter_corpse_util = {
         enabled = true,
         radius = 3, -- radius to search around dying entities
-        corpse_threshold = 10 -- number of corpses allowed on surface, inside radius
+        corpse_threshold = 10, -- number of corpses allowed on surface inside radius
+        cleanup_chance_percent = 10 -- 100 means check on every biter death, 50 means every second death, etc.
     }
 }
 

--- a/config.lua
+++ b/config.lua
@@ -393,8 +393,8 @@ global.config = {
     -- when biter corpses in an area are above a threshold, remove the desired amount
     biter_corpse_util = {
         enabled = true,
-        radius = 3, -- radius to search around dying entities
-        corpse_threshold = 10 -- number of corpses allowed on surface inside radius
+        chunk_size = 3, -- size of chunk in tiles
+        corpse_threshold = 10 -- number of corpses allowed on surface inside chunk
     }
 }
 

--- a/config.lua
+++ b/config.lua
@@ -389,6 +389,12 @@ global.config = {
     -- enables the redmew settings GUI
     redmew_settings = {
         enabled = true
+    },
+    -- when biter corpses in an area are above a threshold, remove the desired amount
+    biter_corpse_util = {
+        enabled = true,
+        radius = 3, -- radius to search around dying entities
+        corpse_threshold = 10 -- number of corpses allowed on surface, inside radius
     }
 }
 

--- a/control.lua
+++ b/control.lua
@@ -97,8 +97,8 @@ end
 if config.player_quick_bars.enabled then
     require 'features.player_quick_bars'
 end
-if config.biter_corpse_util.enabled then
-    require 'features.biter_corpse_util'
+if config.biter_corpse_remover.enabled then
+    require 'features.biter_corpse_remover'
 end
 
 -- GUIs

--- a/control.lua
+++ b/control.lua
@@ -97,6 +97,9 @@ end
 if config.player_quick_bars.enabled then
     require 'features.player_quick_bars'
 end
+if config.biter_corpse_util.enabled then
+    require 'features.biter_corpse_util'
+end
 
 -- GUIs
 -- The order determines the order they appear from left to right.

--- a/features/biter_corpse_remover.lua
+++ b/features/biter_corpse_remover.lua
@@ -5,7 +5,7 @@ local table = require 'utils.table'
 local fast_remove = table.fast_remove
 local pairs = pairs
 
-local biter_utils_conf = global.config.biter_corpse_util
+local biter_utils_conf = global.config.biter_corpse_remover
 
 -- Factorio removes corpses that hit 15 minutes anyway
 local max_corpse_age = 15 * 60 * 60

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -91,8 +91,8 @@ local function biter_died(event)
     end
 
     --Calculate the hash position
-    local x = entity.position.x - (entity.position.x % biter_utils_conf.radius)
-    local y = entity.position.y - (entity.position.y % biter_utils_conf.radius)
+    local x = entity.position.x - (entity.position.x % biter_utils_conf.chunk_size)
+    local y = entity.position.y - (entity.position.y % biter_utils_conf.chunk_size)
     local hash_position = x .. "_" .. y
 
     -- check global table has this position, add if not

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -1,58 +1,121 @@
+-- dependencies
 local Event = require 'utils.event'
+local Global = require 'utils.global'
 
 local biter_utils_conf = global.config.biter_corpse_util
 
-local random = math.random
+local corpse_chunks = {}
 
--- currently no on_corpse_spawned event, using on_entity_died instead
+-- Factorio removes corpses that hit 15 minutes anyway
+local max_corpse_age = 15 * 60 * 60
 
-local function biter_died(event)
-    local entity = event.entity
-    if not entity.valid then
-        return
+Global.register(
+    {
+        corpse_chunks = corpse_chunks
+    },
+    function(tbl)
+        corpse_chunks = tbl.corpse_chunks
     end
+)
 
-    -- ignore non-enemy entities
-    if entity.force.name ~= 'enemy' then
-        return
-    end
+-- cleans up the stored list of corpses and chunks
+local function remove_outdated_corpses()
+    local now = game.tick
+    -- loop each stored chunk
+    for cci, corpse_chunk in pairs(corpse_chunks) do
+        local count = corpse_chunk.count
 
-    -- Only trigger on units
-    if entity.type ~= 'unit' then
-        return
-    end
+        -- loop stored corpses
+        local corpses = corpse_chunk.corpses
+        local i = 1
+        local corpse = corpses[i]
+        while corpse ~= nil do
+            if corpse.tick < now then
+                table.fast_remove(corpses, i)
+                count = count - 1
+            else
+                i = i + 1
+            end
+            corpse = corpses[i]
+        end
 
-    -- Only a chance of cleanup
-    if biter_utils_conf.cleanup_chance_percent < random(100) then
-        return
-    end
+        corpse_chunk.count = count
 
-    local surface = entity.surface
-
-    local filter = {
-        position = entity.position,
-        radius = biter_utils_conf.radius,
-        type = 'corpse',
-        force = 'neutral'
-    }
-
-    -- More than the desired number of corpses?
-    if surface.count_entities_filtered(filter) <= biter_utils_conf.corpse_threshold then
-        return
-    end
-
-    -- Get the actual entities
-    local corpse_list = surface.find_entities_filtered (filter)
-
-    local corpse_list_len = #corpse_list
-    local num_to_remove = corpse_list_len - biter_utils_conf.corpse_threshold
-    local random_offset = random(corpse_list_len)
-
-    -- Starting at a random number, remove enough entities to be under the threshold
-    for i = random_offset, num_to_remove + random_offset do
-        --modulus + 1 to ensure we are not past the end of the table
-        corpse_list[(i % corpse_list_len) + 1].destroy()
+        -- remove tracked chunk if no corpses
+        if count < 1 then
+            corpse_chunks[cci] = nil
+        end
     end
 end
 
-Event.add(defines.events.on_entity_died, biter_died)
+--Remove extra corpses that are in this area
+local function corpse_cleanup(hash_position)
+
+    local corpse_chunk = corpse_chunks[hash_position]
+    local count = corpse_chunk.count
+    local corpses = corpse_chunk.corpses
+    local num_to_remove = count - biter_utils_conf.corpse_threshold
+
+    -- remove enough entities to be under the threshold
+    for i = 1, num_to_remove do
+        local corpse = corpses[i]
+        if corpse.entity.valid then
+            corpse.entity.destroy()
+        end
+
+        table.fast_remove(corpses, i)
+        count = count -1
+    end
+
+    corpse_chunk.count = count
+
+end
+
+local function biter_died(event)
+    local prot = event.prototype
+
+    -- Only trigger on dead units
+    if prot.type ~= 'unit' then
+        return
+    end
+
+    local entity = event.corpses[1]
+    -- Ensure there is actually a corpse
+    if entity == nil then
+        return
+    end
+
+    -- Chance to clean up old corpses and chunks
+    if game.tick % 60 == 0 then
+        remove_outdated_corpses()
+    end
+
+    --Calculate the hash position
+    local x = entity.position.x - (entity.position.x % biter_utils_conf.radius)
+    local y = entity.position.y - (entity.position.y % biter_utils_conf.radius)
+    local hash_position = x .. "_" .. y
+
+    -- check global table has this position, add if not
+    if corpse_chunks[hash_position] == nil then
+        corpse_chunks[hash_position] = {
+            count = 0,
+            corpses = {}
+        }
+    end
+
+    -- get and increment this chunk, add this entity
+    local corpse_chunk = corpse_chunks[hash_position];
+    local count = corpse_chunk.count + 1
+    corpse_chunk.count = count
+    corpse_chunk.corpses[count] = {
+        entity = entity,
+        tick = game.tick + max_corpse_age
+    }
+
+    -- Call cleanup if above threshold
+    if corpse_chunk.count > biter_utils_conf.corpse_threshold then
+        corpse_cleanup(hash_position)
+    end
+end
+
+Event.add(defines.events.on_post_entity_died, biter_died)

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -20,8 +20,7 @@ Global.register(
 )
 
 -- cleans up the stored list of corpses and chunks
-local function remove_outdated_corpses()
-    local now = game.tick
+local function remove_outdated_corpses(now)
     -- loop each stored chunk
     for cci, corpse_chunk in pairs(corpse_chunks) do
         local count = corpse_chunk.count
@@ -86,9 +85,11 @@ local function biter_died(event)
         return
     end
 
+    local tick = event.tick
+
     -- Chance to clean up old corpses and chunks
-    if game.tick % 60 == 0 then
-        remove_outdated_corpses()
+    if tick % 60 == 0 then
+        remove_outdated_corpses(tick)
     end
 
     --Calculate the hash position
@@ -110,7 +111,7 @@ local function biter_died(event)
     corpse_chunk.count = count
     corpse_chunk.corpses[count] = {
         entity = entity,
-        tick = game.tick + max_corpse_age
+        tick = tick + max_corpse_age
     }
 
     -- Call cleanup if above threshold

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -24,23 +24,20 @@ local function biter_died(event)
 
     local surface = entity.surface
 
+    local filter = {
+        position = entity.position,
+        radius = biter_utils_conf.radius,
+        type = 'corpse',
+        force = 'neutral'
+    }
+
     -- More than the desired number of corpses?
-    if not (surface.count_entities_filtered {
-            position = entity.position,
-            radius = biter_utils_conf.radius,
-            type = 'corpse',
-            force = 'neutral'
-            } > biter_utils_conf.corpse_threshold) then
+    if not (surface.count_entities_filtered(filter)  > biter_utils_conf.corpse_threshold) then
         return
     end
 
     -- Get the actual entities
-    local corpse_list = surface.find_entities_filtered {
-            position = entity.position,
-            radius = biter_utils_conf.radius,
-            type = 'corpse',
-            force = 'neutral'
-        }
+    local corpse_list = surface.find_entities_filtered (filter)
 
     local corpse_list_len = #corpse_list
     local num_to_remove = corpse_list_len - biter_utils_conf.corpse_threshold

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -8,39 +8,43 @@ local random = math.random
 
 local function biter_died(event)
     local entity = event.entity
-    if entity.valid then
-        local dying_force = entity.force
-        -- ignore player owned entities
-        if dying_force == 'player' then
-            return
-        end
+    if not entity.valid then
+        return
+    end
 
-        local surface = entity.surface
+    local dying_force = entity.force
+    -- ignore player owned entities
+    if dying_force == 'player' then
+        return
+    end
 
-        -- More than the desired number of corpses?
-        if surface.count_entities_filtered {
-                position = entity.position,
-                radius = biter_utils_conf.radius,
-                type = 'corpse',
-                force = 'neutral'
-                } > biter_utils_conf.corpse_threshold then
-            -- Get the actual entities
-            local corpse_list = surface.find_entities_filtered {
-                    position = entity.position,
-                    radius = biter_utils_conf.radius,
-                    type = 'corpse',
-                    force = 'neutral'
-                }
+    local surface = entity.surface
 
-            local num_to_remove = #corpse_list - biter_utils_conf.corpse_threshold
-            local random_offset = random(#corpse_list)
+    -- More than the desired number of corpses?
+    if not (surface.count_entities_filtered {
+            position = entity.position,
+            radius = biter_utils_conf.radius,
+            type = 'corpse',
+            force = 'neutral'
+            } > biter_utils_conf.corpse_threshold) then
+        return
+    end
 
-            -- Starting at a random number, remove enough entities to be under the threshold
-            for i = random_offset, num_to_remove + random_offset do
-                --modulus + 1 to ensure we are not past the end of the table
-                corpse_list[(i % #corpse_list) + 1].destroy()
-            end
-        end
+    -- Get the actual entities
+    local corpse_list = surface.find_entities_filtered {
+            position = entity.position,
+            radius = biter_utils_conf.radius,
+            type = 'corpse',
+            force = 'neutral'
+        }
+
+    local num_to_remove = #corpse_list - biter_utils_conf.corpse_threshold
+    local random_offset = random(#corpse_list)
+
+    -- Starting at a random number, remove enough entities to be under the threshold
+    for i = random_offset, num_to_remove + random_offset do
+        --modulus + 1 to ensure we are not past the end of the table
+        corpse_list[(i % #corpse_list) + 1].destroy()
     end
 end
 

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -42,13 +42,14 @@ local function biter_died(event)
             force = 'neutral'
         }
 
-    local num_to_remove = #corpse_list - biter_utils_conf.corpse_threshold
-    local random_offset = random(#corpse_list)
+    local corpse_list_len = #corpse_list
+    local num_to_remove = corpse_list_len - biter_utils_conf.corpse_threshold
+    local random_offset = random(corpse_list_len)
 
     -- Starting at a random number, remove enough entities to be under the threshold
     for i = random_offset, num_to_remove + random_offset do
         --modulus + 1 to ensure we are not past the end of the table
-        corpse_list[(i % #corpse_list) + 1].destroy()
+        corpse_list[(i % corpse_list_len) + 1].destroy()
     end
 end
 

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -1,0 +1,52 @@
+local Event = require 'utils.event'
+
+local biter_utils_conf = global.config.biter_corpse_util
+
+local random = math.random
+
+-- currently no on_corpse_spawned event, using on_entity_died instead
+
+local function biter_died(event)
+    local entity = event.entity
+    if entity.valid then
+        local dying_force = entity.force
+        -- ignore player owned entities
+        if dying_force == 'player' then
+            return
+        end
+
+        local surface = entity.surface
+
+        -- More than the desired number of corpses?
+        if surface.count_entities_filtered {
+                position = entity.position,
+                radius = biter_utils_conf.radius,
+                type = 'corpse',
+                force = 'neutral'
+                } > biter_utils_conf.corpse_threshold then
+            -- Get the actual entities
+            local corpse_list = surface.find_entities_filtered {
+                    position = entity.position,
+                    radius = biter_utils_conf.radius,
+                    type = 'corpse',
+                    force = 'neutral'
+                }
+
+            local num_to_remove = #corpse_list - biter_utils_conf.corpse_threshold
+            local random_offset = random(#corpse_list)
+
+            -- Starting at a random number, remove enough entities to be under the threshold
+            for i = random_offset, num_to_remove + random_offset do
+                --modulus + 1 to ensure we are not past the end of the table
+                if entity == corpse_list[(i % #corpse_list) + 1] then
+                    game.print('Collision')
+                else
+                    corpse_list[(i % #corpse_list) + 1].destroy()
+                end
+
+            end
+        end
+    end
+end
+
+Event.add(defines.events.on_entity_died, biter_died)

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -12,9 +12,13 @@ local function biter_died(event)
         return
     end
 
-    local dying_force = entity.force
-    -- ignore player owned entities
-    if dying_force == 'player' then
+    -- ignore non-enemy entities
+    if entity.force.name ~= 'enemy' then
+        return
+    end
+
+    -- Only trigger on units
+    if entity.type ~= 'unit' then
         return
     end
 

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -22,6 +22,11 @@ local function biter_died(event)
         return
     end
 
+    -- Only a chance of cleanup
+    if biter_utils_conf.cleanup_chance_percent < random(100) then
+        return
+    end
+
     local surface = entity.surface
 
     local filter = {

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -37,7 +37,7 @@ local function biter_died(event)
     }
 
     -- More than the desired number of corpses?
-    if not (surface.count_entities_filtered(filter)  > biter_utils_conf.corpse_threshold) then
+    if surface.count_entities_filtered(filter) <= biter_utils_conf.corpse_threshold then
         return
     end
 

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -38,12 +38,7 @@ local function biter_died(event)
             -- Starting at a random number, remove enough entities to be under the threshold
             for i = random_offset, num_to_remove + random_offset do
                 --modulus + 1 to ensure we are not past the end of the table
-                if entity == corpse_list[(i % #corpse_list) + 1] then
-                    game.print('Collision')
-                else
-                    corpse_list[(i % #corpse_list) + 1].destroy()
-                end
-
+                corpse_list[(i % #corpse_list) + 1].destroy()
             end
         end
     end

--- a/features/biter_corpse_util.lua
+++ b/features/biter_corpse_util.lua
@@ -1,6 +1,7 @@
 -- dependencies
 local Event = require 'utils.event'
 local Global = require 'utils.global'
+local table = require 'utils.table'
 
 local biter_utils_conf = global.config.biter_corpse_util
 


### PR DESCRIPTION
This is a revival and partial re-write of #883 that was abandoned.

It looks at corpses within a small range of any new corpse, and randomly removes to get under the limit. Although it has to run every time an entity dies, it only touches a small area (36 tiles), so it should be fairly low impact. The number of corpses and radius are adjustable, but these values seem reasonable. The 'after' screenshot is using these settings.

I've tested what I can think of, but I'm open to suggestions.

Before:
![Before](https://user-images.githubusercontent.com/1916332/58908046-c8185900-86cc-11e9-816c-024995ed6220.PNG)
After:
![After](https://user-images.githubusercontent.com/1916332/58908045-c77fc280-86cc-11e9-8234-2da0b08ec140.PNG)