### PR TITLE
apocalypse fix

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -357,7 +357,9 @@ global.config = {
     },
     -- enables a command which allows for an end-game event
     apocalypse = {
-        enabled = true
+        enabled = true,
+        -- chance behemoth biters and spitters will double on death.
+        duplicate_chance = 0.05
     },
     -- gradually informs players of features such as chat, toasts, etc.
     player_onboarding = {


### PR DESCRIPTION
Best I can tell the apocalypse module stopped working correctly because of changes made to the hail hydra module and the apocalypse module wasn't updated for those changes.

Give all that apocalypse wanted to do was respawn the biters on death, this PR changes apocalypse to handle the respawning itself rather than set all the hail hydra configs. This also means it wont override any previous hail hydra configs so the modules will both work together.

Tested on a vanilla map, crashsite and diggy and seems to work as expected.