### PR TITLE
Spidertron artillery immunity fix

### DIFF
--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1116,7 +1116,8 @@ local artillery_target_entities = {
     'locomotive',
     'cargo-wagon',
     'fluid-wagon',
-    'artillery-wagon'
+    'artillery-wagon',
+    'spidertron'
 }
 
 local artillery_target_callback =
@@ -1142,6 +1143,16 @@ local artillery_target_callback =
                 target = entity,
                 speed = 1.5
             }
+            if entity.name == "spidertron" then
+                -- fire a rocket as well as artillery-projectile since artillery-projectile doesn't damage spidertrons
+                -- Balance note: 1 rocket per artillery kills spidertron shield fast but takes ~ 1 minute to kill the spidertron
+                entity.surface.create_entity {
+                    name = 'rocket',
+                    position = position,
+                    target = entity,
+                    speed = 1.5
+                }
+            end
         end
     end
 )


### PR DESCRIPTION
- Added spidetron to artillery_target_entities list
- Added code to fire a rocket at spidertrons as well as the non-damaging artillery
- Tested effect of 4 and 8 artillery rockets on spidertron. Kills shields quick but spidertron takes about a minute to die. Enough to deter them from staying too long but not too OP.