### PR TITLE
Fix poll

### DIFF
--- a/features/gui/poll.lua
+++ b/features/gui/poll.lua
@@ -518,7 +518,7 @@ local function redraw_create_poll_content(data)
                 delete_flow.add {
                 type = 'sprite-button',
                 name = create_poll_delete_answer_name,
-                sprite = 'utility/remove',
+                sprite = 'utility/trash',
                 tooltip = 'Delete answer field.'
             }
             delete_button.style.height = 26


### PR DESCRIPTION
Fix poll in shared RedMew GUI.   One of the recent Factorio updates appears to have done away with the sprite 'utility/remove', so replacing it with 'utility/trash'.