### PR TITLE
Fixed player coin count bug from picking up chests

### DIFF
--- a/features/market.lua
+++ b/features/market.lua
@@ -10,6 +10,7 @@ local RS = require 'map_gen.shared.redmew_surface'
 local market_items = require 'resources.market_items'
 local fish_market_bonus_message = require 'resources.fish_messages'
 local ScoreTracker = require 'utils.score_tracker'
+local Color = require 'resources.color_presets'
 local change_for_player = ScoreTracker.change_for_player
 local get_for_player = ScoreTracker.get_for_player
 local coins_earned_name = 'coins-earned'
@@ -123,7 +124,7 @@ local function fish_earned(event, amount)
 
     local stack = {name = currency, count = amount}
     local inserted = player.insert(stack)
-    player.surface.create_entity{name="flying-text", position = {player.position.x - 1, player.position.y}, text = "+" .. amount .. " [img=item.coin]", color = {1, 0.8, 0, 0.5}, render_player_index = player.index}
+    player.surface.create_entity{name="flying-text", position = {player.position.x - 1, player.position.y}, text = "+" .. amount .. " [img=item.coin]", color = Color.gold, render_player_index = player.index}
 
     local diff = amount - inserted
     if diff > 0 then

--- a/features/market.lua
+++ b/features/market.lua
@@ -123,6 +123,7 @@ local function fish_earned(event, amount)
 
     local stack = {name = currency, count = amount}
     local inserted = player.insert(stack)
+    player.surface.create_entity{name="flying-text", position = {player.position.x - 1, player.position.y}, text = "+" .. amount .. " [img=item.coin]", color = {1, 0.8, 0, 0.5}, render_player_index = player.index}
 
     local diff = amount - inserted
     if diff > 0 then

--- a/features/player_stats.lua
+++ b/features/player_stats.lua
@@ -145,13 +145,20 @@ local function picked_up_item(event)
     end
 end
 
-local function player_mined_item(event)
+local function pre_player_mined_item(event)
     if event.entity.type == 'simple-entity' then -- Cheap check for rock, may have other side effects
         change_for_global(rocks_smashed_name, 1)
         return
     end
     if event.entity.type == 'tree' then
         change_for_global(trees_cut_down_name, 1)
+    end
+    if event.entity.type == 'container'  and event.entity.operable == false then-- We have to do it here because we can't check the entity from player_mined_item
+        local inv = event.entity.get_inventory(defines.inventory.chest)
+        local coin_count = inv.get_item_count("coin")
+        if coin_count then
+            change_for_player(event.player_index, coins_earned_name, coin_count)
+        end
     end
 end
 
@@ -310,9 +317,8 @@ end
 
 Event.add(defines.events.on_player_created, player_created)
 Event.add(defines.events.on_player_died, player_died)
-Event.add(defines.events.on_player_mined_item, picked_up_item)
 Event.add(defines.events.on_picked_up_item, picked_up_item)
-Event.add(defines.events.on_pre_player_mined_item, player_mined_item)
+Event.add(defines.events.on_pre_player_mined_item, pre_player_mined_item)
 Event.add(defines.events.on_player_crafted_item, player_crafted_item)
 Event.add(defines.events.on_console_chat, player_console_chat)
 Event.add(defines.events.on_built_entity, player_built_entity)

--- a/features/player_stats.lua
+++ b/features/player_stats.lua
@@ -146,15 +146,17 @@ local function picked_up_item(event)
 end
 
 local function pre_player_mined_item(event)
-    if event.entity.type == 'simple-entity' then -- Cheap check for rock, may have other side effects
+    local entity = event.entity
+    if entity.type == 'simple-entity' then -- Cheap check for rock, may have other side effects
         change_for_global(rocks_smashed_name, 1)
         return
     end
-    if event.entity.type == 'tree' then
+    if entity.type == 'tree' then
         change_for_global(trees_cut_down_name, 1)
+        return
     end
-    if event.entity.type == 'container'  and event.entity.operable == false then-- We have to do it here because we can't check the entity from player_mined_item
-        local inv = event.entity.get_inventory(defines.inventory.chest)
+    if entity.type == 'container'  and entity.operable == false then -- We check the container is not operable as these are used as loot chests in Crash Site and players can't add coins to them.
+        local inv = entity.get_inventory(defines.inventory.chest)
         local coin_count = inv.get_item_count("coin")
         if coin_count then
             change_for_player(event.player_index, coins_earned_name, coin_count)

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1866,13 +1866,6 @@ function Public.do_factory_loot(entity, weights, loot)
     entity.get_output_inventory().insert {name = name, count = count}
 end
 
-local function coin_mined(event)
-    local stack = event.item_stack
-    if stack.name == 'coin' then
-        change_for_player(event.player_index, coins_earned_name, stack.count)
-    end
-end
-
 local function market_selected(event)
     local player = game.get_player(event.player_index)
     if not player or not player.valid then
@@ -1930,8 +1923,6 @@ Event.on_init(
         game.forces.neutral.recipes['steel-plate'].enabled = true
     end
 )
-
-Event.add(defines.events.on_player_mined_item, coin_mined)
 
 Event.add(Retailer.events.on_market_purchase, do_outpost_upgrade)
 

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -11,8 +11,6 @@ local RS = require 'map_gen.shared.redmew_surface'
 local Server = require 'features.server'
 local CrashSiteToast = require 'map_gen.maps.crash_site.crash_site_toast'
 local ScoreTracker = require 'utils.score_tracker'
-local change_for_player = ScoreTracker.change_for_player
-local coins_earned_name = 'coins-earned'
 
 local table = require 'utils.table'
 --local next = next

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -10,7 +10,6 @@ local Donator = require 'features.donator'
 local RS = require 'map_gen.shared.redmew_surface'
 local Server = require 'features.server'
 local CrashSiteToast = require 'map_gen.maps.crash_site.crash_site_toast'
-local ScoreTracker = require 'utils.score_tracker'
 
 local table = require 'utils.table'
 --local next = next


### PR DESCRIPTION
Problem: Picking up a chest with coins in it added to the player's coin score. Players could place chests with coins and mine them to increase their score.

Solution: Change the event that adds the coin to the player score so that we can check what entity was mined and apply the coins to the count conditionally.

Details:
- Removed events.on_player_mined_item from outpost_builder because we don't want to add coins every time they mine and it's duplicated in player_stats.
- Removed events.on_player_mined_item from player_stats because it doesn't tell us what entity the items came from.
- Added coin tracking to events.on_pre_player_mined_item event instead. Checks if the mined item was a chest with coins in it and adds to the player stats if so.
- Tested that coins from trees and rocks still track when market is enabled
- While I was at it, added a pretty coin floating text for when RNG gives coins from mining trees/rocks