### PR TITLE
Artillery kills cause bots to spawn and shoot across the map.

### DIFF
--- a/map_gen/maps/crash_site/entity_died_events.lua
+++ b/map_gen/maps/crash_site/entity_died_events.lua
@@ -283,7 +283,14 @@ end
 local bot_spawn_whitelist = {
     ['gun-turret'] = true,
     ['laser-turret'] = true,
-    ['flamethrower-turret'] = true
+    ['flamethrower-turret'] = true,
+    ['artillery-turret'] = true
+}
+
+local bot_cause_whitelist = {
+    ['character'] = true,
+    ['artillery-turret'] = true,
+    ['artillery-wagon'] = true,
 }
 
 local function do_bot_spawn(entity_name, entity, event)
@@ -292,8 +299,7 @@ local function do_bot_spawn(entity_name, entity, event)
     local entity_force = entity.force
     local ef = entity_force.evolution_factor
 
-    -- Remove 'character' condition so that attack form any entity such as artillery will cause the bots to spawn.
-    if not bot_spawn_whitelist[entity_name] or (cause.name ~= 'character') or ef <= 0.2 then
+    if not bot_spawn_whitelist[entity_name] or not bot_cause_whitelist[cause.name] or ef <= 0.2 then
         return
     end
 
@@ -308,7 +314,6 @@ local function do_bot_spawn(entity_name, entity, event)
         target = cause,
         force = entity_force
     }
-
     if entity_name == 'gun-turret' then
         for i = 1, repeat_cycle do
             spawn_entity.name = 'defender'
@@ -327,13 +332,23 @@ local function do_bot_spawn(entity_name, entity, event)
             create_entity(spawn_entity)
             create_entity(spawn_entity)
         end
-    else
+    elseif entity_name == 'flamethrower-turret' then
         for i = 1, repeat_cycle do
             spawn_entity.name = 'distractor-capsule'
             spawn_entity.speed = 0
             create_entity(spawn_entity)
         end
     end
+    else
+        for i = 1, 10 do
+            spawn_entity.name = 'defender'
+            create_entity(spawn_entity)
+            create_entity(spawn_entity)
+
+            spawn_entity.name = 'destroyer'
+            create_entity(spawn_entity)
+            create_entity(spawn_entity)
+        end
 end
 
 local function do_coin_drop(entity_name, entity)

--- a/map_gen/maps/crash_site/entity_died_events.lua
+++ b/map_gen/maps/crash_site/entity_died_events.lua
@@ -314,7 +314,23 @@ local function do_bot_spawn(entity_name, entity, event)
         target = cause,
         force = entity_force
     }
-    if entity_name == 'gun-turret' then
+    
+    if cause.name ~= 'character' then
+        if entity_name == 'artillery-turret' then
+            repeat_cycle = 15
+        else
+            repeat_cycle = 4
+        end
+        for i = 1, repeat_cycle do
+            spawn_entity.name = 'defender'
+            create_entity(spawn_entity)
+            create_entity(spawn_entity)
+
+            spawn_entity.name = 'destroyer'
+            create_entity(spawn_entity)
+            create_entity(spawn_entity)
+        end
+    elseif entity_name == 'gun-turret' then
         for i = 1, repeat_cycle do
             spawn_entity.name = 'defender'
             create_entity(spawn_entity)
@@ -332,23 +348,13 @@ local function do_bot_spawn(entity_name, entity, event)
             create_entity(spawn_entity)
             create_entity(spawn_entity)
         end
-    elseif entity_name == 'flamethrower-turret' then
+    else
         for i = 1, repeat_cycle do
             spawn_entity.name = 'distractor-capsule'
             spawn_entity.speed = 0
             create_entity(spawn_entity)
         end
     end
-    else
-        for i = 1, 10 do
-            spawn_entity.name = 'defender'
-            create_entity(spawn_entity)
-            create_entity(spawn_entity)
-
-            spawn_entity.name = 'destroyer'
-            create_entity(spawn_entity)
-            create_entity(spawn_entity)
-        end
 end
 
 local function do_coin_drop(entity_name, entity)


### PR DESCRIPTION
- If player Arty kills enemy arty about 60 bots spawn (30 defenders + 30 destroyers)
Typically players kill 4 enemy arty so about 240 bots will spawn.

- If player Arty kills any enemy turret spawn about 16 bots (8 defenders + 8 destroyers) 
Typically arty automatically kills 6 enemy turrets so 96 bots will be spawned that 

Tested on a typical end game crash site map haven't noticed any performance issues. (I don't have a good PC)

I feel it is a good addition to the late game. Players will have to fortify around the arty turrets and make sure the damage is repaired while before the arty's were just placed and fed ammo.
