### PR TITLE
Send auto bans to discord moderation log channel.

### DIFF
--- a/features/nuke_control.lua
+++ b/features/nuke_control.lua
@@ -4,13 +4,11 @@ local Utils = require 'utils.core'
 local Task = require 'utils.task'
 local Token = require 'utils.token'
 local Global = require 'utils.global'
-local Server = require 'features.server'
 local Report = require 'features.report'
 local Popup = require 'features.gui.popup'
 local Ranks = require 'resources.ranks'
 
 local format = string.format
-local match = string.match
 
 -- capsule antigreif player entities threshold.
 local capsule_bomb_threshold = 8
@@ -231,15 +229,12 @@ local function on_capsule_used(event)
 
     if players_warned[event.player_index] then
         if nuke_control.enable_autoban then
-            Server.ban_sync(
-                player.name,
-                format(
-                    'Damaged entities: %s with %s. This action was performed automatically. If you want to contest this ban please visit redmew.com/discord',
-                    list_damaged_entities(item_name, entities),
-                    item_name
-                ),
-                '<script>'
+            local reason = format(
+                'Damaged entities: %s with %s. This action was performed automatically. If you want to contest this ban please visit redmew.com/discord',
+                list_damaged_entities(item_name, entities),
+                item_name
             )
+            Report.ban_player(player, reason)
         end
     else
         players_warned[event.player_index] = true
@@ -249,13 +244,6 @@ local function on_capsule_used(event)
                 format('Damaged entities: %s with %s -Antigrief', list_damaged_entities(item_name, entities), item_name)
             )
         end
-    end
-end
-
-local function on_player_joined(event)
-    local player = game.players[event.player_index]
-    if match(player.name, '^[Ili1|]+$') then
-        Server.ban_sync(player.name, '', '<script>') --No reason given, to not give them any hints to change their name
     end
 end
 
@@ -330,7 +318,6 @@ local function on_entity_died(event)
 end
 
 Event.add(defines.events.on_player_ammo_inventory_changed, ammo_changed)
-Event.add(defines.events.on_player_joined_game, on_player_joined)
 Event.add(defines.events.on_player_deconstructed_area, on_player_deconstructed_area)
 Event.add(defines.events.on_player_used_capsule, on_capsule_used)
 Event.add(defines.events.on_entity_died, on_entity_died)

--- a/features/report.lua
+++ b/features/report.lua
@@ -430,6 +430,48 @@ function Module.unjail(target_player, player)
     end
 end
 
+--- Bans the player and reports the ban to moderation log channel.
+-- @param  player<LuaPlayer>
+-- @param  reason<string?> defaults to empty string.
+function Module.ban_player(player, reason)
+    if not player or not player.valid then
+        return
+    end
+
+    if reason == nil then
+        reason = ''
+    elseif type(reason) ~= 'string' then
+        error('reason must be a string or nil', 2)
+    end
+
+    game.ban_player(player, reason)
+
+    local server_id = Server.get_server_id()
+    local server_name = Server.get_server_name()
+
+    local text = {'**'}
+    text[#text + 1] = Utils.sanitise_string_for_discord(player.name)
+    text[#text + 1] = ' was banned by <script>**\\n'
+
+    if server_id ~= '' then
+        text[#text + 1] = 'Server: s'
+        text[#text + 1] = Utils.sanitise_string_for_discord(server_id)
+        text[#text + 1] = ' - '
+        text[#text + 1] = Utils.sanitise_string_for_discord(server_name)
+        text[#text + 1] = '\\n'
+    end
+
+    text[#text + 1] = ' Game time: '
+    text[#text + 1] = Utils.format_time(game.tick)
+    text[#text + 1] = '\\nPlayer online time: '
+    text[#text + 1] = Utils.format_time(player.online_time)
+    text[#text + 1] = '\\nReason: '
+    text[#text + 1] = Utils.sanitise_string_for_discord(reason)
+
+    text = table.concat(text)
+    Server.to_discord_named_embed_raw(moderation_log_channel, text)
+end
+
 Gui.on_custom_close(report_frame_name, function(event)
     Gui.destroy(event.element)
 end)

--- a/features/server.lua
+++ b/features/server.lua
@@ -51,8 +51,6 @@ local data_set_tag = '[DATA-SET]'
 local data_get_tag = '[DATA-GET]'
 local data_get_all_tag = '[DATA-GET-ALL]'
 local data_tracked_tag = '[DATA-TRACKED]'
-local ban_sync_tag = '[BAN-SYNC]'
-local unbanned_sync_tag = '[UNBANNED-SYNC]'
 local query_players_tag = '[QUERY-PLAYERS]'
 local player_join_tag = '[PLAYER-JOIN]'
 local player_leave_tag = '[PLAYER-LEAVE]'
@@ -585,89 +583,6 @@ end
 
 local function escape(str)
     return str:gsub('\\', '\\\\'):gsub('"', '\\"')
-end
-
---- If the player exists bans the player.
--- Regardless of whether or not the player exists the name is synchronized with other servers
--- and stored in the database.
--- @param  username<string>
--- @param  reason<string?> defaults to empty string.
--- @param  admin<string?> admin's name, defaults to '<script>'
-function Public.ban_sync(username, reason, admin)
-    if type(username) ~= 'string' then
-        error('username must be a string', 2)
-    end
-
-    if reason == nil then
-        reason = ''
-    elseif type(reason) ~= 'string' then
-        error('reason must be a string or nil', 2)
-    end
-
-    if admin == nil then
-        admin = '<script>'
-    elseif type(admin) ~= 'string' then
-        error('admin must be a string or nil', 2)
-    end
-
-    -- game.ban_player errors if player not found.
-    -- However we may still want to use this function to ban player names.
-    local player = game.players[username]
-    if player then
-        game.ban_player(player, reason)
-    end
-
-    username = escape(username)
-    reason = escape(reason)
-    admin = escape(admin)
-
-    local message = concat({ban_sync_tag, '{username:"', username, '",reason:"', reason, '",admin:"', admin, '"}'})
-    raw_print(message)
-end
-
---- If the player exists bans the player else throws error.
--- The ban is not synchronized with other servers or stored in the database.
--- @param  PlayerSpecification
--- @param  reason<string?> defaults to empty string.
-function Public.ban_non_sync(PlayerSpecification, reason)
-    game.ban_player(PlayerSpecification, reason)
-end
-
---- If the player exists unbans the player.
--- Regardless of whether or not the player exists the name is synchronized with other servers
--- and removed from the database.
--- @param  username<string>
--- @param  admin<string?> admin's name, defaults to '<script>'. This name is stored in the logs for who removed the ban.
-function Public.unban_sync(username, admin)
-    if type(username) ~= 'string' then
-        error('username must be a string', 2)
-    end
-
-    if admin == nil then
-        admin = '<script>'
-    elseif type(admin) ~= 'string' then
-        error('admin must be a string or nil', 2)
-    end
-
-    -- game.unban_player errors if player not found.
-    -- However we may still want to use this function to unban player names.
-    local player = game.players[username]
-    if player then
-        game.unban_player(username)
-    end
-
-    username = escape(username)
-    admin = escape(admin)
-
-    local message = concat({unbanned_sync_tag, '{username:"', username, '",admin:"', admin, '"}'})
-    raw_print(message)
-end
-
---- If the player exists unbans the player else throws error.
--- The ban is not synchronized with other servers or removed from the database.
--- @param  PlayerSpecification
-function Public.unban_non_sync(PlayerSpecification)
-    game.unban_player(PlayerSpecification)
 end
 
 --- Called by the web server to set the server time.


### PR DESCRIPTION
Also did some refactoring. 
- Removed the ban_sync/unsynced functions. They don't actually do anything on the server, it was a leftover from the early days when I thought I would need them and I never removed them. The server backend just reads the output message factorio prints for bans/unbans to sync bans between servers.
- Moved the ban code into Report.