### PR TITLE
Updated crash site /restart command so that guests and regulars can call it when map is cleared

### DIFF
--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -59,10 +59,10 @@ local function restart(args, player)
 
     if Rank.less_than(player.name, Ranks.admin) then
         -- Check enemy count
-        local enemy_count = game.player.surface.count_entities_filtered{force= "enemy"}
+        local enemy_count = game.player.surface.count_entities_filtered{force= "enemy", limit=1}
         
         if (enemy_count ~= 0) then
-            game.player.print('All enemy spawners, worms, buildings, biters and spitters must be cleared for non-admin restart. Current enemy count: '.. enemy_count)
+            game.player.print('All enemy spawners, worms, buildings, biters and spitters must be cleared for non-admin restart.')
             return
         end 
     end
@@ -136,7 +136,7 @@ function Public.control(config)
             description = {'command_description.crash_site_restart'},
             arguments = {'scenario_name'},
             default_values = {scenario_name = default_name},
-            required_rank = Ranks.guest,
+            required_rank = Ranks.auto_trusted,
             allowed_by_server = true
         },
         restart

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -1,10 +1,12 @@
 local Command = require 'utils.command'
+local Rank = require 'features.rank_system'
 local Task = require 'utils.task'
 local Token = require 'utils.token'
 local Server = require 'features.server'
 local Popup = require 'features.gui.popup'
 local Global = require 'utils.global'
 local Ranks = require 'resources.ranks'
+local Utils = require 'utils.core'
 
 local server_player = {name = '<server>', print = print}
 
@@ -55,6 +57,16 @@ local function restart(args, player)
         return
     end
 
+    if Rank.less_than(player.name, Ranks.admin) then
+        -- Check enemy count
+        local enemy_count = game.player.surface.count_entities_filtered{force= "enemy"}
+        
+        if (enemy_count ~= 0) then
+            game.player.print('All enemy spawners, worms, buildings, biters and spitters must be cleared for non-admin restart. Current enemy count: '.. enemy_count)
+            return
+        end 
+    end
+    
     global_data.restarting = true
 
     double_print('#################-Attention-#################')
@@ -67,7 +79,7 @@ local function restart(args, player)
         end
     end
     print('Abort restart with /abort')
-
+    
     Task.set_timeout_in_ticks(60, callback, {name = player.name, scenario_name = args.scenario_name, state = 10})
 end
 
@@ -124,7 +136,7 @@ function Public.control(config)
             description = {'command_description.crash_site_restart'},
             arguments = {'scenario_name'},
             default_values = {scenario_name = default_name},
-            required_rank = Ranks.admin,
+            required_rank = Ranks.guest,
             allowed_by_server = true
         },
         restart

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -6,7 +6,6 @@ local Server = require 'features.server'
 local Popup = require 'features.gui.popup'
 local Global = require 'utils.global'
 local Ranks = require 'resources.ranks'
-local Utils = require 'utils.core'
 
 local Public = {}
 
@@ -55,9 +54,10 @@ callback =
 
 local entities_to_check = {
     'spitter-spawner','biter-spawner',
-    'small-worm-turret', 'medium-worm-turret','big-worm-turret', 'behemoth-worm-turret', 
-    'small-spitter', 'medium-spitter', 'big-spitter', 'behemoth-spitter', 
-    'small-biter', 'medium-biter', 'big-biter', 'behemoth-biter'
+    'small-worm-turret', 'medium-worm-turret','big-worm-turret', 'behemoth-worm-turret',
+    'small-spitter', 'medium-spitter', 'big-spitter', 'behemoth-spitter',
+    'small-biter', 'medium-biter', 'big-biter', 'behemoth-biter',
+    'gun-turret', 'laser-turret', 'artillery-turret', 'flamethrower-turret'
 }
 
 local function map_cleared()
@@ -81,18 +81,18 @@ local function restart(args, player)
         return
     end
 
-    if Rank.less_than(player.name, Ranks.admin) then
-        -- Check enemy count      
+    if player ~= server_player and Rank.less_than(player.name, Ranks.admin) then
+        -- Check enemy count
         if not map_cleared() then
-            game.player.print('All enemy spawners, worms, buildings, biters and spitters must be cleared for non-admin restart.')
+            player.print('All enemy spawners, worms, buildings, biters and spitters must be cleared for non-admin restart.')
             return
-        end 
+        end
 
         -- Limit the ability of non-admins to call the restart function with arguments to change the scenario
         -- If not an admin, restart the same scenario always
         sanitised_scenario = config.scenario_name
     end
-    
+
     global_data.restarting = true
 
     double_print('#################-Attention-#################')
@@ -105,7 +105,7 @@ local function restart(args, player)
         end
     end
     print('Abort restart with /abort')
-      
+
     Task.set_timeout_in_ticks(60, callback, {name = player.name, scenario_name = sanitised_scenario, state = 10})
 end
 

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -61,7 +61,6 @@ local entities_to_check = {
 }
 
 local function map_cleared()
-
     local get_entity_count = game.forces["enemy"].get_entity_count
     for i = 1, #entities_to_check do
         local name = entities_to_check[i]
@@ -99,9 +98,9 @@ local function restart(args, player)
     double_print('Server restart initiated by ' .. player.name)
     double_print('###########################################')
 
-    for k, v in pairs(game.players) do
-        if v.admin then
-            game.print('Abort restart with /abort')
+    for _, p in pairs(game.players) do
+        if p.admin then
+            p.print('Abort restart with /abort')
         end
     end
     print('Abort restart with /abort')

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -17,6 +17,7 @@ local RedmewConfig = require 'config'
 local Cutscene = require 'map_gen.maps.crash_site.cutscene'
 
 local degrees = math.degrees
+local cutscene_force_name = 'cutscene'
 
 local default_map_gen_settings = {
     MGSP.grass_only,
@@ -140,7 +141,7 @@ local spawn_callback =
 )
 
 local function cutscene_builder(name, x, y)
-    return game.surfaces.cutscene.create_entity {name = name, position = {x, y}, force = game.forces.enemy}
+    return game.surfaces.cutscene.create_entity {name = name, position = {x, y}, force = cutscene_force_name}
 end
 
 local function cutscene_outpost()
@@ -838,6 +839,11 @@ local map
 Global.register_init(
     {},
     function(tbl)
+        game.create_force(cutscene_force_name)
+        local surface = game.surfaces[1]
+        surface.map_gen_settings = {width = 2, height = 2}
+        surface.clear()
+
         local seed = RS.get_surface().map_gen_settings.seed
         tbl.outpost_seed = outpost_seed or seed
         tbl.ore_seed = ore_seed or seed


### PR DESCRIPTION

Updated crash site /restart command so that guests and regulars can call it when map is cleared
- Only admin can abort, once the map is cleared.
- Guests and Regular can both call /restart when all enemy units and structures are dead
- Tested on S10 by running this command:
/c local surface=game.player.surface
for key, entity in pairs(surface.find_entities_filtered({force="enemy"})) do
	entity.destroy()
end
- Need to merge into develop to test on live server in case conditions at the end of the game are different
- Thought about adding rocket launched condition but decided against it.