### PR TITLE
Fix error in player stats when robot built entity.

### DIFF
--- a/features/player_stats.lua
+++ b/features/player_stats.lua
@@ -189,10 +189,9 @@ local function robot_built_entity(event)
 
     -- When item gets built, add to the total entities built for the player whose robot built the entity NOT for the player who placed the ghost
     local robot_owner = robot.logistic_network.cells[1].owner
-    if robot_owner.player then  -- nil if the robot owner is a roboport
+    if robot_owner.name == 'character' and robot_owner.player then  -- nil if the robot owner is a roboport
         change_for_player(robot_owner.player.index, player_entities_built_name, 1)
     end
-
 end
 
 local function get_player_index_from_cause(cause, event)


### PR DESCRIPTION
When the robot_owner is a spidertron there is no player for the owner and calling the player property would error, now we check that the owner is a character first.