### PR TITLE
Updated stupid wooden chest in crash site

### DIFF
--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -840,7 +840,7 @@ local function init(config)
             market = market,
             chest = chest,
             [15] = {entity = {name = 'market', force = 'neutral', callback = 'market'}},
-            [18] = {entity = {name = 'wooden-chest', force = 'player', callback = 'chest'}}
+            [18] = {entity = {name = 'steel-chest', force = 'player', callback = 'chest'}}
         },
         [2] = {
             force = 'player',


### PR DESCRIPTION
The wooden chest is frustrating end game on crash site because you can't fit enough loaders around it. By changing to steel chest it's more usable over time.