### PR TITLE
Fixed evo floating text bug

### DIFF
--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -279,8 +279,8 @@ local function do_evolution(entity, entity_name, entity_force)
         local old = entity_force.evolution_factor
         local extra = (1 - old) * factor
         local new = old + extra
+        entity_force.evolution_factor = math.min(new,1)
         if new < 1 then
-            entity_force.evolution_factor = new
             local position = entity.position
             entity.surface.create_entity{name="flying-text", position = {position.x - 1, position.y}, text = "+" .. round(extra*100,2) .. "% evo", color = Color.plum}
         end


### PR DESCRIPTION
We managed to get into a state where the evo never quite reached 1 because the code to set the evolution was inside the if statement. Therefore +0% evo would pop up for the whole of late game

