### PR TITLE
Diggy - Prevent oil from spawning too close to other oil patches

### DIFF
--- a/map_gen/maps/diggy/feature/scattered_resources.lua
+++ b/map_gen/maps/diggy/feature/scattered_resources.lua
@@ -36,14 +36,9 @@ end
 
 --overcrowded_resource returns true if one or more entity <resource_name> is found within <min_gap> tiles from <position>
 local function overcrowded_resource(surface, position, resource_name, min_gap)
-    local d = min_gap
-    local bounding_box = {{x = position.x - d + 1, y = position.y - d + 1}, {x = position.x + d, y = position.y + d}}
+    local bounding_box = {{x = position.x - min_gap + 1, y = position.y - min_gap + 1}, {x = position.x + min_gap, y = position.y + min_gap}}
     local found_resources = surface.count_entities_filtered{area = bounding_box, name = resource_name, limit = 1}
-    if found_resources == 0 then
-        return false
-    else
-        return true
-    end
+    return found_resources ~= 0
 end
 
 --[[--
@@ -148,7 +143,7 @@ function ScatteredResources.register(config)
 
         local position = {x = x, y = y}
         if resource_name == 'crude-oil' then
-            local min_gap = 2  --must be at least this many tiles between crude-oil patches
+            local min_gap = 2  --default is 2.  Represents minimum tile gap between resources.
             if overcrowded_resource(surface, position, resource_name, min_gap) then
                 return false  --when overcrowded_resource is true, skip this resource spawn
             end

--- a/map_gen/maps/diggy/feature/scattered_resources.lua
+++ b/map_gen/maps/diggy/feature/scattered_resources.lua
@@ -34,6 +34,18 @@ local function get_name_by_weight(collection, sum)
     Debug.print('Current \'' .. current .. '\' should be higher or equal to random \'' .. target .. '\'')
 end
 
+--overcrowded_resource returns true if one or more entity <resource_name> is found within <min_gap> tiles from <position>
+local function overcrowded_resource(surface, position, resource_name, min_gap)
+    local d = min_gap
+    local bounding_box = {{x = position.x - d + 1, y = position.y - d + 1}, {x = position.x + d, y = position.y + d}}
+    local found_resources = surface.find_entities_filtered{area = bounding_box, name = resource_name}
+    if #found_resources == 0 then
+        return false
+    else
+        return true
+    end
+end
+
 --[[--
     Registers all event handlers.
 ]]
@@ -134,6 +146,14 @@ function ScatteredResources.register(config)
             return false
         end
 
+        local position = {x = x, y = y}
+        if resource_name == 'crude-oil' then
+            local min_gap = 2  --must be at least this many tiles between crude-oil patches
+            if overcrowded_resource(surface, position, resource_name, min_gap) then
+                return false  --when overcrowded_resource is true, skip this resource spawn
+            end
+        end
+
         local range = resource_richness_values[get_name_by_weight(resource_richness_weights, resource_richness_weights_sum)]
         local amount = random(range[1], range[2]) * (1 + ((distance / cluster.distance_richness) * 0.01)) * cluster.yield
 
@@ -141,7 +161,7 @@ function ScatteredResources.register(config)
             amount = amount * resource_type_scalar[resource_name]
         end
 
-        template_resources(surface, {{name = resource_name, position = {x = x, y = y}, amount = ceil(amount)}})
+        template_resources(surface, {{name = resource_name, position = position, amount = ceil(amount)}})
         return true
     end
 

--- a/map_gen/maps/diggy/feature/scattered_resources.lua
+++ b/map_gen/maps/diggy/feature/scattered_resources.lua
@@ -38,8 +38,8 @@ end
 local function overcrowded_resource(surface, position, resource_name, min_gap)
     local d = min_gap
     local bounding_box = {{x = position.x - d + 1, y = position.y - d + 1}, {x = position.x + d, y = position.y + d}}
-    local found_resources = surface.find_entities_filtered{area = bounding_box, name = resource_name}
-    if #found_resources == 0 then
+    local found_resources = surface.count_entities_filtered{area = bounding_box, name = resource_name, limit = 1}
+    if found_resources == 0 then
         return false
     else
         return true

--- a/map_gen/maps/diggy/feature/scattered_resources.lua
+++ b/map_gen/maps/diggy/feature/scattered_resources.lua
@@ -143,7 +143,9 @@ function ScatteredResources.register(config)
 
         local position = {x = x, y = y}
         if resource_name == 'crude-oil' then
-            local min_gap = 2  --default is 2.  Represents minimum tile gap between resources.
+            -- min_gap default is 2.  Represents minimum tile gap between resources in cluster.
+            -- Can be >=0, but keep value small in relation to expected resource patch width. 
+            local min_gap = 2  
             if overcrowded_resource(surface, position, resource_name, min_gap) then
                 return false  --when overcrowded_resource is true, skip this resource spawn
             end

--- a/map_gen/maps/diggy/feature/scattered_resources.lua
+++ b/map_gen/maps/diggy/feature/scattered_resources.lua
@@ -144,8 +144,8 @@ function ScatteredResources.register(config)
         local position = {x = x, y = y}
         if resource_name == 'crude-oil' then
             -- min_gap default is 2.  Represents minimum tile gap between resources in cluster.
-            -- Can be >=0, but keep value small in relation to expected resource patch width. 
-            local min_gap = 2  
+            -- Can be >=0, but keep value small in relation to expected resource patch width.
+            local min_gap = 2
             if overcrowded_resource(surface, position, resource_name, min_gap) then
                 return false  --when overcrowded_resource is true, skip this resource spawn
             end


### PR DESCRIPTION
Over time I have seen several people report that some oil patches that were too close to place adjacent pumpjacks in diggy.   Although it isn't game breaking (you can still choose one or the other to tap into) it keeps getting reported as buggy behavior.    Since vanilla oil spawn generation is too infrequent even on highest frequency for diggy, I created this update for scattered_resources.lua that will prevent oil patches from spawning less than a two tile gap from another oil patch.