### PR TITLE
Update travis2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_deploy:
   - ./.travis/release_builder.sh
 deploy:
   on:
-    condition: $TRAVIS_EVENT_TYPE = cron || $TRAVIS_EVENT_TYPE = api
+    condition: $TRAVIS_EVENT_TYPE = api
     repo: Refactorio/RedMew
     branch: develop
   provider: releases


### PR DESCRIPTION
Pritority highest fast update this. 

Removed 
--(because this make every 24hour new releases)
$TRAVIS_EVENT_TYPE = cron