### PR TITLE
Fix restart state not reset when fails to start scenario.

### DIFF
--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -34,6 +34,7 @@ callback =
         if state == 0 then
             Server.start_scenario(data.scenario_name)
             double_print('restarting')
+            global_data.restarting = nil
             return
         elseif state == 1 then
             Popup.all('\nServer restarting!\nInitiated by ' .. data.name .. '\n')


### PR DESCRIPTION
When a scenario fails to start the restarting state was not reset, which prevented another restart from being started. We now clear the restarting flag.