### PR TITLE
Spidertron artillery collision fix

### DIFF
--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -365,6 +365,7 @@ local function do_bot_spawn(entity_name, entity, event)
     end
 end
 
+-- Drops coins when biter/spitter spawners and worms are killed
 local function do_coin_drop(entity_name, entity)
     local position = entity.position
     local bounds = entity_drop_amount[entity_name]
@@ -478,3 +479,17 @@ Event.add(
         set_timeout_in_ticks(1, spawn_player, player)
     end
 )
+
+Event.add(
+    defines.events.on_combat_robot_expired,
+    function(event)
+
+        local entity = event.robot
+        local position = entity.position
+        if entity.force.name == 'enemy' then
+            entity.surface.create_entity{name = "cluster-grenade", position=position, target=position, speed=1}
+        end
+
+    end
+)
+

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -1,5 +1,5 @@
 require 'map_gen.maps.crash_site.blueprint_extractor'
-require 'map_gen.maps.crash_site.entity_died_events'
+require 'map_gen.maps.crash_site.events'
 require 'map_gen.maps.crash_site.weapon_balance'
 
 local b = require 'map_gen.shared.builders'


### PR DESCRIPTION
Adapted code from Damageable spider leg mod and added it to events.lua. 

Spidertrons now take damage from enemy artillery since before they were immune.