### PR TITLE
Spidertron jail fix

### DIFF
--- a/features/report.lua
+++ b/features/report.lua
@@ -195,7 +195,6 @@ function Module.jail(target_player, player)
 
     -- Add player to jail group
     permission_group.add_player(target_player)
-
     -- If in vehicle, kick them out and set the speed to 0.
     local vehicle = target_player.vehicle
     if vehicle then
@@ -203,6 +202,11 @@ function Module.jail(target_player, player)
         -- Trains can't have their speed set via ent.speed and instead need ent.train.speed
         if train then
             train.speed = 0
+        elseif vehicle.name == "spidertron" then
+            -- spidertron's can't have their speed set and will stop if a player is driving and exits
+            -- if the player uses spidertron remote then the spidertron will continue without the player
+            -- so set the spidertron autopilot position to its current position before kicking hte player
+            vehicle.autopilot_destination = vehicle.position 
         else
             vehicle.speed = 0
         end

--- a/features/report.lua
+++ b/features/report.lua
@@ -195,6 +195,7 @@ function Module.jail(target_player, player)
 
     -- Add player to jail group
     permission_group.add_player(target_player)
+    
     -- If in vehicle, kick them out and set the speed to 0.
     local vehicle = target_player.vehicle
     if vehicle then

--- a/features/report.lua
+++ b/features/report.lua
@@ -195,7 +195,7 @@ function Module.jail(target_player, player)
 
     -- Add player to jail group
     permission_group.add_player(target_player)
-    
+
     -- If in vehicle, kick them out and set the speed to 0.
     local vehicle = target_player.vehicle
     if vehicle then

--- a/features/report.lua
+++ b/features/report.lua
@@ -206,7 +206,7 @@ function Module.jail(target_player, player)
             -- spidertron's can't have their speed set and will stop if a player is driving and exits
             -- if the player uses spidertron remote then the spidertron will continue without the player
             -- so set the spidertron autopilot position to its current position before kicking hte player
-            vehicle.autopilot_destination = vehicle.position 
+            vehicle.autopilot_destination = vehicle.position
         else
             vehicle.speed = 0
         end


### PR DESCRIPTION
Issue #1102 describes errors when jailing a player while they're inside a spidertron.

This PR fixes that by checking if they're in a spidertron and setting the autopilot destination rather than the speed like for trains/cars/tanks.