### PR TITLE
Updated Redmew settings frame width from 400 to 500

### DIFF
--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -97,7 +97,7 @@ local function draw_main_frame(center, player)
     )
 
     local settings_frame_style = settings_frame.style
-    settings_frame_style.width = 400
+    settings_frame_style.width = 500
 
     local info_text = settings_frame.add({type = 'label', caption = {'redmew_settings_gui.setting_info'}})
     local info_text_style = info_text.style


### PR DESCRIPTION
Irrespective of the UI Scale (Menu > Settings > Interface > UI Scale) the Redmew settings GUI was too narrow and the left column text was truncated:
![Screenshot 2020-12-27 074028](https://user-images.githubusercontent.com/28716932/103166159-3ffe2500-4817-11eb-9d38-3d33e4e0db13.png)
I have updated the width to 500 and tested it on various UI Scale settings and monitor resolutions to check that it looks good in all.
![Screenshot 2020-12-27 074109](https://user-images.githubusercontent.com/28716932/103166182-7471e100-4817-11eb-8490-2c4a1caa53af.png)

