### PR TITLE
Fixed coin pickup on entity death

### DIFF
--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -447,6 +447,7 @@ local function do_coin_drop(entity_name, entity, cause)
         if player and player.valid then
             local coins = {name = "coin", count = count}
             if player.can_insert(coins) then
+                player.insert(coins)
                 entity.surface.create_entity{name="flying-text", position = {position.x - 1, position.y}, text = "+" .. count .. " [img=item.coin]", color = {1, 0.8, 0, 0.5}, render_player_index = player.index}
                 return
             end


### PR DESCRIPTION
I've no idea how this line got lost in the previous PR but coins weren't being inserted into the inventory because this line was missing somehow.