### PR TITLE
updates to locale_builder

### DIFF
--- a/utils/locale_builder.lua
+++ b/utils/locale_builder.lua
@@ -55,7 +55,7 @@ local function localise(item)
 end
 
 function add(self, item)
-    if not item then
+    if item == nil then
         item = self
         self = nil
     end
@@ -68,9 +68,13 @@ function add(self, item)
 
     local tail = self.tail
     if not tail then
-        tail = {'', self}
-        self = new(tail)
-        set_tail(self, tail)
+        if self[1] == '' then
+            tail = self
+        else
+            tail = {'', self}
+            self = new(tail)
+            set_tail(self, tail)
+        end
     end
 
     local count = #tail
@@ -87,6 +91,10 @@ end
 
 Public.add = add
 function Public.__call(_, item)
+    if item == nil then
+        item = {''}
+    end
+
     return add(nil, item)
 end
 setmetatable(Public, Public)


### PR DESCRIPTION
A minor change that allows doing calling `LocaleBuilder()` with no parameters.
Which is useful when you want to build the localised string inside a loop but have nothing to seed it with.