### PR TITLE
Fixed /strike command range issue

### DIFF
--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -203,7 +203,7 @@ end
 
 local spawn_poison_callback = Token.register(function(data)
     local r = data.r
-    data.s.create_entity{name = "poison-capsule", position={0,0}, target={data.xpos + math.random(-r,r), data.ypos + math.random(-r,r)}, speed=10}
+    data.s.create_entity{name = "poison-capsule", position={0,0}, target={data.xpos + math.random(-r,r), data.ypos + math.random(-r,r)}, speed=10, max_range=1400}
 end)
 
 local function strike(args, player)

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -203,7 +203,7 @@ end
 
 local spawn_poison_callback = Token.register(function(data)
     local r = data.r
-    data.s.create_entity{name = "poison-capsule", position={0,0}, target={data.xpos + math.random(-r,r), data.ypos + math.random(-r,r)}, speed=10, max_range=1400}
+    data.s.create_entity{name = "poison-capsule", position={0,0}, target={data.xpos + math.random(-r,r), data.ypos + math.random(-r,r)}, speed=10, max_range=100000}
 end)
 
 local function strike(args, player)


### PR DESCRIPTION
Previously the airstrike was not reaching the corners of the map. There was a default max_range value of 1000 that limited how far the poison capsules could travel. Have set it to 1400 so that it can reach the corners of the map.

~~THIS NEEDS PLAY TESTING. Please don't merge until I've confirmed I've play tested it.~~