### PR TITLE
Updated the starting pollution multiplier

### DIFF
--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1235,7 +1235,7 @@ local function set_pollution_multiplier(args, player)
         end
         -- update the value to the minimum and continue to message all admins
         player.print("Setting magic crafter pollution multiplier to the minimum value of " .. base_pollution_multiplier)
-        multiplier = base_pollution_multiplier        
+        multiplier = base_pollution_multiplier
     end
 
     local old_multiplier = pollution_multiplier.value

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1228,10 +1228,14 @@ local function set_pollution_multiplier(args, player)
         return
     end
 
-    if multiplier < base_pollution_multiplier then
-        pollution_multiplier.value = base_pollution_multiplier
-        player.print("Cannot set the multiplier lower than the base multiplier of " .. base_pollution_multiplier)
-        return
+    if multiplier < base_pollution_multiplier then  
+        if base_pollution_multiplier == pollution_multiplier.value then -- no change, so not necessary to message all admins and update the value
+            player.print("Magic crafter pollution is already at minimum value of " .. base_pollution_multiplier)
+            return
+        else -- update the value to the minimum and continue to message all admins
+            player.print("Setting magic crafter pollution multiplier to the minimum value of " .. base_pollution_multiplier)
+            multiplier = base_pollution_multiplier
+        end
     end
 
     local old_multiplier = pollution_multiplier.value

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1228,7 +1228,7 @@ local function set_pollution_multiplier(args, player)
         return
     end
 
-    if multiplier < base_pollution_multiplier then  
+    if multiplier < base_pollution_multiplier then
         if base_pollution_multiplier == pollution_multiplier.value then -- no change, so not necessary to message all admins and update the value
             player.print("Magic crafter pollution is already at minimum value of " .. base_pollution_multiplier)
             return

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -60,7 +60,8 @@ local magic_fluid_crafters = {index = 1}
 local outposts = {}
 local artillery_outposts = {index = 1}
 local outpost_count = 0
-local pollution_multiplier = {value = 0}
+local base_pollution_multiplier = 10
+local pollution_multiplier = {value = 10}
 
 Global.register(
     {
@@ -1226,6 +1227,11 @@ local function set_pollution_multiplier(args, player)
         player.print("Fail")
         return
     end
+
+    if multiplier < base_pollution_multiplier then
+        pollution_multiplier.value = base_pollution_multiplier
+        player.print("Cannot set the multiplier lower than the base multiplier of " .. base_pollution_multiplier)
+    end 
 
     local old_multiplier = pollution_multiplier.value
     pollution_multiplier.value = multiplier

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1232,10 +1232,10 @@ local function set_pollution_multiplier(args, player)
         if base_pollution_multiplier == pollution_multiplier.value then -- no change, so not necessary to message all admins and update the value
             player.print("Magic crafter pollution is already at minimum value of " .. base_pollution_multiplier)
             return
-        else -- update the value to the minimum and continue to message all admins
-            player.print("Setting magic crafter pollution multiplier to the minimum value of " .. base_pollution_multiplier)
-            multiplier = base_pollution_multiplier
         end
+        -- update the value to the minimum and continue to message all admins
+        player.print("Setting magic crafter pollution multiplier to the minimum value of " .. base_pollution_multiplier)
+        multiplier = base_pollution_multiplier        
     end
 
     local old_multiplier = pollution_multiplier.value

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1231,7 +1231,7 @@ local function set_pollution_multiplier(args, player)
     if multiplier < base_pollution_multiplier then
         pollution_multiplier.value = base_pollution_multiplier
         player.print("Cannot set the multiplier lower than the base multiplier of " .. base_pollution_multiplier)
-    end 
+    end
 
     local old_multiplier = pollution_multiplier.value
     pollution_multiplier.value = multiplier

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1231,6 +1231,7 @@ local function set_pollution_multiplier(args, player)
     if multiplier < base_pollution_multiplier then
         pollution_multiplier.value = base_pollution_multiplier
         player.print("Cannot set the multiplier lower than the base multiplier of " .. base_pollution_multiplier)
+        return
     end
 
     local old_multiplier = pollution_multiplier.value


### PR DESCRIPTION
The new meta sucks. No one builds any walls or defences. Players can go 3 or 4 hours with no attacks so long as they craft nothing.

Now that the pollution from outposts is generated at position = {0,0}.... let's try a very small amount of pollution for every outpost captured to force at least a small amount of defences to be built.

This will be MUCH less pollution than if all of the items they get free were made in base, but it will still force at least a few defenses or clearing of nearby bases.

Starting with a value of 10 to see how it goes.