### PR TITLE
Landfill danger ores preset bug

### DIFF
--- a/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
@@ -52,7 +52,7 @@ ScenarioInfo.set_new_info([[
 ]])
 
 local map = require 'map_gen.maps.danger_ores.modules.map'
-local main_ores_config = require 'map_gen.maps.danger_ores.config.vanilla_ore'
+local main_ores_config = require 'map_gen.maps.danger_ores.config.vanilla_ores'
 local resource_patches = require 'map_gen.maps.danger_ores.modules.resource_patches'
 local resource_patches_config = require 'map_gen.maps.danger_ores.config.vanilla_resource_patches'
 local trees = require 'map_gen.maps.danger_ores.modules.trees'


### PR DESCRIPTION
Zergslayer found a bug in the danger_ore_landfill preset. Conversation starts here:
https://discord.com/channels/432567222481846283/432570636544507905/885327812611952680

I found that the ore preset was misspelled. This branch updates it.

Untested. Will update when I hear back from Zergslayer if it works.