### PR TITLE
Changed magic crafter force to fix unit_group command failure

### DIFF
--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1477,6 +1477,7 @@ Public.magic_item_crafting_callback =
         entity.minable = false
         entity.destructible = false
         entity.operable = false
+        entity.force = 'player'
 
         local recipe = callback_data.recipe
         if recipe then
@@ -1522,6 +1523,7 @@ Public.magic_item_crafting_callback_weighted =
         entity.minable = false
         entity.destructible = false
         entity.operable = false
+        entity.force = 'player'
 
         local weights = callback_data.weights
         local loot = callback_data.loot
@@ -1796,6 +1798,7 @@ function Public.do_random_fluid_loot(entity, weights, loot)
 
     entity.operable = false
     entity.destructible = false
+    entity.force = 'player'
 
     local i = math.random() * weights.total
 
@@ -1831,6 +1834,7 @@ function Public.do_factory_loot(entity, weights, loot)
 
     entity.operable = false
     entity.destructible = false
+    entity.force = 'player'
 
     local i = math.random() * weights.total
 


### PR DESCRIPTION
@grilledham can you think of anything this would break?

For ages I've been frustrated that there are not enough attacks on crash site and that it's too easy. I thought we needed more pollution but after filling the map with pollution today we still weren't getting attacked.

I turned debug on (all the details are in #admin) and watched the biter unit groups forming only to disband after reaching their size. Someone suggested they gave up because they didn't have a path.

After setting all of the assemblers on the map to destructible they started pathing again and would target an assembler first and then move on to the base. We also tried it with the assemblers indestructible still but the force set to player. This allowed us indestructible crafters but the biter pathing no longer errored. After changing all the crafters to the player force we now get consistent attacks and the biter unit groups don't split up and run away.