### PR TITLE
Updated strike cost

### DIFF
--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -219,7 +219,7 @@ local function strike(args, player)
     end
 
     local radius = 5+(radius_level*3)
-    local count = (count_level-1)*5+3
+    local count = (count_level-2)*5+3
     local strikeCost = count * 4            -- the number of poison-capsules required in the chest as payment
 
     -- parse GPS coordinates from map ping


### PR DESCRIPTION
The strike count and cost described by the market was correct but the actual number of capsules sent and the number of capsules removed from the chest was wrong. Bug due to starting index, have now updated the maths to be correct.

Tested and the market description, number of shots fired and the number of capsules removed from the chest are now correct.