### PR TITLE
Add distant large biter caves to Diggy

### DIFF
--- a/map_gen/maps/diggy/config.lua
+++ b/map_gen/maps/diggy/config.lua
@@ -169,15 +169,35 @@ local Config = {
         -- automatically opens areas
         simple_room_generator = {
             enabled = true,
-            -- value between 0 and 1, higher value means stronger variance between coordinates
-            noise_variance = 0.066,
+
+            --distance in tiles that the room noise pattern changes to enable large room (cave) generation
+            --if large caves are not desired, this number can be set to a large distance, i.e. 100000
+            large_room_minimum_distance = 128,
+
+            noise_settings = {
+                -- higher numbers for variance actually have less variance  i.e. larger room features.
+                -- Similar system used ores in scattered_resources.lua.  Here we are using two noise patterns for rooms (caves)
+                -- starting_sources is noise pattern used near spawn to generate small rooms similar to traditional Diggy
+                -- distant_sources is noise pattern used after large_room_minimum_distance to sometimes generate large caves
+                starting_sources = {
+                    {variance = 60, weight = 0, offset = 000, type = "perlin"},
+                    {variance = 20, weight = 1, offset = 150, type = "perlin"},
+                    {variance = 8, weight = 0.2, offset = 300, type = "perlin"}
+                },
+                distant_sources = {
+                    {variance = 60, weight = 1, offset = 000, type = "perlin"},
+                    {variance = 20, weight = 0.3, offset = 150, type = "perlin"},
+                    {variance = 8, weight = 0.1, offset = 300, type = "perlin"}
+                }
+            },
             -- shows where rooms are located
             display_room_locations = false,
             -- minimum distance and noise range required for water to spawn
             room_noise_minimum_distance = 9,
             room_noise_ranges = {
-                {name = 'water', min = 0.54, max = 1},
-                {name = 'dirt', min = 0.37, max = 0.54}
+                {name = 'deep', min = 0.6, max = 3},
+                {name = 'water', min = 0.56, max = 0.6},
+                {name = 'dirt', min = 0.34, max = 0.56}
             }
         },
         -- responsible for resource spawning

--- a/map_gen/maps/diggy/feature/simple_room_generator.lua
+++ b/map_gen/maps/diggy/feature/simple_room_generator.lua
@@ -45,15 +45,17 @@ local function handle_noise(name, surface, position)
 
     if 'dirt' == name then
         return
-    end
-
-    if 'water' == name then
+    elseif 'water' == name then
+        -- water is slower because for some odd reason it doesn't always want to mine it properly
+        set_timeout_in_ticks(4, do_spawn_tile, { surface = surface, tile = {name = 'water-green', position = position}})
+        return
+    elseif 'deep' == name then
         -- water is slower because for some odd reason it doesn't always want to mine it properly
         set_timeout_in_ticks(4, do_spawn_tile, { surface = surface, tile = {name = 'deepwater-green', position = position}})
         return
+    else
+        error('No noise handled for type \'' .. name .. '\'')
     end
-
-    error('No noise handled for type \'' .. name .. '\'')
 end
 
 --[[--
@@ -61,12 +63,43 @@ end
 ]]
 function SimpleRoomGenerator.register(config)
     local room_noise_minimum_distance_sq = config.room_noise_minimum_distance * config.room_noise_minimum_distance
-    local noise_variance = config.noise_variance
+    local large_room_minimum_distance_sq = config.large_room_minimum_distance * config.large_room_minimum_distance
 
-    local seed
-    local function get_noise(surface, x, y)
-        seed = seed or surface.map_gen_settings.seed + surface.index + 100
-        return perlin_noise(x * noise_variance, y * noise_variance, seed)
+    -- Generate noise for room generation using settings from ...\map_gen\maps\diggy\config.lua
+    -- using same seeded_noise function as in scattered_resources.lua.
+    local base_seed
+    local function seeded_noise(surface, x, y, index, sources)
+        base_seed = base_seed or surface.map_gen_settings.seed + surface.index + 4000
+        local noise = 0
+        for _, settings in pairs(sources) do
+            settings.type = settings.type or 'perlin'
+            settings.offset = settings.offset or 0
+            if settings.type == 'zero' then
+                noise = noise + 0
+            elseif settings.type == 'one' then
+                noise = noise + settings.weight * 1
+            elseif settings.type == 'perlin' then
+                noise = noise + settings.weight * perlin_noise(x/settings.variance, y/settings.variance,
+                            base_seed + 2000*index + settings.offset)
+            elseif settings.type == 'simplex' then
+                noise = noise + settings.weight * Simplex.d2(x/settings.variance, y/settings.variance,
+                            base_seed + 2000*index + settings.offset)
+           else
+                Debug.print('noise type \'' .. settings.type .. '\' not recognized')
+           end
+        end
+        return noise
+    end
+
+    function get_room_noise_cfg(x, y)
+        local distance_sq = x * x + y * y
+        if (distance_sq <= room_noise_minimum_distance_sq) then
+            return nil
+        elseif (distance_sq < large_room_minimum_distance_sq) then
+            return config.noise_settings.starting_sources
+        else
+            return config.noise_settings.distant_sources
+        end
     end
 
     Event.add(Template.events.on_void_removed, function (event)
@@ -74,14 +107,15 @@ function SimpleRoomGenerator.register(config)
         local x = position.x
         local y = position.y
 
-        local distance_sq = x * x + y * y
-
-        if (distance_sq <= room_noise_minimum_distance_sq) then
+        local room_noise_cfg = get_room_noise_cfg(x, y)
+        if not room_noise_cfg then
             return
         end
 
         local surface = event.surface
-        local noise = get_noise(surface, x, y)
+
+        local noise = seeded_noise(surface, x, y, 1, room_noise_cfg)
+
         for _, noise_range in pairs(config.room_noise_ranges) do
             if (noise >= noise_range.min and noise <= noise_range.max) then
                 handle_noise(noise_range.name, surface, position)
@@ -97,9 +131,12 @@ function SimpleRoomGenerator.register(config)
             for x = area.left_top.x, area.left_top.x + 31 do
                 for y = area.left_top.y, area.left_top.y + 31 do
                     for _, noise_range in pairs(config.room_noise_ranges) do
-                        local noise = get_noise(surface, x, y)
-                        if (noise >= noise_range.min and noise <= noise_range.max) then
-                            Debug.print_grid_value(noise_range.name, surface, {x = x, y = y}, nil, nil, true)
+                        local room_noise_cfg = get_room_noise_cfg(x, y)
+                        if room_noise_cfg then
+                            local noise = seeded_noise(surface, x, y, 1, room_noise_cfg)
+                            if (noise >= noise_range.min and noise <= noise_range.max) then
+                                Debug.print_grid_value(noise_range.name, surface, {x = x, y = y}, nil, nil, true)
+                            end
                         end
                     end
                 end

--- a/map_gen/maps/diggy/feature/simple_room_generator.lua
+++ b/map_gen/maps/diggy/feature/simple_room_generator.lua
@@ -10,7 +10,8 @@ local Task = require 'utils.task'
 local Token = require 'utils.token'
 local raise_event = script.raise_event
 local pairs = pairs
-local perlin_noise = require 'map_gen.shared.perlin_noise'.noise
+local Perlin = require 'map_gen.shared.perlin_noise'
+local Simplex = require 'map_gen.shared.simplex_noise'
 local template_insert = Template.insert
 local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local on_entity_died = defines.events.on_entity_died
@@ -79,7 +80,7 @@ function SimpleRoomGenerator.register(config)
             elseif settings.type == 'one' then
                 noise = noise + settings.weight * 1
             elseif settings.type == 'perlin' then
-                noise = noise + settings.weight * perlin_noise(x/settings.variance, y/settings.variance,
+                noise = noise + settings.weight * Perlin.noise(x/settings.variance, y/settings.variance,
                             base_seed + 2000*index + settings.offset)
             elseif settings.type == 'simplex' then
                 noise = noise + settings.weight * Simplex.d2(x/settings.variance, y/settings.variance,
@@ -91,7 +92,7 @@ function SimpleRoomGenerator.register(config)
         return noise
     end
 
-    function get_room_noise_cfg(x, y)
+    local function get_room_noise_cfg(x, y)
         local distance_sq = x * x + y * y
         if (distance_sq <= room_noise_minimum_distance_sq) then
             return nil

--- a/map_gen/maps/diggy/scenario.lua
+++ b/map_gen/maps/diggy/scenario.lua
@@ -73,8 +73,11 @@ function Scenario.register()
         end
     )
 
-    local landfill_tiles = {'dirt-1','dirt-2','dirt-3','dirt-4','dirt-5','dirt-6','dirt-7'}
-    require ('map_gen.shared.change_landfill_tile')(landfill_tiles)
+    --[[ The commented lines below were used prior to the new landfill introduced in Factorio 0.17.10 to replace the grass-1 landfill
+          with dirt tiles. The new landfill looks great in Diggy, so let's use that instead.
+    ]]
+    -- local landfill_tiles = {'dirt-1','dirt-2','dirt-3','dirt-4','dirt-5','dirt-6','dirt-7'}
+    -- require ('map_gen.shared.change_landfill_tile')(landfill_tiles)
 
     ScenarioInfo.set_map_name('Diggy')
     ScenarioInfo.set_map_description('Dig your way through!')


### PR DESCRIPTION
Description:   This pull request is related to Diggy feedback/todo collection thread #926 and specifically, Diggy Scenario Idea - Biter caves: #244.   
The implementation below creates two different noise patterns.   One compound noise pattern is used near the spawn area and creates small openings near the spawn similar in size to current Diggy implementation.   A second compound noise pattern is used when over a certain distance (set in config) from the origin which has the potential to generate cave-like openings that can be approximately 2-10 times as large in size.     Effort was made to use the same seeded_noise function in scattered_resources.lua to move closer towards another wishlist item "Replace room and terrain generation by the same system that generates ores". 
Additional small change in this PR:  Allow for the use of the new landfill tile introduced in 0.17.10 which looks great in Diggy.  (it used to be grass-1 and Diggy overwrote it with random dirt tiles). 
Would like to open to beta test play and gather some feedback prior to merging.       