### PR TITLE
Fixed artillery pickup exploit

### DIFF
--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -358,9 +358,7 @@ local function do_bot_spawn(entity_name, entity, event)
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)
             else
-                -- projectiles don't have AI so won't track/follow a player
-                -- if the cause wasn't artillery turret/wagon then spawn a capsule entity not projectile so that it will track the spidertron/player
-                spawn_entity.name = 'defender'  -- use defender (entity) not defender-capsule (projectile) since an entity can track the player and is more fun to kite/dodge
+                spawn_entity.name = 'defender'
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)
 

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -301,6 +301,12 @@ local function do_bot_spawn(entity_name, entity, event)
     local ef = entity_force.evolution_factor
     local create_entity = entity.surface.create_entity
 
+    if not bot_spawn_whitelist[entity_name] then
+        if cause then
+            return
+        end
+    end
+
     if ef <= 0.2 then
         return
     end
@@ -310,12 +316,6 @@ local function do_bot_spawn(entity_name, entity, event)
         target = cause,
         force = entity_force
     }
-
-    if not bot_spawn_whitelist[entity_name] then
-        if cause then
-            return
-        end
-    end
 
     if not cause then
         -- If we reach here then the player might have picked up the artillery turret before the projectile hit the entity and killed it.
@@ -348,7 +348,7 @@ local function do_bot_spawn(entity_name, entity, event)
             if (cause.name == 'artillery-turret') or (cause.name == 'artillery-wagon') then
                 spawn_entity.target = cause.position    -- Overwrite target. Artillery turrets/wagons don't move so send them to entity position. Stops players from picking up the arty and the bots stopping dead.
                 spawn_entity.speed = 0.2
-
+                -- This is particularly risky for players to do because defender-capsule quantities are not limited by the player force's follower robot count.
                 spawn_entity.name = 'defender-capsule'  -- use 'defender-capsule' (projectile) not 'defender' (entity) since a projectile can target a position but a capsule entity must have another entity as target
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -304,12 +304,18 @@ local function do_bot_spawn(entity_name, entity, event)
     if ef <= 0.2 then
         return
     end
-    
+
     local spawn_entity = {
         position = entity.position,
         target = cause,
         force = entity_force
     }
+
+    if not bot_spawn_whitelist[entity_name] then
+        if cause then
+            return
+        end
+    end
 
     if not cause then
         -- If we reach here then the player might have picked up the artillery turret before the projectile hit the entity and killed it.
@@ -323,10 +329,6 @@ local function do_bot_spawn(entity_name, entity, event)
         return
     end
 
-    if not bot_spawn_whitelist[entity_name] then
-        return
-    end
-
     if not bot_cause_whitelist[cause.name] then
         return
     end
@@ -335,8 +337,6 @@ local function do_bot_spawn(entity_name, entity, event)
     if ef > .95 then
         repeat_cycle = 2
     end
-
-   
 
     if cause.name ~= 'character' then
         if (entity_name == 'artillery-turret') or (entity_name == 'artillery-wagon') then
@@ -347,15 +347,15 @@ local function do_bot_spawn(entity_name, entity, event)
         for i = 1, repeat_cycle do
             if (cause.name == 'artillery-turret') or (cause.name == 'artillery-wagon') then 
                 spawn_entity.target = cause.position    -- Overwrite target. Artillery turrets/wagons don't move so send them to entity position. Stops players from picking up the arty and the bots stopping dead.
-                spawn_entity.speed = 0.2  
-                
+                spawn_entity.speed = 0.2
+
                 spawn_entity.name = 'defender-capsule'  -- use 'defender-capsule' (projectile) not 'defender' (entity) since a projectile can target a position but a capsule entity must have another entity as target
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)
 
                 spawn_entity.name = 'destroyer-capsule'
                 create_entity(spawn_entity)
-                create_entity(spawn_entity) 
+                create_entity(spawn_entity)
             else
                 -- projectiles don't have AI so won't track/follow a player
                 -- if the cause wasn't artillery turret/wagon then spawn a capsule entity not projectile
@@ -365,8 +365,8 @@ local function do_bot_spawn(entity_name, entity, event)
 
                 spawn_entity.name = 'destroyer'
                 create_entity(spawn_entity)
-                create_entity(spawn_entity) 
-            end 
+                create_entity(spawn_entity)
+            end
         end
     elseif entity_name == 'gun-turret' then
         for i = 1, repeat_cycle do

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -322,7 +322,7 @@ local function do_bot_spawn(entity_name, entity, event)
     if not cause then
         for i = 1, 30 do
             spawn_entity.name = 'destroyer-capsule'
-            spawn_entity.speed = 0.2
+            spawn_entity.speed = 0.4
             spawn_entity.target = {0,0}
             create_entity(spawn_entity)
         end
@@ -340,7 +340,7 @@ local function do_bot_spawn(entity_name, entity, event)
     end
 
     if cause.name ~= 'character' then
-        if (entity_name == 'artillery-turret') or (entity_name == 'artillery-wagon') then
+        if (entity_name == 'artillery-turret') then
             repeat_cycle = 15
         else
             repeat_cycle = 4
@@ -359,8 +359,8 @@ local function do_bot_spawn(entity_name, entity, event)
                 create_entity(spawn_entity)
             else
                 -- projectiles don't have AI so won't track/follow a player
-                -- if the cause wasn't artillery turret/wagon then spawn a capsule entity not projectile so that it will track the spidertron
-                spawn_entity.name = 'defender'  -- use defender-capsule (projectile) not defender (entity) since a projectile can target a position but a capsule entity must have another entity as target
+                -- if the cause wasn't artillery turret/wagon then spawn a capsule entity not projectile so that it will track the spidertron/player
+                spawn_entity.name = 'defender'  -- use defender (entity) not defender-capsule (projectile) since an entity can track the player and is more fun to kite/dodge
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)
 

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -345,7 +345,7 @@ local function do_bot_spawn(entity_name, entity, event)
             repeat_cycle = 4
         end
         for i = 1, repeat_cycle do
-            if (cause.name == 'artillery-turret') or (cause.name == 'artillery-wagon') then 
+            if (cause.name == 'artillery-turret') or (cause.name == 'artillery-wagon') then
                 spawn_entity.target = cause.position    -- Overwrite target. Artillery turrets/wagons don't move so send them to entity position. Stops players from picking up the arty and the bots stopping dead.
                 spawn_entity.speed = 0.2
 


### PR DESCRIPTION
- Current behaviour is that when destroyers/defenders are created their target position is set to the entity that killed them.
- If a player picks up the artillery after the capsules spawn then they lose their cause.target and stop, not reaching the cause of the turret death. If the player picks up the artillery after it spawns the killing projectile but before it hits the target, then the event has no cause and no bots spawn!
- I've changed this behaviour so that if the target.cause is artillery then it spawns a defender/destroyer projectile NOT an entity. The projectile target can therefore be a position not an entity. So the capsules won't stop if the artillery is picked up.
- If the cause is not artillery turret or wagon then a destroyer/defender capsule entity is spawned instead of a projectile because a projectile cannot track the player. This will mean we'll still get the nice behaviour where the capsule target updates as the player/tank/car/spidertron moves and they can kite them.
- If the player picks up the artillery turret before the projectile that kills a turret arrives then the event cause.name will be missing and no bots spawn at all. I have changed the behaviour so that "if not cause" then we assume they're doing something fucky. We won't have the entity cause name or position, so let's just spawn double the normal amount of destroyers and just send them at 0, 0 since we know nothing else to do with them.