### PR TITLE
spidertron added to bot spawn whitelist

### DIFF
--- a/map_gen/maps/crash_site/entity_died_events.lua
+++ b/map_gen/maps/crash_site/entity_died_events.lua
@@ -290,7 +290,8 @@ local bot_spawn_whitelist = {
 local bot_cause_whitelist = {
     ['character'] = true,
     ['artillery-turret'] = true,
-    ['artillery-wagon'] = true
+    ['artillery-wagon'] = true,
+    ['spidertron'] = true
 }
 
 local function do_bot_spawn(entity_name, entity, event)


### PR DESCRIPTION
After playtesting this locally I feel taking outposts will be a challenge and not just mindless shooting. The spawned bots can kill a fully decked out spidertron due to its low speed of fire. Players may need to place turrets nearby when taking over outposts using spidertrons.