### PR TITLE
Refactor corpse features:

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -81,10 +81,9 @@ global.config = {
     tag_group = {
         enabled = true
     },
-    -- enables dumping of inventories of offline players to a corpse near spawn
-    -- This feature is dependant upon corpse_util and will enable it
+    -- enables dumping of inventories of offline players to a corpse at the player's last location
     dump_offline_inventories = {
-        enabled = false,
+        enabled = true,
         offline_timout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
     },
     -- enables players to create and prioritize tasks
@@ -287,7 +286,7 @@ global.config = {
         enabled = true
     },
     -- when a player dies, leaves a map marker until the corpse expires or is looted
-    corpse_util = {
+    death_corpse_tags = {
         enabled = true
     },
     -- adds many commands for users and admins alike

--- a/control.lua
+++ b/control.lua
@@ -49,8 +49,8 @@ end
 if config.hodor.enabled or config.auto_respond.enabled or config.mentions.enabled then
     require 'features.chat_triggers'
 end
-if config.corpse_util.enabled then
-    require 'features.corpse_util'
+if config.death_corpse_tags.enabled then
+    require 'features.death_corpse_tags'
 end
 if config.dump_offline_inventories.enabled  then
     require 'features.dump_offline_inventories'

--- a/features/death_corpse_tags.lua
+++ b/features/death_corpse_tags.lua
@@ -1,0 +1,94 @@
+local Event = require 'utils.event'
+local Settings = require 'utils.redmew_settings'
+local CorpseUtil = require 'features.corpse_util'
+
+local Public = {}
+
+local ping_own_death_name = 'death_corpse_tags.ping_own_death'
+local ping_other_death_name = 'death_corpse_tags.ping_other_death'
+
+Public.ping_own_death_name = ping_own_death_name
+Public.ping_other_death_name = ping_other_death_name
+
+Settings.register(ping_own_death_name, Settings.types.boolean, true, 'death_corpse_tags.ping_own_death')
+Settings.register(ping_other_death_name, Settings.types.boolean, false, 'death_corpse_tags.ping_other_death')
+
+local function player_died(event)
+    local player_index = event.player_index
+    local player = game.get_player(player_index)
+
+    if not player or not player.valid then
+        return
+    end
+
+    local pos = player.position
+    local entities = player.surface.find_entities_filtered {
+        area = {{pos.x - 0.5, pos.y - 0.5}, {pos.x + 0.5, pos.y + 0.5}},
+        name = 'character-corpse'
+    }
+
+    local tick = game.tick
+    local entity
+    for _, e in ipairs(entities) do
+        if e.character_corpse_player_index == event.player_index and e.character_corpse_tick_of_death == tick then
+            entity = e
+            break
+        end
+    end
+
+    if not entity or not entity.valid then
+        return
+    end
+
+    local inv_corpse = entity.get_inventory(defines.inventory.character_corpse)
+    if not inv_corpse or not inv_corpse.valid then
+        return
+    end
+
+    if inv_corpse.is_empty() then
+        entity.destroy()
+        player.print({'death_corpse_tags.empty_corpse'})
+        return
+    end
+
+    local text = player.name .. "'s corpse"
+    local position = entity.position
+    local tag = player.force.add_chart_tag(player.surface, {
+        icon = {type = 'item', name = 'power-armor-mk2'},
+        position = position,
+        text = text
+    })
+
+    if not tag then
+        return
+    end
+
+    if Settings.get(player_index, ping_own_death_name) then
+        player.print({
+            'death_corpse_tags.own_corpse_location',
+            string.format('%.1f', position.x),
+            string.format('%.1f', position.y),
+            player.surface.name
+        })
+    end
+
+    for _, other_player in pairs(player.force.players) do
+        if other_player ~= player and Settings.get(other_player.index, ping_other_death_name) then
+            other_player.print({
+                'death_corpse_tags.other_corpse_location',
+                player.name,
+                string.format('%.1f', position.x),
+                string.format('%.1f', position.y),
+                player.surface.name
+            })
+        end
+    end
+
+    CorpseUtil.add_tag(tag, player_index, tick, true)
+end
+
+Event.add(defines.events.on_player_died, player_died)
+
+Public._player_died = player_died
+
+return Public

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -72,10 +72,18 @@ local spawn_player_corpse =
             text = text
         })
 
-        game.print("[gps="..position.x..","..position.y..",redmew] "..player.name.." has been offline "..offline_timout_mins.." minutes. Their inventory is now available.")
+        local message = {
+            'dump_offline_inventories.inventory_location',
+            player.name,
+            offline_timout_mins,
+            string.format('%.1f', position.x),
+            string.format('%.1f', position.y),
+            player.surface.name
+        }
+        game.print(message)
 
         if tag then
-            CorpseUtil.add_tag(tag, player_index, game.tick)
+            CorpseUtil.add_tag(tag, player_index, game.tick, false)
         end
     end
 )

--- a/locale/en/redmew_features.cfg
+++ b/locale/en/redmew_features.cfg
@@ -181,8 +181,12 @@ select_brush=Select Brush Tile.
 instructions=Select a brush tile to replace [item=refined-concrete] and [item=refined-hazard-concrete].\nOnly works when Paint Brush window is open.
 no_place_landfill=Coloured concrete can not be placed on landfill tiles.
 
-[corpse_util]
+[death_corpse_tags]
 ping_own_death=Ping the location when you die.
 ping_other_death=Ping the location when other players die.
 own_corpse_location=[color=red][Corpse][/color] Your corpse is located at [gps=__1__,__2__,__3__]
 other_corpse_location=[color=red][Corpse][/color] __1__'s corpse is located at [gps=__2__,__3__,__4__]
+empty_corpse=[color=red][Corpse][/color]Your corpse was empty and has been removed.
+
+[dump_offline_inventories]
+inventory_location=[color=blue][Corpse][/color] __1__ has been offline __2__ minutes. Their inventory is now available at [gps=__3__,__4__,__5__]


### PR DESCRIPTION
- Turn dump_offline_inventories on by default.
- Reduce corpse_util to storing and removing corpse tags.
- Add death_corpse_tags which handles adding tags for dead players. This prevents dump_offline_inventories from needing a dependency on what is now death_corpse_tags.
- If a player dies with no items, don't create a map tag and remove the corpse.
- Changed the message slightly for dump_offline_inventories to make it consistent with the other corpse messages.