### PR TITLE
Remove compilatron-chest from cheat items.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -202,8 +202,6 @@ global.config = {
                 {name = 'computer', count = 2},
                 {name = 'infinity-pipe', count = 10},
                 {name = 'heat-interface', count = 10},
-                {name = 'compilatron-chest', count = 5},
-                {name = 'compilatron-chest', count = 5},
                 {name = 'selection-tool', count = 1}
             }
         }


### PR DESCRIPTION
Looks like they have been removed from the game so we have to remove them from the cheat items to allow cheat mode to still work.