### PR TITLE
crash site: enable steel research on start

### DIFF
--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1920,7 +1920,7 @@ Event.add(defines.events.on_entity_died, turret_died)
 
 Event.on_init(
     function()
-        game.forces.neutral.recipes['steel-plate'].enabled = true
+        game.forces.player.recipes['steel-plate'].enabled = true
     end
 )
 


### PR DESCRIPTION
This enables the players to see the steel icons on outpost furnaces on the map.