### PR TITLE
Fix redmew shared gui tasklist

### DIFF
--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -249,7 +249,7 @@ local function redraw_tasks(data, enabled)
             parent.add({type = 'flow'}).add {
             type = 'sprite-button',
             name = delete_task_button_name,
-            sprite = 'utility/remove',
+            sprite = 'utility/trash',
             tooltip = delete_button_tooltip
         }
         delete_button.enabled = enabled


### PR DESCRIPTION
It was noticed yesterday that the tasklist feature in the redmew shared gui is broken.    I tried in multiplayer Diggy as well as crashsite to create a new task.   Nothing happens.  When trying it in single player with debug mode turned on an error generated indicating  'Unknown sprite "utility/remove"'.    A sprite by this name no longer appears to be available https://wiki.factorio.com/Prototype/UtilitySprites .  Located a suitable replacement sprite 'utility/trash'  and tested.    