### PR TITLE
Added adjustable Respawn Time to CrashSite (#957)

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -206,14 +206,16 @@ global.config = {
                 }
             }
         },
-        -- settings for controlling length of delay before player respawn
+        -- settings for controlling length of delay before player respawn - the delay goes *down* over time
         -- respawn time is determined by biter progression:
-        --   min_time + (increment_amount * biter_progression )
+        --   respawn_delay = max_time - (decrement_amount * biter_progression)
+        --   respawn_time = max( min_time, respawn_delay )
         -- min_time default is 10 seconds
-        -- increment_amount default of 3000 will add ~5 seconds per 10% evolution and max at 60 seconds
+        -- decrement_amount default of 3000 will remove ~5 seconds per 10% evolution
         player_respawn_time = {
           min_time = 600,
-          increment_amount = 3000
+          max_time = 3600,
+          decrement_amount = 3000
         },
     -- spawns more units when one dies
     hail_hydra = {

--- a/config.lua
+++ b/config.lua
@@ -213,6 +213,7 @@ global.config = {
         -- min_time default is 10 seconds
         -- decrement_amount default of 3000 will remove ~5 seconds per 10% evolution
         player_respawn_time = {
+          enabled = false,
           min_time = 600,
           max_time = 3600,
           decrement_amount = 3000

--- a/config.lua
+++ b/config.lua
@@ -203,9 +203,18 @@ global.config = {
                 {name = 'compilatron-chest', count = 5},
                 {name = 'compilatron-chest', count = 5},
                 {name = 'selection-tool', count = 1}
+                }
             }
-        }
-    },
+        },
+        -- settings for controlling length of delay before player respawn
+        -- respawn time is determined by biter progression:
+        --   min_time + (increment_amount * biter_progression )
+        -- min_time default is 10 seconds
+        -- increment_amount default of 3000 will add ~5 seconds per 10% evolution and max at 60 seconds
+        player_respawn_time = {
+          min_time = 600,
+          increment_amount = 3000
+        },
     -- spawns more units when one dies
     hail_hydra = {
         enabled = false,

--- a/map_gen/maps/crash_site/entity_died_events.lua
+++ b/map_gen/maps/crash_site/entity_died_events.lua
@@ -5,6 +5,7 @@ local Global = require 'utils.global'
 local math = require 'utils.math'
 local table = require 'utils.table'
 
+local max = math.max
 local random = math.random
 local round = math.round
 local set_timeout_in_ticks = Task.set_timeout_in_ticks
@@ -174,8 +175,10 @@ local spawn_player =
     Token.register(
     function(player)
         if player and player.valid then
-            local increment = round(game.forces.enemy.evolution_factor * global.config.player_respawn_time.increment_amount)
-            player.ticks_to_respawn = global.config.player_respawn_time.min_time + increment
+            local decrement_amount = round(game.forces.enemy.evolution_factor * global.config.player_respawn_time.decrement_amount)
+            local adjusted_respawn = global.config.player_respawn_time.max_time - decrement_amount
+            local respawn_delay = max(global.config.player_respawn_time.min_time, adjusted_respawn) -- limit smallest delay to min_time, if evolution goes above 100%
+            player.ticks_to_respawn =  respawn_delay
         end
     end
 )

--- a/map_gen/maps/crash_site/entity_died_events.lua
+++ b/map_gen/maps/crash_site/entity_died_events.lua
@@ -6,6 +6,7 @@ local math = require 'utils.math'
 local table = require 'utils.table'
 
 local random = math.random
+local round = math.round
 local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local ceil = math.ceil
 local draw_arc = rendering.draw_arc
@@ -173,7 +174,8 @@ local spawn_player =
     Token.register(
     function(player)
         if player and player.valid then
-            player.ticks_to_respawn = 3600
+            local increment = round(game.forces.enemy.evolution_factor * global.config.player_respawn_time.increment_amount)
+            player.ticks_to_respawn = global.config.player_respawn_time.min_time + increment
         end
     end
 )

--- a/map_gen/maps/crash_site/entity_died_events.lua
+++ b/map_gen/maps/crash_site/entity_died_events.lua
@@ -175,10 +175,15 @@ local spawn_player =
     Token.register(
     function(player)
         if player and player.valid then
+          local respawn_delay
+          if global.config.player_respawn_time.enabled then
             local decrement_amount = round(game.forces.enemy.evolution_factor * global.config.player_respawn_time.decrement_amount)
             local adjusted_respawn = global.config.player_respawn_time.max_time - decrement_amount
-            local respawn_delay = max(global.config.player_respawn_time.min_time, adjusted_respawn) -- limit smallest delay to min_time, if evolution goes above 100%
-            player.ticks_to_respawn =  respawn_delay
+            respawn_delay = max(global.config.player_respawn_time.min_time, adjusted_respawn) -- limit smallest delay to min_time, if evolution goes above 100%
+          else
+            respawn_delay = global.config.player_respawn_time.max_time
+          end
+          player.ticks_to_respawn =  respawn_delay
         end
     end
 )


### PR DESCRIPTION
"Respawn timer shouldn't be as long or maybe timer starts off ~small and increases~ per death or maybe based off evolution"
- Implementation is based off evolution
- I chose to not cache global.config


Based on conversation with GrilledHam:
- Respawn delay is to prevent / punish early game suicide runs to clear nests.

This implementation decreases the respawn time from default of 60 seconds to a minimum of 10 seconds, by 5 seconds per 10% of evolution.

Added enable (default false) to control adjustable respawn delay.  When disabled, respawn is 60 seconds.
