### PR TITLE
Recommended Diggy bot mining update for Factorio .18.27

### DIFF
--- a/map_gen/maps/diggy/config.lua
+++ b/map_gen/maps/diggy/config.lua
@@ -56,8 +56,10 @@ local Config = {
         -- core feature
         diggy_hole = {
             enabled = true,
-            -- initial damage per tick it damages a rock to mine, can be enhanced by robot_damage_per_mining_prod_level
-            robot_initial_mining_damage = 4,
+            -- delay in ticks between robot mining rock and rock being marked again for deconstruction
+            robot_mining_delay = 10,
+            -- This value is multiplied with robot_mining_delay to determine mining damage applied.  Can be enhanced by robot_damage_per_mining_prod_level
+            robot_per_tick_damage = 4,
             -- damage added per level of mining productivity level research
             robot_damage_per_mining_prod_level = 1,
 

--- a/map_gen/maps/diggy/config.lua
+++ b/map_gen/maps/diggy/config.lua
@@ -57,7 +57,7 @@ local Config = {
         diggy_hole = {
             enabled = true,
             -- delay in ticks between robot mining rock and rock being marked again for deconstruction
-            robot_mining_delay = 10,
+            robot_mining_delay = 6,
             -- This value is multiplied with robot_mining_delay to determine mining damage applied.  Can be enhanced by robot_damage_per_mining_prod_level
             robot_per_tick_damage = 4,
             -- damage added per level of mining productivity level research

--- a/map_gen/maps/diggy/feature/diggy_hole.lua
+++ b/map_gen/maps/diggy/feature/diggy_hole.lua
@@ -186,6 +186,9 @@ function DiggyHole.register(cfg)
         if not is_diggy_rock(name) then
             return
         end
+        if event.force.name == "remove_loot" then
+            event.loot.clear()
+        end
         diggy_hole(entity)
         if event.cause then
             destroy_rock(entity.surface.create_particle, 10, entity.position)
@@ -203,7 +206,7 @@ function DiggyHole.register(cfg)
         if not is_diggy_rock(name) then
             return
         end
-        entity.die(event.force, event.cause)
+        entity.die("remove_loot", event.cause)
     end)
 
     Event.add(defines.events.on_robot_mined_entity, function (event)
@@ -226,11 +229,11 @@ function DiggyHole.register(cfg)
 
         if health_update < 1 then
             mine_rock(create_particle, 6, position)
-            entity.die(force)
+            entity.die("remove_loot")
         else
             entity.destroy()
             local rock = create_entity({name = name, position = position})
-            mine_rock(create_particle, 1, position)
+            mine_rock(create_particle, 2, position)
             rock.graphics_variation = graphics_variation
             rock.health = health
             --Mark replaced rock for de-construction and apply health_update after delay.  Health verified and
@@ -281,6 +284,9 @@ end
 function DiggyHole.on_init()
     game.forces.player.technologies['landfill'].enabled = config.allow_landfill_research
     game.forces.player.technologies['atomic-bomb'].enabled = false
+    -- remove_loot force name used to tag entities that have died using entity.die()
+    -- that need loot removed when handling event on_entity_died
+    game.create_force("remove_loot")
 end
 
 return DiggyHole

--- a/map_gen/maps/diggy/feature/diggy_hole.lua
+++ b/map_gen/maps/diggy/feature/diggy_hole.lua
@@ -20,6 +20,7 @@ local pairs = pairs
 local is_diggy_rock = Template.is_diggy_rock
 local destroy_rock = CreateParticles.destroy_rock
 local mine_rock = CreateParticles.mine_rock
+local raise_event = script.raise_event
 local mine_size_name = 'mine-size'
 local ceil = math.ceil
 
@@ -247,7 +248,7 @@ function DiggyHole.register(cfg)
         entity.destroy()
 
         local rock = create_entity({name = name, position = position})
-        mine_rock(create_particle, ceil(delay / 3), position)
+        mine_rock(create_particle, ceil(delay / 2), position)
         rock.graphics_variation = graphics_variation
         rock.health = health
         --Mark replaced rock for de-construction and apply health_update after delay.  Health verified and

--- a/map_gen/maps/diggy/feature/diggy_hole.lua
+++ b/map_gen/maps/diggy/feature/diggy_hole.lua
@@ -11,13 +11,15 @@ local ScoreTracker = require 'utils.score_tracker'
 local Command = require 'utils.command'
 local CreateParticles = require 'features.create_particles'
 local Ranks = require 'resources.ranks'
+local Token = require 'utils.token'
+local Task = require 'utils.task'
+local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local random = math.random
 local tonumber = tonumber
 local pairs = pairs
 local is_diggy_rock = Template.is_diggy_rock
 local destroy_rock = CreateParticles.destroy_rock
 local mine_rock = CreateParticles.mine_rock
-local raise_event = script.raise_event
 local mine_size_name = 'mine-size'
 
 -- this
@@ -32,7 +34,26 @@ local robot_mining = {
     damage = 0,
     active_modifier = 0,
     research_modifier = 0,
+    delay = 0
 }
+
+-- Used in conjunction with set_timeout_in_ticks(robot_mining_delay...  to control bot mining frequency
+-- Robot_mining.damage is equal to robot_mining_delay * robot_per_tick_damage
+-- So for example if robot_mining delay is doubled, robot_mining.damage gets doubled to compensate.
+local metered_bot_mining = Token.register(function(params)
+    local entity = params.entity
+    local force = params.force
+    local health_update = params.health_update
+    if entity.valid then
+        local health = entity.health
+        --If health of entity didn't change during delay apply bot mining damage and re-order order_deconstruction
+        --If rock was damaged during the delay the bot gets scared off and stops mining this particular rock.
+        if health_update == health - robot_mining.damage then
+            entity.health = health_update
+            entity.order_deconstruction(force)
+        end
+    end
+end)
 
 Global.register({
     full_inventory_mining_cache = full_inventory_mining_cache,
@@ -156,7 +177,8 @@ function DiggyHole.register(cfg)
     global_to_show[#global_to_show + 1] = mine_size_name
 
     config = cfg
-    robot_mining.damage = cfg.robot_initial_mining_damage
+    robot_mining.delay = cfg.robot_mining_delay
+    robot_mining.damage = cfg.robot_per_tick_damage * robot_mining.delay
 
     Event.add(defines.events.on_entity_died, function (event)
         local entity = event.entity
@@ -181,9 +203,7 @@ function DiggyHole.register(cfg)
         if not is_diggy_rock(name) then
             return
         end
-
-        raise_event(defines.events.on_entity_died, {entity = entity, cause = event.cause, force = event.force})
-        entity.destroy()
+        entity.die(event.force, event.cause)
     end)
 
     Event.add(defines.events.on_robot_mined_entity, function (event)
@@ -195,7 +215,7 @@ function DiggyHole.register(cfg)
         end
 
         local health = entity.health
-        health = health - robot_mining.damage
+        local health_update = health - robot_mining.damage
         event.buffer.clear()
 
         local graphics_variation = entity.graphics_variation
@@ -204,19 +224,19 @@ function DiggyHole.register(cfg)
         local position = entity.position
         local force = event.robot.force
 
-        if health < 1 then
-            raise_event(defines.events.on_entity_died, {entity = entity, force = force})
+        if health_update < 1 then
             mine_rock(create_particle, 6, position)
+            entity.die(force)
+        else
             entity.destroy()
-            return
+            local rock = create_entity({name = name, position = position})
+            mine_rock(create_particle, 1, position)
+            rock.graphics_variation = graphics_variation
+            rock.health = health
+            --Mark replaced rock for de-construction and apply health_update after delay.  Health verified and
+            --update applied after delay to help prevent more rapid damage if someone were to spam deconstruction blueprints
+            set_timeout_in_ticks(robot_mining.delay, metered_bot_mining, {entity = rock, force = force, health_update = health_update})
         end
-        entity.destroy()
-
-        local rock = create_entity({name = name, position = position})
-        mine_rock(create_particle, 1, position)
-        rock.graphics_variation = graphics_variation
-        rock.order_deconstruction(force)
-        rock.health = health
     end)
 
     Event.add(defines.events.on_player_mined_entity, function (event)


### PR DESCRIPTION
This update is not strictly required for Factorio .18.27
However, .18.27 adds a bot deconstruction sound (no sound previously) and with the way that Diggy currently handles bot 'mining', each bot is triggering the sound 60 times a second.    This creates a very loud and annoying buzzing sound.
The proposed update changes bot behavior to only mark rocks again for deconstruction every x ticks instead of every tick.    This results in a softer, more pleasing pulsed mining sound.
This update also seems to improve bot mining predictability a little as well. 
If one has equal or more bots than the number of rocks selected bots will focus on their own rocks.  
Without this update even if one has more bots than rocks selected, some bots will jump around between different rocks (not exactly sure why).    Initially marking this as work in progress to get feedback and tweak frequency and damage for early and late game balance.

Special note:   This update would need to be merged after PR #1061 since it contains changes in diggy_hole.lua that are part of that PR