### PR TITLE
WIP - airstrike command

### DIFF
--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -16,7 +16,6 @@ crash_site_airstrike_radius=Upgrade the airstrike radius to level __1__\n\nTo us
 crash_site_airstrike_radius_name_label=Airstrike Radius __1__
 crash_site_airstrike_count_name_label=Airstrike Damage __1__
 crash_site_airstrike_not_researched=You have not researched airstrike yet. Visit the market at the spawn [gps=-3,-3,redmew]
-crash_site_airstrike_chest_removed_error=Someone removed the chest. Replace it here: [gps=-0.5,-3.5,redmew]
 crash_site_airstrike_insufficient_currency_error=To send an air strike, load __1__ more poison capsules into the payment chest [gps=-0.5,-3.5,redmew]
 crash_site_airstrike_friendly_fire_error=You don't want to do that, no enemies found in the target area.
 crash_site_airstrike_damage_upgrade_success=Airstrike damage has been upgraded to level __1__

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -9,9 +9,19 @@ crash_site_restart_abort=Aborts the restart of the crashsite scenario.
 crash_site_spy=Spend coins to send a fish to spy on the enemy for a short time.
 crash_site_spy_invalid=You need to add a valid location to send a spy fish. e.g /spy [gps=-110,-17,redmew]
 crash_site_spy_funds=Training these spy fish ain't cheap! You need more coins!
+crash_site_airstrike_invalid=Invalid co-ordinates.
 crash_site_spy_success=__1__ used the /spy command and spent 1000 coins to train a fish to spy on the enemy [gps=__2__,__3__,redmew]
-crash_site_airstrike_count=Upgrade the airstrike damage to  to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike with a gps position\n\nDamage upgrades increase the number of poison capsules launched by airstrike.\n\nCurrent level: __2__\nCurrent shell count: __3__\nCurrent cost: __4__ poison capsules"
+crash_site_airstrike_count=Upgrade the airstrike damage to  to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike with a gps position\n\nDamage upgrades increase the number of poison capsules launched by airstrike.\n\nCurrent level: __2__\nCurrent shell count: __3__\nCurrent cost: __4__
 crash_site_airstrike_radius=Upgrade the airstrike radius to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike with a gps position\n\nCurrent level: __2__\nCurrent radius: __3__
+crash_site_airstrike_radius_name_label=Airstrike Radius __1__
+crash_site_airstrike_count_name_label=Airstrike Damage __1__
+crash_site_airstrike_not_researched=You have not researched airstrike yet. Visit the market at the spawn [gps=-3,-3,redmew]
+crash_site_airstrike_chest_removed_error=Someone removed the chest. Replace it here: [gps=-0.5,-3.5,redmew]
+crash_site_airstrike_insufficient_currency_error=To send an air strike, load __1__ more poison capsules into the payment chest [gps=-0.5,-3.5,redmew]
+crash_site_airstrike_friendly_fire_error=You don't want to do that, no enemies found in the target area.
+crash_site_airstrike_damage_upgrade_success=Airstrike damage has been upgraded to level __1__
+crash_site_airstrike_radius_upgrade_success=Airstrike radius has been upgraded to level __1__
+crash_site_airstrike_success=__1__ called an air strike [gps=__2__,__3__,redmew]
 dataset_copy=Copies a dataset
 dataset_move=Moves a dataset
 dataset_delete=Deletes a dataset

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -10,6 +10,8 @@ crash_site_spy=Spend coins to send a fish to spy on the enemy for a short time.
 crash_site_spy_invalid=You need to add a valid location to send a spy fish. e.g /spy [gps=-110,-17,redmew]
 crash_site_spy_funds=Training these spy fish ain't cheap! You need more coins!
 crash_site_spy_success=__1__ used the /spy command and spent 1000 coins to train a fish to spy on the enemy [gps=__2__,__3__,redmew]
+crash_site_airstrike_count=Upgrade the airstrike damage to  to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike with a gps position\n\nDamage upgrades increase the number of poison capsules launched by airstrike.\n\nCurrent level: __2__\nCurrent shell count: __3__\nCurrent cost: __4__ poison capsules"
+crash_site_airstrike_radius=Upgrade the airstrike radius to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike with a gps position\n\nCurrent level: __2__\nCurrent radius: __3__
 dataset_copy=Copies a dataset
 dataset_move=Moves a dataset
 dataset_delete=Deletes a dataset

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -253,8 +253,7 @@ local function strike(args, player)
 
     -- Do a simple check to make sure the player isn't trying to grief the base
     --local enemyEntities = s.find_entities_filtered {position = {xpos, ypos}, radius = radius, force = "enemy"}
-    local enemyEntities = game.player.surface.find_entities_filtered {area={{100,-100},{-100,100}}, force = "enemy"}
-    game.print(#enemyEntities)
+    local enemyEntities = player.surface.find_entities_filtered {position = {xpos,ypos}, radius=radius+30, force = "enemy"}
     if #enemyEntities < 1 then
         player.print("You don't want to do that, no enemies found in the target area.")
         for _, p in pairs(game.players) do

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -245,7 +245,7 @@ local function strike(args, player)
     -- Check the contents of the chest by spawn for enough poison capsules to use as payment
     local inv = dropbox.get_inventory(defines.inventory.chest)
     local capCount = inv.get_item_count("poison-capsule")
-    
+
     if capCount < strikeCost then
         player.print("To send an air strike, load " .. strikeCost - capCount .. " more poison capsules into the payment chest [gps=-0.5,-3.5,redmew]")
         return
@@ -282,7 +282,7 @@ local function strike(args, player)
 end
 
 Event.add(Retailer.events.on_market_purchase, function(event)
-    
+
     local market_id = event.group_name
     local group_label = Retailer.get_market_group_label(market_id)
     if group_label ~= 'Spawn' then

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -250,7 +250,7 @@ local function strike(args, player)
 
     -- Do a simple check to make sure the player isn't trying to grief the base
     --local enemyEntities = s.find_entities_filtered {position = {xpos, ypos}, radius = radius, force = "enemy"}
-    local enemyEntities = player.surface.count_entities_filtered {position = {xpos,ypos}, radius=radius+30, force = "enemy"}
+    local enemyEntities = player.surface.count_entities_filtered {position = {xpos,ypos}, radius=radius+30, force = "enemy", limit=1}
     if enemyEntities < 1 then
         player.print({'command_description.crash_site_airstrike_friendly_fire_error'}, Color.fail)
         Utils.print_admins(player.name .. " tried to airstrike the base here: [gps=" .. xpos .. "," .. ypos ..",redmew]", nil)

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -250,8 +250,8 @@ local function strike(args, player)
 
     -- Do a simple check to make sure the player isn't trying to grief the base
     --local enemyEntities = s.find_entities_filtered {position = {xpos, ypos}, radius = radius, force = "enemy"}
-    local enemyEntities = player.surface.find_entities_filtered {position = {xpos,ypos}, radius=radius+30, force = "enemy"}
-    if #enemyEntities < 1 then
+    local enemyEntities = player.surface.count_entities_filtered {position = {xpos,ypos}, radius=radius+30, force = "enemy"}
+    if enemyEntities < 1 then
         player.print({'command_description.crash_site_airstrike_friendly_fire_error'}, Color.fail)
         Utils.print_admins(player.name .. " tried to airstrike the base here: [gps=" .. xpos .. "," .. ypos ..",redmew]", nil)
         return

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -235,14 +235,6 @@ local function strike(args, player)
     local xpos=coords[1]
     local ypos=coords[2]
 
-    -- Check the chest is still there. Better than making destructible and mineable false because then players can upgrade the chest
-    local entities = s.find_entities_filtered {position = {-0.5, -3.5}, type = 'container', limit=1}
-    local dropbox = entities[1]
-    if dropbox == nil then
-        player.print({'command_description.crash_site_airstrike_chest_removed_error'}, Color.fail)
-        return
-    end
-
     -- Check the contents of the chest by spawn for enough poison capsules to use as payment
     local inv = dropbox.get_inventory(defines.inventory.chest)
     local capCount = inv.get_item_count("poison-capsule")

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -257,7 +257,7 @@ local function strike(args, player)
     local enemyEntities = player.surface.find_entities_filtered {position = {xpos,ypos}, radius=radius+30, force = "enemy"}
     if #enemyEntities < 1 then
         player.print({'command_description.crash_site_airstrike_friendly_fire_error'}, Color.fail)
-        --Utils.print_admins(player.name .. " tried to airstrike the base here: [gps=" .. xpos .. "," .. ypos ..",redmew]", nil)
+        Utils.print_admins(player.name .. " tried to airstrike the base here: [gps=" .. xpos .. "," .. ypos ..",redmew]", nil)
         return
     end
 

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -235,9 +235,14 @@ local function strike(args, player)
     local xpos=coords[1]
     local ypos=coords[2]
 
-    -- Check the chest is still there. Better than making destructible and mineable false because then players can upgrade the chest
+    -- Check that the chest is where it should be.
     local entities = s.find_entities_filtered {position = {-0.5, -3.5}, type = 'container', limit=1}
     local dropbox = entities[1]
+
+    if dropbox == nil then
+        player.print("Chest not found. Replace it here: [gps=-0.5,-3.5,redmew]")
+        return
+    end
 
     -- Check the contents of the chest by spawn for enough poison capsules to use as payment
     local inv = dropbox.get_inventory(defines.inventory.chest)

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -155,7 +155,7 @@ local function abort(_, player)
     end
 end
 
-local chart_area_callback = Token.register(function(data)      
+local chart_area_callback = Token.register(function(data)
     local xpos = data.xpos
     local ypos = data.ypos
     local player = data.player
@@ -200,20 +200,19 @@ local function spy(args, player)
     end
 end
 
-local spawn_poison_callback = Token.register(function(data)      
+local spawn_poison_callback = Token.register(function(data)
     local r = data.r
     data.s.create_entity{name = "poison-capsule", position={0,0}, target={data.xpos + math.random(-r,r), data.ypos + math.random(-r,r)}, speed=10}
 end)
 
 local function strike(args, player)
-    local player_name = player.name
     local s = player.surface
     local location_string = args.location
     local coords = {}
- 
+
     local radius_level = airstrike_data.radius_level    -- max radius of the strike area
     local count_level = airstrike_data.count_level      -- the number of poison capsules launched at the enemy
-    if count_level == 1 then 
+    if count_level == 1 then
         player.print("You have not researched airstrike yet. Visit the market at the spawn [gps=-3,-3,redmew]")
         return
     end
@@ -221,7 +220,7 @@ local function strike(args, player)
     local radius = 5+(radius_level*3)
     local count = (count_level-1)*5+3
     local strikeCost = count * 3            -- the number of poison-capsules required in the chest as payment
-    
+
     -- parse GPS coordinates from map ping
     for m in string.gmatch( location_string, "%-?%d+" ) do
         table.insert(coords, tonumber(m))
@@ -237,7 +236,7 @@ local function strike(args, player)
 
     -- Check the chest is still there. Better than making destructible and mineable false because then players can upgrade the chest
     local entities = s.find_entities_filtered {position = {-0.5, -3.5}, type = 'container', limit=1}
-    dropbox = entities[1]
+    local dropbox = entities[1]
     if dropbox == nil then
         player.print("Someone removed the chest. Replace it here: [gps=-0.5,-3.5,redmew] ")
         return
@@ -245,9 +244,9 @@ local function strike(args, player)
 
     -- Check the contents of the chest by spawn for enough poison capsules to use as payment
     local inv = dropbox.get_inventory(defines.inventory.chest)
-    capCount = inv.get_item_count("poison-capsule")
+    local capCount = inv.get_item_count("poison-capsule")
     
-    if capCount < strikeCost then 
+    if capCount < strikeCost then
         player.print("To send an air strike, load " .. strikeCost - capCount .. " more poison capsules into the payment chest [gps=-0.5,-3.5,redmew]")
         return
     end
@@ -264,7 +263,6 @@ local function strike(args, player)
             end
         end
         return
-        
     end
 
     inv.remove({name = "poison-capsule", count = strikeCost})
@@ -301,7 +299,7 @@ Event.add(Retailer.events.on_market_purchase, function(event)
     local count_level = airstrike_data.count_level      -- the number of poison capsules launched at the enemy
     local radius = 5+(radius_level*3)
     local count = (count_level-1)*5+3
-    local strikeCost = count * 4   
+    local strikeCost = count * 4
 
     local name = item.name
     if name == 'airstrike_damage' then
@@ -312,8 +310,6 @@ Event.add(Retailer.events.on_market_purchase, function(event)
         item.price = math.floor(math.exp(airstrike_data.count_level^0.8)/2)*1000
         item.description = {'command_description.crash_site_airstrike_count',  (count_level + 1), count_level, count, strikeCost}
         Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.
-        local toast_message = player.name .. "has upgraded airstrike damage to level " .. airstrike_data.count_level
-        Toast.toast_all_players(2, "test")
     elseif name == 'airstrike_radius' then
         airstrike_data.radius_level = airstrike_data.radius_level + 1
         Toast.toast_all_players(2, "Airstrike radius has been upgraded to level " .. radius_level)
@@ -321,8 +317,6 @@ Event.add(Retailer.events.on_market_purchase, function(event)
         item.description = {'command_description.crash_site_airstrike_radius', (radius_level + 1), radius_level, radius}
         item.price = math.floor(math.exp(airstrike_data.radius_level^0.8)/2)*1000
         Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.
-        local toast_message = player.name .. " has upgraded airstrike radius to level " .. airstrike_data.radius_level
-        Toast.toast_all_players(2, "test")
     end
 end)
 

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -235,6 +235,10 @@ local function strike(args, player)
     local xpos=coords[1]
     local ypos=coords[2]
 
+    -- Check the chest is still there. Better than making destructible and mineable false because then players can upgrade the chest
+    local entities = s.find_entities_filtered {position = {-0.5, -3.5}, type = 'container', limit=1}
+    local dropbox = entities[1]
+
     -- Check the contents of the chest by spawn for enough poison capsules to use as payment
     local inv = dropbox.get_inventory(defines.inventory.chest)
     local capCount = inv.get_item_count("poison-capsule")

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1560,6 +1560,16 @@ Public.deactivate_callback =
     end
 )
 
+
+Public.scenario_chest_callback = Token.register(function(chest)
+    if not chest or not chest.valid then
+        return
+    end
+
+    chest.destructible = false
+    chest.minable = false
+end)
+
 local function turret_died(event)
     local entity = event.entity
     if not entity or not entity.valid then

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1651,7 +1651,7 @@ Public.market_set_items_callback =
 
             Retailer.set_item(
                 market_id,
-                {name = item.name, price = price, name_label = item.name_label, description = item.description}
+                {name = item.name, type = item.type, price = price, name_label = item.name_label, sprite = item.sprite, description = item.description}
             )
         end
     end

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -823,12 +823,17 @@ local function init(config)
         )
     }
 
+    local chest = {
+        callback = outpost_builder.scenario_chest_callback
+    }
+
     local spawn = {
         size = 2,
         [1] = {
             market = market,
+            chest = chest,
             [15] = {entity = {name = 'market', force = 'neutral', callback = 'market'}},
-            [18] = {entity = {name = 'wooden-chest', force = 'player', destructible=false, minable=false}}
+            [18] = {entity = {name = 'wooden-chest', force = 'player', callback = 'chest'}}
         },
         [2] = {
             force = 'player',

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -785,7 +785,7 @@ local function init(config)
                 name = 'airstrike_radius',
                 name_label = {'command_description.crash_site_airstrike_radius_name_label', 1},
                 sprite = 'item-group/production',
-                description = {'command_description.crash_site_airstrike_radius', 1, 0, "n/a"}
+                description = {'command_description.crash_site_airstrike_radius', 1, 0, 5}
             },
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -775,17 +775,17 @@ local function init(config)
                 price = 1000,
                 type= 'airstrike',
                 name = 'airstrike_damage',
-                name_label = 'Airstrike Damage 1',
+                name_label = {'command_description.crash_site_airstrike_count_name_label', 1},
                 sprite = 'item-group/production',
-                description = 'Upgrade the airstrike damage to  to level 1. Damage upgrades increase the number of poison capsules launched by airstrike. Use /strike with a gps position'
+                description = {'command_description.crash_site_airstrike_count', 1, 0, "n/a", "n/a"}
             },
             {
                 price = 1000,
                 type = 'airstrike',
                 name = 'airstrike_radius',
-                name_label = 'Airstrike Radius 1',
+                name_label = {'command_description.crash_site_airstrike_radius_name_label', 1},
                 sprite = 'item-group/production',
-                description = 'Upgrade the airstrike radius to level 1.\n\nUse /strike with a gps position'
+                description = {'command_description.crash_site_airstrike_radius', 1, 0, "n/a"}
             },
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -772,20 +772,20 @@ local function init(config)
             upgrade_base_cost = 500,
             upgrade_cost_base = 2,
             {
-                price = 100,
-                type = 'airstrike',
-                name = 'airstrike_radius',
-                name_label = 'Airstrike Radius',
-                sprite = 'item-group/production',
-                description = 'Upgrade the airstrike radius. Use /strike'
-            },
-            {
-                price = 100,
+                price = 1000,
                 type= 'airstrike',
                 name = 'airstrike_damage',
-                name_label = 'Airstrike Damage',
+                name_label = 'Airstrike Damage 1',
                 sprite = 'item-group/production',
-                description = 'Upgrade the airstrike damage. Use /strike'
+                description = 'Upgrade the airstrike damage to  to level 1. Damage upgrades increase the number of poison capsules launched by airstrike. Use /strike with a gps position'
+            },
+            {
+                price = 1000,
+                type = 'airstrike',
+                name = 'airstrike_radius',
+                name_label = 'Airstrike Radius 1',
+                sprite = 'item-group/production',
+                description = 'Upgrade the airstrike radius to level 1.\n\nUse /strike with a gps position'
             },
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -772,30 +772,21 @@ local function init(config)
             upgrade_base_cost = 500,
             upgrade_cost_base = 2,
             {
-                price = 10000,
-                name = 'poison-capsule',
+                price = 100,
+                type = 'airstrike',
+                name = 'airstrike_radius',
                 name_label = 'Airstrike Radius',
+                sprite = 'item-group/production',
                 description = 'Upgrade the airstrike radius. Use /strike'
             },
             {
-                price = 10000,
-                name = 'artillery-targeting-remote',
+                price = 100,
+                type= 'airstrike',
+                name = 'airstrike_damage',
                 name_label = 'Airstrike Damage',
+                sprite = 'item-group/production',
                 description = 'Upgrade the airstrike damage. Use /strike'
             },
-            --https://github.com/Refactorio/RedMew/blob/38a5948cb463d6fa10553d403868c76f216ca33a/features/market.lua
-            --[[local function market_item_purchased(event)
-                local item_name = event.item.name
-                if item_name == 'temporary-running-speed-bonus' then
-                    boost_player_running_speed(event.player)
-                    return
-                end
-            
-                if item_name == 'temporary-mining-speed-bonus' then
-                    boost_player_mining_speed(event.player)
-                    return
-                end
-            end]]--
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},
             {name = 'stone', price = 2},

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -771,6 +771,31 @@ local function init(config)
             upgrade_rate = 0.5,
             upgrade_base_cost = 500,
             upgrade_cost_base = 2,
+            {
+                price = 10000,
+                name = 'poison-capsule',
+                name_label = 'Airstrike Radius',
+                description = 'Upgrade the airstrike radius. Use /strike'
+            },
+            {
+                price = 10000,
+                name = 'artillery-targeting-remote',
+                name_label = 'Airstrike Damage',
+                description = 'Upgrade the airstrike damage. Use /strike'
+            },
+            --https://github.com/Refactorio/RedMew/blob/38a5948cb463d6fa10553d403868c76f216ca33a/features/market.lua
+            --[[local function market_item_purchased(event)
+                local item_name = event.item.name
+                if item_name == 'temporary-running-speed-bonus' then
+                    boost_player_running_speed(event.player)
+                    return
+                end
+            
+                if item_name == 'temporary-mining-speed-bonus' then
+                    boost_player_mining_speed(event.player)
+                    return
+                end
+            end]]--
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},
             {name = 'stone', price = 2},
@@ -812,7 +837,7 @@ local function init(config)
         [1] = {
             market = market,
             [15] = {entity = {name = 'market', force = 'neutral', callback = 'market'}},
-            [18] = {entity = {name = 'wooden-chest', force = 'player'}}
+            [18] = {entity = {name = 'wooden-chest', force = 'player', destructible=false, minable=false}}
         },
         [2] = {
             force = 'player',


### PR DESCRIPTION
- Type `/strike [gps=x,y,surface] to send a large cloud of poison into the enemy
- Searches a chest near spawn for poison capsules. Current cost for command is 100 capsules but could be balanced.
- Needs market items adding for technology research, bought with coins.
- Variables strikeCount and strikeRadius start low. As the market upgrades are made (start at 5k each?) the size of teh strike and amount of capsules increases.
- Should be balanced to allow use from mid-game onwards. Don't allow early game use as manual throwing is fine for early outposts. This should be to speed up the boring end-game clearing of worms.
- Need to consider if referencing a chest at -0.5 -0.35 will cause problems. On one hand I like it because you can replace it with a provider. It's also so specific that it doesn't pick up other chests near it. But it might be confusing if someone removes it. I've added checks but we should discuss if this is the best method of collecting resources from the players.
- Probably needs refactoring to take it out of commands.lua and put it in a new features\airstrike.lua
