### PR TITLE
Made strike command less spammy, replaced map pings with tags

### DIFF
--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -23,7 +23,7 @@ crash_site_airstrike_insufficient_currency_error=To send an air strike, load __1
 crash_site_airstrike_friendly_fire_error=You don't want to do that, no enemies found in the target area.
 crash_site_airstrike_damage_upgrade_success=__1__ has upgraded Airstrike Damage to level __2__
 crash_site_airstrike_radius_upgrade_success=__1__ has updgraded Airstrike Radius to level __2__
-crash_site_airstrike_success=__1__ called an air strike [gps=__2__,__3__,redmew]
+crash_site_airstrike_success=Airstrike success: [gps=__2__,__3__,redmew]
 crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__
 crash_site_rocket_tank_upgrade_success=__1__ has upgraded Rocket Tank interval to level __2__
 crash_site_rocket_tanks_description= Upgrade the rocket tank firing interval to reduce the time between rockets.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -23,7 +23,6 @@ crash_site_airstrike_insufficient_currency_error=To send an air strike, load __1
 crash_site_airstrike_friendly_fire_error=You don't want to do that, no enemies found in the target area.
 crash_site_airstrike_damage_upgrade_success=__1__ has upgraded Airstrike Damage to level __2__
 crash_site_airstrike_radius_upgrade_success=__1__ has updgraded Airstrike Radius to level __2__
-crash_site_airstrike_success=Airstrike success: [gps=__2__,__3__,redmew]
 crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__
 crash_site_rocket_tank_upgrade_success=__1__ has upgraded Rocket Tank interval to level __2__
 crash_site_rocket_tanks_description= Upgrade the rocket tank firing interval to reduce the time between rockets.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -338,7 +338,7 @@ function Public.control(config)
     end)
 
     local map_chart_tag_clear_callback = Token.register(function(tag)
-        if not tag then
+        if not tag or not tag.valid then
             return -- in case a player deleted the tag manually
         end
         tag.destroy()

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -422,7 +422,6 @@ function Public.control(config)
         end
 
         inv.remove({name = "poison-capsule", count = strikeCost})
-        player.print({'command_description.crash_site_airstrike_success', xpos, ypos})
 
         for j = 1, count do
             set_timeout_in_ticks(30 * j, spawn_poison_callback,


### PR DESCRIPTION
/strike command now only messages the player that uses it with the location. Everyone else will only see the poison capsule tags appear on the map along with the name of the player that used them. These will timeout after 30 seconds.

You can't place a tag on an uncharted part of the map so the code waits 1 second for it to be charted before placing the map tag.
