### PR TITLE
Updated artillery behaviour to get rid of destroyer-capsule

### DIFF
--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -322,6 +322,10 @@ local artillery_cooldown_callback
 artillery_cooldown_callback =
     Token.register(
     function(entity)
+        if not entity.valid then
+            return
+        end
+
         entity.minable = true
     end
 )

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -318,6 +318,15 @@ destroyer_callback =
     end
 )
 
+local artillery_cooldown_callback
+artillery_cooldown_callback =
+    Token.register(
+    function(data)
+        local entity = data.entity
+        entity.minable = true
+    end
+)
+
 local function do_bot_spawn(entity_name, entity, event)
     -- Return if the entity killed is not on the white list
     if not bot_spawn_whitelist[entity_name] then
@@ -365,19 +374,19 @@ local function do_bot_spawn(entity_name, entity, event)
         end
         for i = 1, repeat_cycle do
             if (cause.name == 'artillery-turret') then
-                spawn_entity.target = cause.position    -- Overwrite target. Artillery turrets/wagons don't move so send them to entity position. Stops players from picking up the arty and the bots stopping dead.
-                spawn_entity.speed = 0.2
-                spawn_entity.max_range = 10000          -- Entities of type projectile have a default max range that's lower than late game artillery range.
-                -- This is particularly risky for players to do because defender-capsule quantities are not limited by the player force's follower robot count.
-                spawn_entity.name = 'defender-capsule'  -- use 'defender-capsule' (projectile) not 'defender' (entity) since a projectile can target a position but a capsule entity must have another entity as target
+                cause.minable = false
+                set_timeout_in_ticks(300, artillery_cooldown_callback, {entity = cause})
+                spawn_entity.name = 'defender'
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)
 
-                spawn_entity.name = 'destroyer-capsule'
+                spawn_entity.name = 'destroyer'
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)
 
             elseif (cause.name == 'artillery-wagon') then
+                cause.minable = false
+                set_timeout_in_ticks(300, artillery_cooldown_callback, {entity = cause})
                 spawn_entity.name = 'defender'
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -321,8 +321,7 @@ destroyer_callback =
 local artillery_cooldown_callback
 artillery_cooldown_callback =
     Token.register(
-    function(data)
-        local entity = data.entity
+    function(entity)
         entity.minable = true
     end
 )
@@ -375,7 +374,7 @@ local function do_bot_spawn(entity_name, entity, event)
         for i = 1, repeat_cycle do
             if (cause.name == 'artillery-turret') then
                 cause.minable = false
-                set_timeout_in_ticks(300, artillery_cooldown_callback, {entity = cause})
+                set_timeout_in_ticks(300, artillery_cooldown_callback, cause)
                 spawn_entity.name = 'defender'
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)
@@ -386,7 +385,7 @@ local function do_bot_spawn(entity_name, entity, event)
 
             elseif (cause.name == 'artillery-wagon') then
                 cause.minable = false
-                set_timeout_in_ticks(300, artillery_cooldown_callback, {entity = cause})
+                set_timeout_in_ticks(300, artillery_cooldown_callback, cause)
                 spawn_entity.name = 'defender'
                 create_entity(spawn_entity)
                 create_entity(spawn_entity)

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1223,12 +1223,13 @@ local server_player = {name = '<server>', print = print}
 
 local function set_pollution_multiplier(args, player)
     local multiplier = tonumber(args.multiplier)
+    player = player or server_player
+    
     if not multiplier then
         player.print("Fail")
         return
     end
 
-    player = player or server_player
     local old_multiplier = pollution_multiplier.value
     pollution_multiplier.value = multiplier
     local message = player.name..' changed magic crafter pollution multiplier from '..old_multiplier..' to '..pollution_multiplier.value
@@ -1955,7 +1956,7 @@ Command.add(
     'get-pollution-multiplier',
     {
         description = {'command_description.get_pollution_multiplier'},
-        required_rank = Ranks.regular,
+        required_rank = Ranks.guest,
         capture_excess_arguments = true,
         allowed_by_server = true
     },

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1219,6 +1219,8 @@ local function do_artillery_turrets_targets()
     end
 end
 
+local server_player = {name = '<server>', print = print}
+
 local function set_pollution_multiplier(args, player)
     local multiplier = tonumber(args.multiplier)
     if not multiplier then
@@ -1226,6 +1228,7 @@ local function set_pollution_multiplier(args, player)
         return
     end
 
+    player = player or server_player
     local old_multiplier = pollution_multiplier.value
     pollution_multiplier.value = multiplier
     local message = player.name..' changed magic crafter pollution multiplier from '..old_multiplier..' to '..pollution_multiplier.value
@@ -1236,7 +1239,6 @@ local function set_pollution_multiplier(args, player)
     end
 end
 
-local server_player = {name = '<server>', print = print}
 local function get_pollution_multiplier(_, player)
     player = player or server_player
     player.print('Current pollution multiplier is: '..pollution_multiplier.value)
@@ -1953,7 +1955,7 @@ Command.add(
     'get-pollution-multiplier',
     {
         description = {'command_description.get_pollution_multiplier'},
-        required_rank = Ranks.admin,
+        required_rank = Ranks.regular,
         capture_excess_arguments = true,
         allowed_by_server = true
     },

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1224,7 +1224,7 @@ local server_player = {name = '<server>', print = print}
 local function set_pollution_multiplier(args, player)
     local multiplier = tonumber(args.multiplier)
     player = player or server_player
-    
+
     if not multiplier then
         player.print("Fail")
         return


### PR DESCRIPTION
Use of the destroyer-capsule projectile instead of destroyer capsule meant that the destroyers and defenders didn't attack player entities until they reached the destination. They also couldn't be shot down by a well defended wall, they'd fly over.

I changed to destroyer-capsule so that they couldn't pick the artillery up after the bots spawned as this would remove their target and cause them to float around.

By request I have reveret to the destroyers that can be shot down as they're more fun and at current balance the destroyers kill the artillery every time, which is not much fun when they cannot be defended against.

To mitigate against players picking up the artillery after the destroyer/defender spawns, artillery targets will become unminable for 5 seconds after the destroyer/defender deploys.

This leaves the bug where they can pick up the artillery before the last shell destroys the turret. I considered adding artillery to a table when placed and checking their ammo inventory once every few seconds. I was going to set all artillery turrets to unminable unless they have no ammo for 3 seconds, but this seems like a lot of work for a small bug.