### PR TITLE
Crashsite updates [Waiting for 0.17.59]

### DIFF
--- a/map_gen/maps/crash_site/outpost_data/big_chemical_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/big_chemical_factory.lua
@@ -34,15 +34,15 @@ local factory = {
 local factory_b = {
     callback = ob.magic_item_crafting_callback,
     data = {
-        recipe = 'sulfuric-acid',
-        output = {min_rate = 10 / 60, distance_factor = 10 / 60 / 512, item = 'sulfuric-acid', fluidbox_index = 2}
+        recipe = 'explosives',
+        output = {min_rate = 2 / 60, distance_factor = 1 / 60 / 512, item = 'explosives'}
     }
 }
 local factory_c = {
     callback = ob.magic_item_crafting_callback,
     data = {
         recipe = 'rocket-fuel',
-        output = {min_rate = 0.5 / 60, distance_factor = 0.5 / 60 / 512, item = 'rocket-fuel'}
+        output = {min_rate = 0.7 / 60, distance_factor = 0.7 / 60 / 512, item = 'rocket-fuel'}
     }
 }
 
@@ -120,7 +120,7 @@ local level3 =
     {
         factory = factory,
         fallback = level2,
-        max_count = 6
+        max_count = 5
     }
 )
 
@@ -130,7 +130,7 @@ local level3b =
     {
         factory = factory_b,
         fallback = level3,
-        max_count = 3
+        max_count = 4
     }
 )
 

--- a/map_gen/maps/crash_site/outpost_data/big_circuit_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/big_circuit_factory.lua
@@ -40,7 +40,7 @@ local factory_d = {
     callback = ob.magic_item_crafting_callback,
     data = {
         recipe = 'rocket-control-unit',
-        output = {min_rate = 0.05 / 60, distance_factor = 0.05 / 60 / 512, item = 'rocket-control-unit'}
+        output = {min_rate = 0.5 / 60, distance_factor = 0.5 / 60 / 512, item = 'rocket-control-unit'}
     }
 }
 

--- a/map_gen/maps/crash_site/outpost_data/big_copper_plate_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/big_copper_plate_factory.lua
@@ -6,7 +6,8 @@ local loot = {
     {stack = {name = 'coin', count = 250, distance_factor = 1 / 20}, weight = 5},
     {stack = {name = 'copper-ore', count = 2400}, weight = 2},
     {stack = {name = 'copper-cable', count = 1500, distance_factor = 1 / 2}, weight = 2},
-    {stack = {name = 'copper-plate', count = 1000, distance_factor = 1 / 5}, weight = 8}
+    {stack = {name = 'copper-plate', count = 1000, distance_factor = 1 / 5}, weight = 8},
+    {stack = {name = 'low-density-structure', count = 30, distance_factor = 1 / 20}, weight = 1}
 }
 
 local weights = ob.prepare_weighted_loot(loot)
@@ -23,6 +24,14 @@ local factory = {
     data = {
         furance_item = {name = 'copper-ore', count = 100},
         output = {min_rate = 2.5 / 60, distance_factor = 2.5 / 60 / 512, item = 'copper-plate'}
+    }
+}
+
+local factory_b = {
+    callback = ob.magic_item_crafting_callback,
+    data = {
+        recipe = 'low-density-structure',
+        output = {min_rate = 0.35 / 60, distance_factor = 0.35 / 60 / 512, item = 'low-density-structure'}
     }
 }
 
@@ -44,11 +53,18 @@ local market = {
             price = 0.3,
             distance_factor = 0.15 / 512,
             min_price = 0.03
+        },
+        {
+            name = 'low-density-structure',
+            price = 25,
+            distance_factor = 12.5 / 512,
+            min_price = 2.5
         }
     }
 }
 
 local base_factory = require 'map_gen.maps.crash_site.outpost_data.medium_furance'
+local base_factory2 = require 'map_gen.maps.crash_site.outpost_data.big_factory'
 
 local level2 = ob.extend_1_way(base_factory[1], {loot = {callback = loot_callback}})
 local level3 =
@@ -60,12 +76,22 @@ local level3 =
     }
 )
 
+local level3b =
+    ob.extend_1_way(
+    base_factory2[2],
+    {
+        factory = factory_b,
+        fallback = level2,
+        max_count = 1
+    }
+)
+
 local level4 =
     ob.extend_1_way(
     base_factory[3],
     {
         market = market,
-        fallback = level3
+        fallback = level3b
     }
 )
 return {

--- a/map_gen/maps/crash_site/outpost_data/big_gear_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/big_gear_factory.lua
@@ -9,6 +9,7 @@ local loot = {
     {stack = {name = 'iron-gear-wheel', count = 4000, distance_factor = 2}, weight = 10},
     {stack = {name = 'engine-unit', count = 800, distance_factor = 1 / 2}, weight = 5},
     {stack = {name = 'electric-engine-unit', count = 400, distance_factor = 1 / 2}, weight = 5},
+    {stack = {name = 'flying-robot-frame', count = 400, distance_factor = 1 / 2}, weight = 5},
     {stack = {name = 'rail', count = 2500, distance_factor = 1}, weight = 1},
     {stack = {name = 'tank', count = 5, distance_factor = 1 / 128}, weight = 1},
     {stack = {name = 'locomotive', count = 5, distance_factor = 1 / 128}, weight = 1},
@@ -36,16 +37,16 @@ local factory = {
 local factory_b = {
     callback = ob.magic_item_crafting_callback,
     data = {
-        recipe = 'engine-unit',
-        output = {min_rate = 1 / 60, distance_factor = 1 / 60 / 512, item = 'engine-unit'}
+        recipe = 'flying-robot-frame',
+        output = {min_rate = 1 / 60, distance_factor = 1 / 60 / 512, item = 'flying-robot-frame'}
     }
 }
 
 local factory_c = {
     callback = ob.magic_item_crafting_callback,
     data = {
-        recipe = 'electric-engine-unit',
-        output = {min_rate = 1 / 60, distance_factor = 1 / 60 / 512, item = 'electric-engine-unit'}
+        recipe = 'satellite',
+        output = {min_rate = 0.01 / 60, distance_factor = 0.01 / 60 / 512, item = 'satellite'}
     }
 }
 
@@ -87,6 +88,12 @@ local market = {
             min_price = 0.8
         },
         {
+            name = 'flying-robot-frame',
+            price = 12,
+            distance_factor = 4 / 512,
+            min_price = 1.2
+        },
+        {
             name = 'car',
             price = 50,
             distance_factor = 25 / 512,
@@ -94,9 +101,27 @@ local market = {
         },
         {
             name = 'rail',
-            price = 1,
+            price = 0.5,
             distance_factor = 0.5 / 512,
             min_price = 0.1
+        },
+        {
+            name = 'rail-signal',
+            price = 2,
+            distance_factor = 1 / 512,
+            min_price = 0.1
+        },
+        {
+            name = 'rail-chain-signal',
+            price = 2,
+            distance_factor = 1 / 512,
+            min_price = 0.1
+        },
+        {
+            name = 'train-stop',
+            price = 20,
+            distance_factor = 10 / 512,
+            min_price = 2
         },
         {
             name = 'tank',
@@ -121,6 +146,12 @@ local market = {
             price = 40,
             distance_factor = 20 / 512,
             min_price = 4
+        },
+        {
+            name = 'satellite',
+            price = 300,
+            distance_factor = 50 / 512,
+            min_price = 50
         }
     }
 }
@@ -143,7 +174,7 @@ local level3b =
     {
         factory = factory_b,
         fallback = level2,
-        max_count = 2
+        max_count = 4
     }
 )
 local level3c =
@@ -152,7 +183,7 @@ local level3c =
     {
         factory = factory_c,
         fallback = level3b,
-        max_count = 2
+        max_count = 1
     }
 )
 local level4 =
@@ -168,12 +199,13 @@ return {
         blocks = 9,
         variance = 3,
         min_step = 2,
-        max_level = 2
+        max_level = 3
     },
     walls = {
         require 'map_gen.maps.crash_site.outpost_data.heavy_gun_turrets'
     },
     bases = {
-        {level4, level3, level2}
+        {level3, level2},
+        {level4}
     }
 }

--- a/map_gen/maps/crash_site/outpost_data/big_iron_plate_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/big_iron_plate_factory.lua
@@ -40,7 +40,7 @@ local factory_c = {
     callback = ob.magic_item_crafting_callback,
     data = {
         recipe = 'low-density-structure',
-        output = {min_rate = 0.1 / 60, distance_factor = 0.1 / 60 / 512, item = 'low-density-structure'}
+        output = {min_rate = 0.35 / 60, distance_factor = 0.35 / 60 / 512, item = 'low-density-structure'}
     }
 }
 

--- a/map_gen/maps/crash_site/outpost_data/medium_circuit_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/medium_circuit_factory.lua
@@ -23,7 +23,7 @@ local factory_b = {
     callback = ob.magic_item_crafting_callback,
     data = {
         recipe = 'advanced-circuit',
-        output = {min_rate = 0.5 / 600, distance_factor = 0.5 / 600 / 512, item = 'advanced-circuit'}
+        output = {min_rate = 2.5 / 600, distance_factor = 2.5 / 600 / 512, item = 'advanced-circuit'}
     }
 }
 

--- a/map_gen/maps/crash_site/outpost_data/medium_gear_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/medium_gear_factory.lua
@@ -9,6 +9,7 @@ local loot = {
     {stack = {name = 'iron-gear-wheel', count = 1500, distance_factor = 1}, weight = 10},
     {stack = {name = 'engine-unit', count = 200, distance_factor = 1 / 2}, weight = 5},
     {stack = {name = 'electric-engine-unit', count = 100, distance_factor = 1 / 2}, weight = 5},
+    {stack = {name = 'flying-robot-frame', count = 50, distance_factor = 1 / 2}, weight = 5},
     {stack = {name = 'rail', count = 500, distance_factor = 1}, weight = 2},
     {stack = {name = 'tank', count = 1, distance_factor = 1 / 128}, weight = 2},
     {stack = {name = 'locomotive', count = 5, distance_factor = 1 / 128}, weight = 2},
@@ -87,6 +88,12 @@ local market = {
             min_price = 0.8
         },
         {
+            name = 'flying-robot-frame',
+            price = 12,
+            distance_factor = 4 / 512,
+            min_price = 1.2
+        },
+        {
             name = 'car',
             price = 50,
             distance_factor = 25 / 512,
@@ -118,9 +125,27 @@ local market = {
         },
         {
             name = 'rail',
-            price = 1,
+            price = 0.5,
             distance_factor = 0.5 / 512,
             min_price = 0.1
+        },
+        {
+            name = 'rail-signal',
+            price = 2,
+            distance_factor = 1 / 512,
+            min_price = 0.1
+        },
+        {
+            name = 'rail-chain-signal',
+            price = 2,
+            distance_factor = 1 / 512,
+            min_price = 0.1
+        },
+        {
+            name = 'train-stop',
+            price = 20,
+            distance_factor = 10 / 512,
+            min_price = 2
         }
     }
 }

--- a/map_gen/maps/crash_site/outpost_data/small_gear_factory.lua
+++ b/map_gen/maps/crash_site/outpost_data/small_gear_factory.lua
@@ -83,10 +83,46 @@ local market = {
             min_price = 40
         },
         {
+            name = 'locomotive',
+            price = 100,
+            distance_factor = 50 / 512,
+            min_price = 40
+        },
+        {
+            name = 'cargo-wagon',
+            price = 20,
+            distance_factor = 10 / 512,
+            min_price = 10
+        },
+        {
+            name = 'fluid-wagon',
+            price = 40,
+            distance_factor = 20 / 512,
+            min_price = 20
+        },
+        {
             name = 'rail',
-            price = 1,
+            price = 0.5,
             distance_factor = 0.5 / 512,
             min_price = 0.1
+        },
+        {
+            name = 'rail-signal',
+            price = 2,
+            distance_factor = 1 / 512,
+            min_price = 0.1
+        },
+        {
+            name = 'rail-chain-signal',
+            price = 2,
+            distance_factor = 1 / 512,
+            min_price = 0.1
+        },
+        {
+            name = 'train-stop',
+            price = 20,
+            distance_factor = 10 / 512,
+            min_price = 2
         }
     }
 }

--- a/map_gen/maps/crash_site/outpost_data/small_oil_refinery.lua
+++ b/map_gen/maps/crash_site/outpost_data/small_oil_refinery.lua
@@ -4,8 +4,12 @@ local Token = require 'utils.token'
 local loot = {
     {weight = 10},
     {stack = {name = 'coin', count = 50, distance_factor = 1 / 20}, weight = 5},
-    {stack = {name = 'crude-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 5},
-    {stack = {name = 'petroleum-gas-barrel', count = 100, distance_factor = 1 / 20}, weight = 5}
+    {stack = {name = 'crude-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
+    {stack = {name = 'heavy-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
+    {stack = {name = 'light-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
+    {stack = {name = 'petroleum-gas-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
+    {stack = {name = 'lubricant-barrel', count = 100, distance_factor = 1 / 20}, weight = 1},
+    {stack = {name = 'sulfuric-acid-barrel', count = 100, distance_factor = 1 / 20}, weight = 1}
 }
 
 local weights = ob.prepare_weighted_loot(loot)
@@ -37,7 +41,9 @@ local factory = {
         recipe = 'basic-oil-processing',
         keep_active = true,
         output = {
-            {min_rate = 10 / 60, distance_factor = 10 / 60 / 512, item = 'petroleum-gas', fluidbox_index = 2}
+            {min_rate = 3.75 / 60, distance_factor = 3.75 / 60 / 512, item = 'heavy-oil', fluidbox_index = 2},
+            {min_rate = 3.75 / 60, distance_factor = 3.75 / 60 / 512, item = 'light-oil', fluidbox_index = 3},
+            {min_rate = 5 / 60, distance_factor = 5 / 60 / 512, item = 'petroleum-gas', fluidbox_index = 4}
         }
     }
 }

--- a/map_gen/maps/crash_site/outpost_data/small_oil_refinery.lua
+++ b/map_gen/maps/crash_site/outpost_data/small_oil_refinery.lua
@@ -4,12 +4,8 @@ local Token = require 'utils.token'
 local loot = {
     {weight = 10},
     {stack = {name = 'coin', count = 50, distance_factor = 1 / 20}, weight = 5},
-    {stack = {name = 'crude-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
-    {stack = {name = 'heavy-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
-    {stack = {name = 'light-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
-    {stack = {name = 'petroleum-gas-barrel', count = 100, distance_factor = 1 / 20}, weight = 2},
-    {stack = {name = 'lubricant-barrel', count = 100, distance_factor = 1 / 20}, weight = 1},
-    {stack = {name = 'sulfuric-acid-barrel', count = 100, distance_factor = 1 / 20}, weight = 1}
+    {stack = {name = 'crude-oil-barrel', count = 100, distance_factor = 1 / 20}, weight = 5},
+    {stack = {name = 'petroleum-gas-barrel', count = 100, distance_factor = 1 / 20}, weight = 5}
 }
 
 local weights = ob.prepare_weighted_loot(loot)
@@ -41,9 +37,7 @@ local factory = {
         recipe = 'basic-oil-processing',
         keep_active = true,
         output = {
-            {min_rate = 3.75 / 60, distance_factor = 3.75 / 60 / 512, item = 'heavy-oil', fluidbox_index = 2},
-            {min_rate = 3.75 / 60, distance_factor = 3.75 / 60 / 512, item = 'light-oil', fluidbox_index = 3},
-            {min_rate = 5 / 60, distance_factor = 5 / 60 / 512, item = 'petroleum-gas', fluidbox_index = 4}
+            {min_rate = 10 / 60, distance_factor = 10 / 60 / 512, item = 'petroleum-gas', fluidbox_index = 2}
         }
     }
 }


### PR DESCRIPTION
Small changes to the items in the outposts.

Waiting on 0.17.59 and the recipe change to test the changes to the oil outpost.

Changes:
- Big chemical outpost: magic crafts explosives rather than acid, +40% magic crafting rocket fuel.
- Big circuit outpost: 10x magic crafting rocket control units.
- Big copper outpost: now magic crafts low density structures.
- Big gear outpost: magic crafts flying robot frames instead of engines, satellites instead of electric engines.
- Big iron outpost: 3.5x faster low density structures.
- ~~Small oil refinery: Now only magic crafts petroleum gas in line with the 0.17.59 recipe change. Loot changed to be more weighted towards petroleum gas and removed lubricant and sulfuric acid loot.~~
- All of the gear factorys now sell all rail supplies.
- Medium circuit outpost 5x advanced circuit output.