### PR TITLE
Crash site rocket tanks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -210,8 +210,12 @@ stds.factorio_control = {
         -- (http://lua-api.factorio.com/latest/LuaBootstrap.html)
         script = {
             fields = {
-                "on_configuration_changed", "raise_event",
-                "get_event_handler", "mod_name", "get_event_order"
+                'on_configuration_changed',
+                'raise_event',
+                'get_event_handler',
+                'mod_name',
+                'get_event_order',
+                'register_on_entity_destroyed'
             },
             other_fields = false,
         },
@@ -1002,6 +1006,7 @@ stds.factorio_defines = {
                         'on_entity_cloned',
                         'on_entity_damaged',
                         'on_entity_died',
+                        'on_entity_destroyed',
                         'on_entity_renamed',
                         'on_entity_settings_pasted',
                         'on_entity_spawned',

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -24,6 +24,7 @@ crash_site_airstrike_success=__1__ called an air strike [gps=__2__,__3__,redmew]
 crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__
 crash_site_rocket_tanks_description= Upgrade the rocket tank firing interval to reduce the time between rockets.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.
 crash_site_rocket_tank_upgrade_success=Rocket tank interval has been upgraded to level __1__
+max_level=(MAX LEVEL)
 dataset_copy=Copies a dataset
 dataset_move=Moves a dataset
 dataset_delete=Deletes a dataset

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -21,6 +21,9 @@ crash_site_airstrike_friendly_fire_error=You don't want to do that, no enemies f
 crash_site_airstrike_damage_upgrade_success=Airstrike damage has been upgraded to level __1__
 crash_site_airstrike_radius_upgrade_success=Airstrike radius has been upgraded to level __1__
 crash_site_airstrike_success=__1__ called an air strike [gps=__2__,__3__,redmew]
+crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__
+crash_site_rocket_tanks_description= Update the rocket tanks fire interval to level __1__.\n\nCurrent interval: __2__ seconds per rocket\n\nNext interval: __3__ seconds per rocket
+crash_site_rocket_tank_upgrade_success=Rocket tank interval has been upgraded to level __1__
 dataset_copy=Copies a dataset
 dataset_move=Moves a dataset
 dataset_delete=Deletes a dataset

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -22,7 +22,7 @@ crash_site_airstrike_damage_upgrade_success=Airstrike damage has been upgraded t
 crash_site_airstrike_radius_upgrade_success=Airstrike radius has been upgraded to level __1__
 crash_site_airstrike_success=__1__ called an air strike [gps=__2__,__3__,redmew]
 crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__
-crash_site_rocket_tanks_description= Update the rocket tanks fire interval to level __1__.\n\nCurrent interval: __2__ seconds per rocket\n\nNext interval: __3__ seconds per rocket
+crash_site_rocket_tanks_description= Upgrade the rocket tank firing interval to reduce the time between rockets.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.
 crash_site_rocket_tank_upgrade_success=Rocket tank interval has been upgraded to level __1__
 dataset_copy=Copies a dataset
 dataset_move=Moves a dataset

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1672,7 +1672,16 @@ Public.market_set_items_callback =
 
             Retailer.set_item(
                 market_id,
-                {name = item.name, type = item.type, price = price, name_label = item.name_label, sprite = item.sprite, description = item.description}
+                {
+                    name = item.name,
+                    type = item.type,
+                    price = price,
+                    stack_limit = item.stack_limit,
+                    name_label = item.name_label,
+                    sprite = item.sprite,
+                    disabled = item.disabled,
+                    disabled_reason = item.disabled_reason,
+                    description = item.description}
             )
         end
     end

--- a/map_gen/maps/crash_site/rocket_tanks.lua
+++ b/map_gen/maps/crash_site/rocket_tanks.lua
@@ -82,8 +82,6 @@ local on_tick = Token.register(function()
     end
 end)
 
-local rocket_tank_level_intervals = {[2] = 180, [3] = 120, [4] = 60, [5] = 30}
-
 Event.add(Retailer.events.on_market_purchase, function(event)
     local market_id = event.group_name
     local group_label = Retailer.get_market_group_label(market_id)
@@ -103,7 +101,7 @@ Event.add(Retailer.events.on_market_purchase, function(event)
 
         Toast.toast_all_players(15, {'command_description.crash_site_rocket_tank_upgrade_success', interval_level})
         item.name_label = {'command_description.crash_site_rocket_tanks_name_label', (interval_level + 1)}
-        item.price = (interval_level + 1) * 7500
+        item.price = (interval_level + 1) * 4000
         Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.
     end
     if interval_level >= 4 then -- update label, set price to 0, disable further purchases
@@ -114,8 +112,9 @@ Event.add(Retailer.events.on_market_purchase, function(event)
         Retailer.set_item(market_id, item)
     end
 
+    -- Interval for each level should decrease 30 from 120 ticks each level. 120, 90, 60, 30.
     if interval_level > 2 then
-        Event.remove_removable_nth_tick(rocket_tank_level_intervals[tank_research.interval_level - 1], on_tick)
+        Event.remove_removable_nth_tick((120-(((interval_level-1)-2)*30)), on_tick)
     end
-    Event.add_removable_nth_tick(rocket_tank_level_intervals[tank_research.interval_level], on_tick)
+    Event.add_removable_nth_tick((120-((interval_level-2)*30)), on_tick)
 end)

--- a/map_gen/maps/crash_site/rocket_tanks.lua
+++ b/map_gen/maps/crash_site/rocket_tanks.lua
@@ -92,7 +92,7 @@ Event.add(Retailer.events.on_market_purchase, function(event)
     end
 
     local item = event.item
-    if item.type ~= 'rocket_tanks' and event.name ~= 'rocket_tanks_fire_rate' then
+    if item.type ~= 'rocket_tanks' or item.name ~= 'rocket_tanks_fire_rate' then
         return
     end
 

--- a/map_gen/maps/crash_site/rocket_tanks.lua
+++ b/map_gen/maps/crash_site/rocket_tanks.lua
@@ -1,0 +1,153 @@
+local Event = require 'utils.event'
+local Global = require 'utils.global'
+local Toast = require 'features.gui.toast'
+local Retailer = require 'features.retailer'
+local Token = require 'utils.token'
+
+local tank_entities = {}
+local tank_research = {interval_level = 1}
+
+Global.register(
+    {tank_entities = tank_entities,
+    tank_research = tank_research},
+    function(tbl)
+        tank_entities = tbl.tank_entities
+        tank_research = tbl.tank_research
+    end
+)
+
+local function register_tank(entity)
+    if not entity then
+        return
+    end
+    if not entity.valid then
+        return
+    end
+    if entity.name ~= 'tank' then
+        return
+    end
+    tank_entities[entity.unit_number] = entity
+    script.register_on_entity_destroyed(entity)
+end
+
+Event.add(defines.events.on_entity_destroyed, function(event)
+    tank_entities[event.unit_number] = nil
+end)
+
+Event.add(defines.events.on_robot_built_entity, function(event)
+    register_tank(event.created_entity)
+end)
+
+Event.add(defines.events.on_built_entity, function(event)
+    register_tank(event.created_entity)
+end)
+
+Event.add(defines.events.on_entity_cloned, function(event)
+    register_tank(event.destination)
+end)
+
+local static_entities_to_check = {
+    'spitter-spawner',
+    'biter-spawner',
+    'small-worm-turret',
+    'medium-worm-turret',
+    'big-worm-turret',
+    'behemoth-worm-turret'
+}
+--[[local function on_tick()
+    for k, v in pairs(tank_entities) do
+        local unit_number = k
+        local tank = v
+        local s = game.surfaces["redmew"]
+        if tank.get_driver() then   -- only allow tanks to fire rockets when the tank has a driver
+            local inv = tank.get_inventory(defines.inventory.car_trunk)
+            local rocket_count = inv.get_item_count("rocket")
+            if rocket_count > 0 then
+                local target = s.find_entities_filtered {
+                    position = tank.position,
+                    radius = 30,
+                    force = "enemy",
+                    name = static_entities_to_check,
+                    limit = 1
+                }
+                if target[1] then
+                    s.create_entity {name = "rocket", position = tank.position, target = target[1], speed = 0.2}
+                    inv.remove({name = "rocket", count = 1})
+                end
+            end
+        end
+    end
+end]]
+local on_tick
+on_tick = Token.register(
+    function()
+    for k, v in pairs(tank_entities) do
+        local unit_number = k
+        local tank = v
+        local s = game.surfaces["redmew"]
+        if tank.get_driver() then   -- only allow tanks to fire rockets when the tank has a driver
+            local inv = tank.get_inventory(defines.inventory.car_trunk)
+            local rocket_count = inv.get_item_count("rocket")
+            if rocket_count > 0 then
+                local target = s.find_entities_filtered {
+                    position = tank.position,
+                    radius = 30,
+                    force = "enemy",
+                    name = static_entities_to_check,
+                    limit = 1
+                }
+                if target[1] then
+                    s.create_entity {name = "rocket", position = tank.position, target = target[1], speed = 0.2}
+                    inv.remove({name = "rocket", count = 1})
+                end
+            end
+        end
+    end
+end
+)
+
+local rocket_tank_level_intervals = {
+    [2] = 180,
+    [3] = 120,
+    [4] = 60,
+    [5] = 30 
+}
+
+--Event.on_nth_tick(180, on_tick)
+--Event.on_nth_tick(rocket_tank_level_intervals[tank_research.interval_level], on_tick)
+
+Event.add(Retailer.events.on_market_purchase, function(event)
+
+    local market_id = event.group_name
+    local group_label = Retailer.get_market_group_label(market_id)
+    if group_label ~= 'Spawn' then
+        return
+    end
+
+    local item = event.item
+    if item.type ~= 'rocket_tanks' then
+        return
+    end
+
+    local interval_level = tank_research.interval_level
+    local name = item.name
+    local max_level = 5
+    if  (name == 'rocket_tanks_fire_rate') and (interval_level < max_level) then
+        tank_research.interval_level = tank_research.interval_level + 1
+
+        Toast.toast_all_players(15, {'command_description.crash_site_rocket_tank_upgrade_success', interval_level})
+        item.name_label = {'command_description.crash_site_rocket_tanks_name_label', (interval_level + 1)}
+        item.price = (interval_level+1)*7500
+        item.description = 'Upgrade the tank rocket firing rate to reduce the rocket interval.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.'
+        Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.
+    end
+    if interval_level == 5 then
+        -- This doesn't work....
+        Retailer.remove_item('Spawn', 'rocket_tanks_fire_rate')
+    end
+    if interval_level > 2 then
+        Event.remove_removable_nth_tick(rocket_tank_level_intervals[tank_research.interval_level-1], on_tick)
+    end
+    Event.add_removable_nth_tick(rocket_tank_level_intervals[tank_research.interval_level], on_tick)
+
+end)

--- a/map_gen/maps/crash_site/rocket_tanks.lua
+++ b/map_gen/maps/crash_site/rocket_tanks.lua
@@ -104,7 +104,7 @@ Event.add(Retailer.events.on_market_purchase, function(event)
         Toast.toast_all_players(15, {'command_description.crash_site_rocket_tank_upgrade_success', interval_level})
         item.name_label = {'command_description.crash_site_rocket_tanks_name_label', (interval_level + 1)}
         item.price = (interval_level + 1) * 7500
-        Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.    
+        Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.
     end
     if interval_level >= 4 then -- update label, set price to 0, disable further purchases
         item.price = 0

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -792,13 +792,12 @@ local function init(config)
                 description = {'command_description.crash_site_airstrike_radius', 1, 0, 5}
             },
             {
-                price = 5000,
+                price = 7500,
                 type = 'rocket_tanks',
                 name = 'rocket_tanks_fire_rate',
                 name_label = {'command_description.crash_site_rocket_tanks_name_label', 1},
                 sprite = 'item-group/production',
-                description = 'Upgrade the tank rocket firing rate to reduce the rocket interval.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.'
-            },
+                description = {'command_description.crash_site_rocket_tanks_description'}            },
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},
             {name = 'stone', price = 2},

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -777,6 +777,7 @@ local function init(config)
             upgrade_cost_base = 2,
             {
                 price = 1000,
+                stack_limit = 1,
                 type= 'airstrike',
                 name = 'airstrike_damage',
                 name_label = {'command_description.crash_site_airstrike_count_name_label', 1},
@@ -785,6 +786,7 @@ local function init(config)
             },
             {
                 price = 1000,
+                stack_limit = 1,
                 type = 'airstrike',
                 name = 'airstrike_radius',
                 name_label = {'command_description.crash_site_airstrike_radius_name_label', 1},
@@ -793,11 +795,13 @@ local function init(config)
             },
             {
                 price = 7500,
+                stack_limit = 1,
                 type = 'rocket_tanks',
                 name = 'rocket_tanks_fire_rate',
                 name_label = {'command_description.crash_site_rocket_tanks_name_label', 1},
-                sprite = 'item-group/production',
-                description = {'command_description.crash_site_rocket_tanks_description'}            },
+                sprite = 'entity/tank',
+                description = {'command_description.crash_site_rocket_tanks_description'}
+            },
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},
             {name = 'stone', price = 2},

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -794,7 +794,7 @@ local function init(config)
                 description = {'command_description.crash_site_airstrike_radius', 1, 0, 5}
             },
             {
-                price = 7500,
+                price = 4000,
                 stack_limit = 1,
                 type = 'rocket_tanks',
                 name = 'rocket_tanks_fire_rate',

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -1,6 +1,8 @@
 require 'map_gen.maps.crash_site.blueprint_extractor'
 require 'map_gen.maps.crash_site.events'
 require 'map_gen.maps.crash_site.weapon_balance'
+require 'map_gen.maps.crash_site.rocket_tanks'
+
 
 local b = require 'map_gen.shared.builders'
 local Global = require('utils.global')
@@ -16,6 +18,8 @@ local MGSP = require 'resources.map_gen_settings'
 local RedmewConfig = require 'config'
 local Cutscene = require 'map_gen.maps.crash_site.cutscene'
 local cutscene_surface_settings = require 'map_gen.maps.crash_site.cutscene_surface_settings'
+
+
 
 local degrees = math.degrees
 local cutscene_force_name = 'cutscene'
@@ -786,6 +790,14 @@ local function init(config)
                 name_label = {'command_description.crash_site_airstrike_radius_name_label', 1},
                 sprite = 'item-group/production',
                 description = {'command_description.crash_site_airstrike_radius', 1, 0, 5}
+            },
+            {
+                price = 5000,
+                type = 'rocket_tanks',
+                name = 'rocket_tanks_fire_rate',
+                name_label = {'command_description.crash_site_rocket_tanks_name_label', 1},
+                sprite = 'item-group/production',
+                description = 'Upgrade the tank rocket firing rate to reduce the rocket interval.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.'
             },
             {name = 'wood', price = 1},
             {name = 'iron-plate', price = 2},


### PR DESCRIPTION
Adds research, unlockable from the market, that allows tanks to fire rockets at enemy worms and spawners.

The intention is to make mid-game more fun and make tanks more useful, they're often ignored while players wait for spidertrons. Intentionally didn't allow rockets to target biters and spitters because the part of the game I want them to be enticing for is when we have few rockets just after we get the science to make them.

They don't target enemy turrets because I don't want to change the destroyer spawning behaviour.

The first level of tech allows rockets to be shot at a 3 second interval. Upgradable to level 4, 0.5 seconds per rocket.

Almost ready for a live test, one small feature to complete.