### PR TITLE
Player kills deposit coins in inventory

### DIFF
--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -439,9 +439,10 @@ local function do_coin_drop(entity_name, entity, cause)
 
     local count = random(bounds.low, bounds.high)
     if count > 0 then
-        if cause.name == 'character' and cause.player.can_insert({name="coin", count = count}) then -- try put coins into inventory
-            cause.player.insert{name="coin", count = count}
-            entity.surface.create_entity{name="flying-text", position = {entity.position.x-1, entity.position.y}, text="+"..count.." [img=item.coin]", color={1, 0.8, 0, 0.5}, render_player_index=cause.player.index}
+        local coins = {name="coin", count = count}
+        if cause and cause.player and cause.name == 'character'  and cause.player.can_insert(coins) then
+            cause.player.insert(coins)
+            entity.surface.create_entity{name="flying-text", position = {position.x-1, position.y}, text="+"..count.." [img=item.coin]", color={1, 0.8, 0, 0.5}, render_player_index=cause.player.index}
         else -- spill them on the floor
             set_timeout_in_ticks(
                 1,

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -438,23 +438,31 @@ local function do_coin_drop(entity_name, entity, cause)
     end
 
     local count = random(bounds.low, bounds.high)
-    if count > 0 then
-        local coins = {name="coin", count = count}
-        if cause and cause.player and cause.name == 'character'  and cause.player.can_insert(coins) then
-            cause.player.insert(coins)
-            entity.surface.create_entity{name="flying-text", position = {position.x-1, position.y}, text="+"..count.." [img=item.coin]", color={1, 0.8, 0, 0.5}, render_player_index=cause.player.index}
-        else -- spill them on the floor
-            set_timeout_in_ticks(
-                1,
-                spill_items,
-                {
-                    count = count,
-                    surface = entity.surface,
-                    position = position
-                }
-            )
+    if count <= 0 then
+        return
+    end
+
+    if cause and cause.name == 'character' then
+        local player = cause.player
+        if player and player.valid then
+            local coins = {name = "coin", count = count}
+            if player.can_insert(coins) then
+                entity.surface.create_entity{name="flying-text", position = {position.x - 1, position.y}, text = "+" .. count .. " [img=item.coin]", color = {1, 0.8, 0, 0.5}, render_player_index = player.index}
+                return
+            end
         end
     end
+
+    -- spill them on the floor
+    set_timeout_in_ticks(
+        1,
+        spill_items,
+        {
+            count = count,
+            surface = entity.surface,
+            position = position
+        }
+    )
 end
 
 local function do_spawn_entity(entity_name, entity, event)


### PR DESCRIPTION
The amount of coins all over the map has been frustrating some people. With there being more stuff to spend coins on I thought I'd make this change to reduce frustration. Kills by artillery, turrets and airstrike will still spill coins but this way a nice flying text pops up and the coins go straight into the inventory of the player that caused the death if they have space in their inventory.

![image](https://user-images.githubusercontent.com/28716932/107226564-33720c80-6a12-11eb-94e5-c9b95b91f741.png)
