### PR TITLE
Dump player inventories 

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -81,6 +81,12 @@ global.config = {
     tag_group = {
         enabled = true
     },
+    -- enables dumping of inventories of offline players to a corpse near spawn
+    -- This feature is dependant upon corpse_util and will enable it
+    dump_offline_inventories = {
+        enabled = true,
+        offline_timout_mins = 1,   -- time after which a player logs off that their inventory is provided to the team
+    },
     -- enables players to create and prioritize tasks
     tasklist = {
         enabled = true

--- a/config.lua
+++ b/config.lua
@@ -84,8 +84,8 @@ global.config = {
     -- enables dumping of inventories of offline players to a corpse near spawn
     -- This feature is dependant upon corpse_util and will enable it
     dump_offline_inventories = {
-        enabled = true,
-        offline_timout_mins = 1,   -- time after which a player logs off that their inventory is provided to the team
+        enabled = false,
+        offline_timout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
     },
     -- enables players to create and prioritize tasks
     tasklist = {

--- a/control.lua
+++ b/control.lua
@@ -53,10 +53,6 @@ if config.corpse_util.enabled then
     require 'features.corpse_util'
 end
 if config.dump_offline_inventories.enabled  then
-    if not config.corpse_util.enabled then
-        config.corpse_util.enabled = true
-        require 'features.corpse_util'
-    end
     require 'features.dump_offline_inventories'
 end
 if config.admin_commands.enabled then

--- a/control.lua
+++ b/control.lua
@@ -52,6 +52,13 @@ end
 if config.corpse_util.enabled then
     require 'features.corpse_util'
 end
+if config.dump_offline_inventories.enabled  then
+    if not config.corpse_util.enabled then
+        config.corpse_util.enabled = true
+        require 'features.corpse_util'
+    end
+    require 'features.dump_offline_inventories'
+end
 if config.admin_commands.enabled then
     require 'features.admin_commands'
 end

--- a/features/corpse_util.lua
+++ b/features/corpse_util.lua
@@ -23,6 +23,10 @@ Global.register(player_corpses, function(tbl)
     player_corpses = tbl
 end)
 
+local function add_tag(tag, player_index, death_tick)
+    player_corpses[player_index * 0x100000000 + death_tick] = tag
+end
+
 local function player_died(event)
     local player_index = event.player_index
     local player = game.get_player(player_index)
@@ -83,7 +87,7 @@ local function player_died(event)
         end
     end
 
-    player_corpses[player_index * 0x100000000 + tick] = tag
+    add_tag(tag, player_index, tick)
 end
 
 local function remove_tag(player_index, tick)
@@ -99,12 +103,14 @@ local function remove_tag(player_index, tick)
     tag.destroy()
 end
 
-local function corpse_expired(event)
-    local entity = event.corpse
-
-    if entity and entity.valid then
-        remove_tag(entity.character_corpse_player_index, entity.character_corpse_tick_of_death)
+local function remove_corpse_tag(corpse)
+    if corpse and corpse.valid then
+        remove_tag(corpse.character_corpse_player_index, corpse.character_corpse_tick_of_death)
     end
+end
+
+local function corpse_expired(event)
+    remove_corpse_tag(event.corpse)
 end
 
 local corpse_util_mined_entity = Token.register(function(data)
@@ -131,14 +137,14 @@ local function mined_entity(event)
     local player_index = event.player_index
     local corpse_owner_index = entity.character_corpse_player_index
 
-    if player_index == corpse_owner_index then
+    if player_index == corpse_owner_index or not entity.active then
         return
     end
 
     local player = game.get_player(player_index)
     local corpse_owner = game.get_player(corpse_owner_index)
 
-    if player and corpse_owner and entity.active then
+    if player and corpse_owner then
         local message = table.concat {player.name, ' has looted ', corpse_owner.name, "'s corpse"}
         Utils.action_warning('[Corpse]', message)
     end
@@ -153,16 +159,38 @@ local function on_gui_opened(event)
     local player_index = event.player_index
     local corpse_owner_index = entity.character_corpse_player_index
 
-    if player_index == corpse_owner_index then
+    if player_index == corpse_owner_index or not entity.active then
         return
     end
 
     local player = game.get_player(player_index)
     local corpse_owner = game.get_player(corpse_owner_index)
 
-    if player and corpse_owner and entity.active then
+    if player and corpse_owner then
         local message = table.concat {player.name, ' is looting ', corpse_owner.name, "'s corpse"}
         Utils.action_warning('[Corpse]', message)
+    end
+end
+
+local function on_gui_closed(event)
+    local player = game.get_player(event.player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    local entity = event.entity
+    if not entity or not entity.valid or entity.name ~= 'character-corpse' then
+        return
+    end
+
+    local inv_corpse = entity.get_inventory(defines.inventory.character_corpse)
+    if not inv_corpse or not inv_corpse.valid then
+        return
+    end
+
+    if inv_corpse.is_empty() then
+        remove_corpse_tag(entity)
+        entity.destroy()
     end
 end
 
@@ -170,10 +198,13 @@ Event.add(defines.events.on_player_died, player_died)
 Event.add(defines.events.on_character_corpse_expired, corpse_expired)
 Event.add(defines.events.on_pre_player_mined_item, mined_entity)
 Event.add(defines.events.on_gui_opened, on_gui_opened)
+Event.add(defines.events.on_gui_closed, on_gui_closed)
 
 function Public.clear()
     table.clear_table(player_corpses)
 end
+
+Public.add_tag = add_tag
 
 Public._player_died = player_died
 Public.player_corpses = player_corpses

--- a/features/corpse_util.lua
+++ b/features/corpse_util.lua
@@ -160,7 +160,7 @@ local function on_gui_opened(event)
     local player = game.get_player(player_index)
     local corpse_owner = game.get_player(corpse_owner_index)
 
-    if player and corpse_owner then
+    if player and corpse_owner and entity.active == true then
         local message = table.concat {player.name, ' is looting ', corpse_owner.name, "'s corpse"}
         Utils.action_warning('[Corpse]', message)
     end

--- a/features/corpse_util.lua
+++ b/features/corpse_util.lua
@@ -138,7 +138,7 @@ local function mined_entity(event)
     local player = game.get_player(player_index)
     local corpse_owner = game.get_player(corpse_owner_index)
 
-    if player and corpse_owner then
+    if player and corpse_owner and entity.active == true then
         local message = table.concat {player.name, ' has looted ', corpse_owner.name, "'s corpse"}
         Utils.action_warning('[Corpse]', message)
     end
@@ -176,5 +176,6 @@ function Public.clear()
 end
 
 Public._player_died = player_died
+Public.player_corpses = player_corpses
 
 return Public

--- a/features/corpse_util.lua
+++ b/features/corpse_util.lua
@@ -138,7 +138,7 @@ local function mined_entity(event)
     local player = game.get_player(player_index)
     local corpse_owner = game.get_player(corpse_owner_index)
 
-    if player and corpse_owner and entity.active == true then
+    if player and corpse_owner and entity.active then
         local message = table.concat {player.name, ' has looted ', corpse_owner.name, "'s corpse"}
         Utils.action_warning('[Corpse]', message)
     end
@@ -160,7 +160,7 @@ local function on_gui_opened(event)
     local player = game.get_player(player_index)
     local corpse_owner = game.get_player(corpse_owner_index)
 
-    if player and corpse_owner and entity.active == true then
+    if player and corpse_owner and entity.active then
         local message = table.concat {player.name, ' is looting ', corpse_owner.name, "'s corpse"}
         Utils.action_warning('[Corpse]', message)
     end

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -1,4 +1,4 @@
--- This feature allows you to turn on anti-hoarding so that X minutes after a player leaves the game 
+-- This feature allows you to turn on anti-hoarding so that X minutes after a player leaves the game
 -- the resources in their inventory are returned to the teams
 
 -- To do
@@ -56,7 +56,7 @@ local spawn_player_corpse =
                     position = position,
                     text = text
                 })
-                
+
                 corpse_util.player_corpses[player.index * 0x100000000 + game.tick] = tag
         end
     end

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -5,55 +5,61 @@
 local Event = require 'utils.event'
 local Task = require 'utils.task'
 local Token = require 'utils.token'
+local Global = require 'utils.global'
 local corpse_util = require 'features.corpse_util'
 
 local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local config = global.config.dump_offline_inventories
 local offline_timout_mins = config.offline_timout_mins
-local offline_player_queue = {}
 
---[[local config = global.config
-config.dump_offline_inventories = {
-    enabled = true,
-    offline_timout_mins = 1,   -- time after which a player logs off that their inventory is provided to the team
-}]]--
+local offline_player_queue = {}
+Global.register({offline_player_queue = offline_player_queue}, function(tbl)
+    offline_player_queue = tbl.offline_player_queue
+end)
 
 local spawn_player_corpse =
     Token.register(
-    function(player)
-        if player and player.valid and player.connected == false and offline_player_queue[player.index] then
-            -- fetch table of items in main inventory and logistics trash. Leave weapons and armor.
-            local inv_main = player.get_inventory(defines.inventory.character_main)
-            local inv_trash = player.get_inventory(defines.inventory.character_trash)
+    function(data)
+        local player = data.player
+        if not player or not player.valid or player.connected or not offline_player_queue[player.index] or offline_player_queue[player.index].tick ~= data.tick then
+            return
+        end
 
-            local inv_main_contents = inv_main.get_contents()
-            local inv_trash_contents = inv_trash.get_contents()
-            local inv_corpse_size = (#inv_main - inv_main.count_empty_stacks()) + (#inv_trash - inv_trash.count_empty_stacks())
-            -- create corpse
-            local position = player.position
-            local corpse = player.surface.create_entity{name="character-corpse", position=position, inventory_size = inv_corpse_size, player_index = player.index}
-            corpse.active = false
+        game.print("Debug: callback reached")
+        local inv_main = player.get_inventory(defines.inventory.character_main)
+        local inv_trash = player.get_inventory(defines.inventory.character_trash)
 
-            local inv_corpse = corpse.get_inventory(defines.inventory.character_corpse)
+        local inv_main_contents = inv_main.get_contents()
+        local inv_trash_contents = inv_trash.get_contents()
 
-            for item_name, count in pairs(inv_main_contents) do
-                inv_corpse.insert({name = item_name, count = count})
-            end
-            for item_name, count in pairs(inv_trash_contents) do
-                inv_corpse.insert({name = item_name, count = count})
-            end
+        local inv_corpse_size = (#inv_main - inv_main.count_empty_stacks()) + (#inv_trash - inv_trash.count_empty_stacks())
 
-            inv_main.clear()
-            inv_trash.clear()
+        local position = player.position
+        local corpse = player.surface.create_entity{name="character-corpse", position=position, inventory_size = inv_corpse_size, player_index = player.index}
+        corpse.active = false
 
-                local text = player.name .. "'s inventory (offline)"
-                local tag = player.force.add_chart_tag(player.surface, {
-                    icon = {type = 'item', name = 'modular-armor'},
-                    position = position,
-                    text = text
-                })
+        local inv_corpse = corpse.get_inventory(defines.inventory.character_corpse)
 
-                corpse_util.player_corpses[player.index * 0x100000000 + game.tick] = tag
+        for item_name, count in pairs(inv_main_contents) do
+            inv_corpse.insert({name = item_name, count = count})
+        end
+        for item_name, count in pairs(inv_trash_contents) do
+            inv_corpse.insert({name = item_name, count = count})
+        end
+
+        inv_main.clear()
+        inv_trash.clear()
+
+        offline_player_queue[data.player.index] = nil
+
+        local text = player.name .. "'s inventory (offline)"
+        local tag = player.force.add_chart_tag(player.surface, {
+            icon = {type = 'item', name = 'modular-armor'},
+            position = position,
+            text = text
+        })
+        if tag then
+            corpse_util.player_corpses[player.index * 0x100000000 + game.tick] = tag
         end
     end
 )
@@ -62,6 +68,7 @@ Event.add(
     defines.events.on_player_joined_game,
     function(event)
         offline_player_queue[event.player_index] = nil -- ensures they're not in the offline_player_queue for wealth redistribution
+        game.print("Debug: player removed from queue")
     end
 )
 
@@ -70,9 +77,22 @@ Event.add(
     function(event)
         local player_index = event.player_index
         local player = game.get_player(player_index)
-        if player.character then -- if player leaves before respawning they wont have a character and we don't need to add them to the list
-            offline_player_queue[player_index] = true
-            set_timeout_in_ticks(offline_timout_mins*60*60, spawn_player_corpse, player)
+        if player and player.valid and player.character then -- if player leaves before respawning they wont have a character and we don't need to add them to the list
+            offline_player_queue[player_index] = game.tick  -- tick is used to check that the callback happens after X minutes as multiple callbacks may be active if the player logs off and on multiple times
+            game.print("Debug: player added to queue")
+            set_timeout_in_ticks(offline_timout_mins*60*60, spawn_player_corpse, {player = player, tick = game.tick})
+        end
+    end
+)
+
+Event.add(
+    defines.events.on_player_banned,
+    function(event)
+        local player_index = event.player_index
+        local player = game.get_player(player_index)
+        if player and player.valid and player.character then -- if player leaves before respawning they wont have a character and we don't need to add them to the list
+            offline_player_queue[player_index] = game.tick  -- tick is used to check that the callback happens after X minutes as multiple callbacks may be active if the player logs off and on multiple times
+            set_timeout_in_ticks(60, spawn_player_corpse, {player = player, tick = game.tick})
         end
     end
 )

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -1,10 +1,6 @@
 -- This feature allows you to turn on anti-hoarding so that X minutes after a player leaves the game
--- the resources in their inventory are returned to the teams
-
--- To do
--- What if player has no body when they leave?
--- What if players is kicked?
--- Do we want to allow donators and admins to keep their inventories as a perk? Or is that too pay to win?
+-- the resources in their inventory are returned to the teams. A corpse will spawn on the player's last
+-- position and remain until they log back in to claim it or someone else mines it.
 
 local Event = require 'utils.event'
 local Task = require 'utils.task'
@@ -66,7 +62,6 @@ Event.add(
     defines.events.on_player_joined_game,
     function(event)
         offline_player_queue[event.player_index] = nil -- ensures they're not in the offline_player_queue for wealth redistribution
-        game.print("Player rejoined. Removed from offline list")
     end
 )
 
@@ -78,7 +73,6 @@ Event.add(
         if player.character then -- if player leaves before respawning they wont have a character and we don't need to add them to the list
             offline_player_queue[player_index] = true
             set_timeout_in_ticks(offline_timout_mins*60*60, spawn_player_corpse, player)
-            game.print("Player left. Added to offline list")
         end
     end
 )

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -68,7 +68,6 @@ Event.add(
     defines.events.on_player_joined_game,
     function(event)
         offline_player_queue[event.player_index] = nil -- ensures they're not in the offline_player_queue for wealth redistribution
-        game.print("Debug: player removed from queue")
     end
 )
 
@@ -79,7 +78,6 @@ Event.add(
         local player = game.get_player(player_index)
         if player and player.valid and player.character then -- if player leaves before respawning they wont have a character and we don't need to add them to the list
             offline_player_queue[player_index] = game.tick  -- tick is used to check that the callback happens after X minutes as multiple callbacks may be active if the player logs off and on multiple times
-            game.print("Debug: player added to queue")
             set_timeout_in_ticks(offline_timout_mins*60*60, spawn_player_corpse, {player = player, tick = game.tick})
         end
     end

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -1,0 +1,122 @@
+-- This feature allows you to turn on anti-hoarding so that X minutes after a player leaves the game 
+-- the resources in their inventory are returned to the teams
+
+-- To do
+-- What if player has no body when they leave?
+-- What if players is kicked?
+-- Do we want to allow donators and admins to keep their inventories as a perk? Or is that too pay to win?
+
+local Event = require 'utils.event'
+local Task = require 'utils.task'
+local Token = require 'utils.token'
+local corpse_util = require 'features.corpse_util'
+
+local set_timeout_in_ticks = Task.set_timeout_in_ticks
+local config = global.config.dump_offline_inventories
+local offline_timout_mins = config.offline_timout_mins
+local offline_player_queue = {}
+
+--[[local config = global.config
+config.dump_offline_inventories = {
+    enabled = true,
+    offline_timout_mins = 1,   -- time after which a player logs off that their inventory is provided to the team
+}]]--
+
+/sc
+local player = game.players["Tigress88"]
+local inv_main = player.get_inventory(defines.inventory.character_main)
+local inv_trash = player.get_inventory(defines.inventory.character_trash)
+local inv_main_contents = inv_main.get_contents()
+local inv_trash_contents = inv_trash.get_contents()
+local inv_corpse_size = (#inv_main - inv_main.count_empty_stacks()) + (#inv_trash - inv_trash.count_empty_stacks())
+local position = player.position
+local corpse = player.surface.create_entity{name="character-corpse", position=position, inventory_size = inv_corpse_size, player_index = 2}
+corpse.active = false
+
+local inv_corpse = corpse.get_inventory(defines.inventory.character_corpse)
+
+local success_main = true
+local success_trash = true
+local inserted = nil
+
+
+for item_name, count in pairs(inv_main_contents) do
+    inv_corpse.insert({name = item_name, count = count})
+end
+for item_name, count in pairs(inv_trash_contents) do
+    inv_corpse.insert({name = item_name, count = count})
+end
+
+
+inv_main.clear()
+inv_trash.clear()
+
+local text = player.name .. "'s inventory (offline)"
+local tag = player.force.add_chart_tag(player.surface, {
+    icon = {type = 'item', name = 'modular-armor'},
+    position = position,
+    text = text
+})
+
+
+
+local spawn_player_corpse =
+    Token.register(
+    function(player)
+        if player and player.valid and player.connected == false and offline_player_queue[player.index] then
+            -- fetch table of items in main inventory and logistics trash. Leave weapons and armor.
+            local inv_main = player.get_inventory(defines.inventory.character_main)
+            local inv_trash = player.get_inventory(defines.inventory.character_trash)
+
+            local inv_main_contents = inv_main.get_contents()
+            local inv_trash_contents = inv_trash.get_contents()
+            local inv_corpse_size = (#inv_main - inv_main.count_empty_stacks()) + (#inv_trash - inv_trash.count_empty_stacks())
+            -- create corpse
+            local position = player.position
+            local corpse = player.surface.create_entity{name="character-corpse", position=position, inventory_size = inv_corpse_size, player_index = player.index}
+            corpse.active = false
+
+            local inv_corpse = corpse.get_inventory(defines.inventory.character_corpse)
+
+            for item_name, count in pairs(inv_main_contents) do
+                inv_corpse.insert({name = item_name, count = count})
+            end
+            for item_name, count in pairs(inv_trash_contents) do
+                inv_corpse.insert({name = item_name, count = count})
+            end
+
+            inv_main.clear()
+            inv_trash.clear()
+
+                local text = player.name .. "'s inventory (offline)"
+                local tag = player.force.add_chart_tag(player.surface, {
+                    icon = {type = 'item', name = 'modular-armor'},
+                    position = position,
+                    text = text
+                })
+                
+                corpse_util.player_corpses[player.index * 0x100000000 + game.tick] = tag
+        end
+    end
+)
+
+Event.add(
+    defines.events.on_player_joined_game,
+    function(event)
+        offline_player_queue[event.player_index] = nil -- ensures they're not in the offline_player_queue for wealth redistribution
+        game.print("Player rejoined. Removed from offline list")
+    end
+)
+
+Event.add(
+    defines.events.on_pre_player_left_game,
+    function(event)
+        local player_index = event.player_index
+        local player = game.get_player(player_index)
+        if player.character then -- if player leaves before respawning they wont have a character and we don't need to add them to the list
+            offline_player_queue[player_index] = true
+            set_timeout_in_ticks(offline_timout_mins*60*60, spawn_player_corpse, player)
+            game.print("Player left. Added to offline list")
+        end
+    end
+)

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -22,44 +22,6 @@ config.dump_offline_inventories = {
     offline_timout_mins = 1,   -- time after which a player logs off that their inventory is provided to the team
 }]]--
 
-/sc
-local player = game.players["Tigress88"]
-local inv_main = player.get_inventory(defines.inventory.character_main)
-local inv_trash = player.get_inventory(defines.inventory.character_trash)
-local inv_main_contents = inv_main.get_contents()
-local inv_trash_contents = inv_trash.get_contents()
-local inv_corpse_size = (#inv_main - inv_main.count_empty_stacks()) + (#inv_trash - inv_trash.count_empty_stacks())
-local position = player.position
-local corpse = player.surface.create_entity{name="character-corpse", position=position, inventory_size = inv_corpse_size, player_index = 2}
-corpse.active = false
-
-local inv_corpse = corpse.get_inventory(defines.inventory.character_corpse)
-
-local success_main = true
-local success_trash = true
-local inserted = nil
-
-
-for item_name, count in pairs(inv_main_contents) do
-    inv_corpse.insert({name = item_name, count = count})
-end
-for item_name, count in pairs(inv_trash_contents) do
-    inv_corpse.insert({name = item_name, count = count})
-end
-
-
-inv_main.clear()
-inv_trash.clear()
-
-local text = player.name .. "'s inventory (offline)"
-local tag = player.force.add_chart_tag(player.surface, {
-    icon = {type = 'item', name = 'modular-armor'},
-    position = position,
-    text = text
-})
-
-
-
 local spawn_player_corpse =
     Token.register(
     function(player)

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -68,6 +68,8 @@ local spawn_player_corpse =
             text = text
         })
 
+        game.print("[gps="..position.x..","..position.y..",redmew] "..player.name.." has been offline "..offline_timout_mins.." minutes. Their inventory is now available.")
+
         if tag then
             CorpseUtil.add_tag(tag, player_index, game.tick)
         end

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -49,9 +49,8 @@ RedmewConfig.market.enabled = false
 RedmewConfig.biter_attacks.enabled = false
 RedmewConfig.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 0.5,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
 }
-
 
 -- leave seeds nil to have them filled in based on the map seed.
 local outpost_seed = nil --91000

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -44,13 +44,13 @@ local function control(config)
     local map_gen_settings = config.map_gen_settings or default_map_gen_settings
     RS.set_map_gen_settings(map_gen_settings)
 end
---[[]]
+
 RedmewConfig.market.enabled = false
 RedmewConfig.biter_attacks.enabled = false
 RedmewConfig.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 1,   -- time after which a player logs off that their inventory is provided to the team
-}]]
+    offline_timout_mins = 0.5,   -- time after which a player logs off that their inventory is provided to the team
+}
 
 
 -- leave seeds nil to have them filled in based on the map seed.

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -18,8 +18,6 @@ local RedmewConfig = require 'config'
 local Cutscene = require 'map_gen.maps.crash_site.cutscene'
 local cutscene_surface_settings = require 'map_gen.maps.crash_site.cutscene_surface_settings'
 
-
-
 local degrees = math.degrees
 local cutscene_force_name = 'cutscene'
 
@@ -46,9 +44,14 @@ local function control(config)
     local map_gen_settings = config.map_gen_settings or default_map_gen_settings
     RS.set_map_gen_settings(map_gen_settings)
 end
-
+--[[]]
 RedmewConfig.market.enabled = false
 RedmewConfig.biter_attacks.enabled = false
+RedmewConfig.dump_offline_inventories = {
+    enabled = true,
+    offline_timout_mins = 1,   -- time after which a player logs off that their inventory is provided to the team
+}]]
+
 
 -- leave seeds nil to have them filled in based on the map seed.
 local outpost_seed = nil --91000


### PR DESCRIPTION
New feature to dump player inventories to a corpse after they've been gone 15 minutes. Will spawn on their last position so if no one else wants their stuff it will be there when they get back.

Remaining issues:
1) I couldn't get the config.lua settings to work as I couldn't find a good example. I want it off by default then overwrite that from crashsite. See commented block on lines 19 to 23 of dump_offline_inventories.lua for my attempt that needs correcting.
EDIT: I should have put it in scenario.lua not dump_offline_inventories.lua, right?
2) I don't think I've made the corpse_util,lua player_corpses public properly. It doesn't destroy the tag when it is removed and I added code to stop the looting message when corpse.active is false. That's not working.
EDIT: I fixed the looting message
3) There's some debug I haven't taken out yet. I will remove it all once it's working.
4) The timer's currently set to 1 minute not 15.