### PR TITLE
Added barrage feature to give players more end-game clearing options

### DIFF
--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -12,18 +12,30 @@ crash_site_restart_abort=Aborts the restart of the crashsite scenario.
 crash_site_spy=Spend coins to send a fish to spy on the enemy for a short time.
 crash_site_spy_invalid=You need to add a valid location to send a spy fish. e.g /spy [gps=-110,-17,redmew]
 crash_site_spy_funds=Training these spy fish ain't cheap! You need more coins!
-crash_site_airstrike_invalid=Invalid co-ordinates.
 crash_site_spy_success=__1__ used the /spy command and spent __2__ coins to train a fish to spy on the enemy [gps=__3__,__4__,redmew]
+
+crash_site_airstrike_invalid=Invalid co-ordinates.
 crash_site_airstrike=Launch an airstrike against the enemy with poison capsules.
-crash_site_airstrike_count=Upgrade the airstrike damage to  to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike with a gps position\n\nDamage upgrades increase the number of poison capsules launched by airstrike.\n\nCurrent level: __2__\nCurrent shell count: __3__\nCurrent cost: __4__
-crash_site_airstrike_radius=Upgrade the airstrike radius to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike with a gps position\n\nCurrent level: __2__\nCurrent radius: __3__
+crash_site_airstrike_count=Upgrade the airstrike damage to  to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike followed by a gps position\n\nDamage upgrades increase the number of poison capsules launched by airstrike.\n\nCurrent level: __2__\nCurrent shell count: __3__\nCurrent cost: __4__
+crash_site_airstrike_radius=Upgrade the airstrike radius to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike followed by a gps position\n\nCurrent level: __2__\nCurrent radius: __3__
 crash_site_airstrike_radius_name_label=Airstrike Radius __1__
 crash_site_airstrike_count_name_label=Airstrike Damage __1__
 crash_site_airstrike_not_researched=You have not researched airstrike yet. Visit the market at the spawn [gps=-3,-3,redmew]
-crash_site_airstrike_insufficient_currency_error=To send an air strike, load __1__ more poison capsules into the payment chest [gps=-0.5,-3.5,redmew]
+crash_site_airstrike_insufficient_currency_error=To send an air strike, load __1__ more poison capsules into the payment chest [gps=2.5,-7.5,redmew]
 crash_site_airstrike_friendly_fire_error=You don't want to do that, no enemies found in the target area.
 crash_site_airstrike_damage_upgrade_success=__1__ has upgraded Airstrike Damage to level __2__
 crash_site_airstrike_radius_upgrade_success=__1__ has updgraded Airstrike Radius to level __2__
+crash_site_barrage_invalid=Invalid co-ordinates.
+crash_site_barrage=Launch a barrage of heat seeking rockets against the enemy.
+crash_site_barrage_count=Upgrade the barrage damage to  to level __1__\n\nTo use barrage place explosive rockets in the spawn chest then type /barrage followed by a gps position\n\nDamage upgrades increase the number of rockets launched.\n\nCurrent level: __2__\nCurrent rocket count: __3__\nCurrent cost: __4__ rockets
+crash_site_barrage_radius=Upgrade the barrage radius to level __1__\n\nTo use barrage place explosive rockets in the spawn chest then type /barrage followed by a gps position\n\nCurrent level: __2__\nCurrent radius: __3__
+crash_site_barrage_radius_name_label=Rocket Barrage Radius __1__
+crash_site_barrage_count_name_label=Rocket Barrage Damage __1__
+crash_site_barrage_not_researched=You have not researched Barrage yet. Visit the market at the spawn [gps=-3,-3,redmew]
+crash_site_barrage_insufficient_currency_error=To send a rocket barrage, load __1__ more explosive rockets into the payment chest [gps=2.5,-1.5,redmew]
+crash_site_barrage_no_nests=No nests found, what a waste of rockets!
+crash_site_barrage_damage_upgrade_success=__1__ has upgraded Rocket Barrage Damage to level __2__
+crash_site_barrage_radius_upgrade_success=__1__ has updgraded Rocket Barrage Radius to level __2__
 crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__
 crash_site_rocket_tank_upgrade_success=__1__ has upgraded Rocket Tank interval to level __2__
 crash_site_rocket_tanks_description= Upgrade the rocket tank firing interval to reduce the time between rockets.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -9,7 +9,6 @@ local Ranks = require 'resources.ranks'
 local Core = require 'utils.core'
 local Color = require 'resources.color_presets'
 local Toast = require 'features.gui.toast'
-local Utils = require 'utils.core'
 local Discord = require 'resources.discord'
 local ScoreTracker = require 'utils.score_tracker'
 local PlayerStats = require 'features.player_stats'
@@ -453,7 +452,7 @@ function Public.control(config)
                 }, Color.fail)
                 return
             end
-            
+
             inv.remove({name = "poison-capsule", count = strikeCost})
             player.force.chart(s, {{xpos - 32, ypos - 32}, {xpos + 32, ypos + 32}})
 
@@ -488,8 +487,9 @@ function Public.control(config)
         local location_string = args.location
         local coords = {}
 
-        local radius_level = barrage_data.radius_level -- max radius of the strike area
-        local count_level = barrage_data.count_level -- the number of poison capsules launched at the enemy
+        local radius_level = barrage_data.radius_level -- max radius of the barrage area
+        local count_level = barrage_data.count_level -- the number of rockets launched at the enemy
+
         if count_level == 1 then
             player.print({'command_description.crash_site_barrage_not_researched'}, Color.fail)
             return
@@ -524,7 +524,7 @@ function Public.control(config)
         local ypos = coords[i + 1]
         -- This while loop lets players add multiple GPS coordinates to the /strike command arguments to strike more than one place at once. Up to a maximum of 20
         while xpos ~= nil and ypos ~= nil and i < 20 do
-            -- Check the contents of the chest by spawn for enough poison capsules to use as payment
+            -- Check the contents of the chest by spawn for enough rockets to use as payment
             local inv = dropbox.get_inventory(defines.inventory.chest)
             local capCount = inv.get_item_count("explosive-rocket")
 
@@ -554,13 +554,11 @@ function Public.control(config)
             -- draw radius
             set_timeout_in_ticks(60, map_chart_tag_place_callback, {player = player, xpos = xpos, ypos = ypos, item = 'explosive-rocket'})
             render_radius({position = {x = xpos, y = ypos}, player = player, radius = radius, color = {r = 0.1, g = 0, b = 0, a = 0.1}})
-            for i, nest in pairs(nests) do
+            for _, nest in pairs(nests) do
                 render_crosshair({position = {x = nest.position.x, y = nest.position.y}, player = player, item = "explosive-rocket"})
-                -- send number of rockets
             end
 
             for j = 1, count do
-
                 set_timeout_in_ticks(60 * j + math.random(0, 30), spawn_rocket_callback, {s = s, xpos = nests[(j%nest_count)+1].position.x, ypos = nests[(j%nest_count)+1].position.y})
                 set_timeout_in_ticks(60 * j, chart_area_callback, {player = player, xpos = xpos, ypos = ypos})
             end

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -435,12 +435,11 @@ function Public.control(config)
             return
         end
 
-        -- process each set of coordinates with a 20 strike limit
+        -- process each set of coordinates from the arguments with a 20 coordinate, 10 strike limit.
         local i = 1
         local xpos = coords[i]
         local ypos = coords[i + 1]
-        -- This while loop lets players add multiple GPS coordinates to the /strike command arguments to strike more than one place at once. Up to a maximum of 20
-        while xpos ~= nil and ypos ~= nil and i < 20 do
+        while xpos ~= nil and ypos ~= nil and i < 20 do -- Process multiple GPS coordinates in the /strike command arguments to strike more than one place at once.
             -- Check the contents of the chest by spawn for enough poison capsules to use as payment
             local inv = dropbox.get_inventory(defines.inventory.chest)
             local capCount = inv.get_item_count("poison-capsule")
@@ -519,12 +518,11 @@ function Public.control(config)
             return
         end
 
-        -- process each set of coordinates from the arguments with a 20 strike limit
+        -- process each set of coordinates from the arguments with a 20 coordinate, 10 barrage limit
         local i = 1
         local xpos = coords[i]
         local ypos = coords[i + 1]
-        -- This while loop lets players add multiple GPS coordinates to the /strike command arguments to strike more than one place at once. Up to a maximum of 20
-        while xpos ~= nil and ypos ~= nil and i < 20 do
+        while xpos ~= nil and ypos ~= nil and i < 20 do -- Process multiple GPS coordinates in the /barrage command arguments to strike more than one place at once.
             -- Check the contents of the chest by spawn for enough rockets to use as payment
             local inv = dropbox.get_inventory(defines.inventory.chest)
             local capCount = inv.get_item_count("explosive-rocket")

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -496,7 +496,8 @@ function Public.control(config)
         end
 
         local radius = 25 + (radius_level * 5)
-        local count = count_level * 6
+        local count = (count_level-1) * 6
+        local strikeCost = count * 4
 
         -- parse GPS coordinates from map ping
         for m in string.gmatch(location_string, "%-?%d+") do -- Assuming the surface name isn't a valid number.
@@ -531,7 +532,7 @@ function Public.control(config)
             if capCount < count then
                 player.print({
                     'command_description.crash_site_barrage_insufficient_currency_error',
-                    count - capCount
+                    strikeCost - capCount
                 }, Color.fail)
                 return
             end
@@ -544,12 +545,13 @@ function Public.control(config)
             }
 
             local nest_count = #nests
-            inv.remove({name = "explosive-rocket", count = count})
-            player.force.chart(s, {{xpos - 32, ypos - 32}, {xpos + 32, ypos + 32}})
+            inv.remove({name = "explosive-rocket", count = strikeCost})
             if nest_count == 0 then
                 player.print({'command_description.crash_site_barrage_no_nests',}, Color.fail)
                 return
             end
+
+            player.force.chart(s, {{xpos - 32, ypos - 32}, {xpos + 32, ypos + 32}})
 
             -- draw radius
             set_timeout_in_ticks(60, map_chart_tag_place_callback, {player = player, xpos = xpos, ypos = ypos, item = 'explosive-rocket'})
@@ -635,8 +637,8 @@ function Public.control(config)
         if item.type == 'barrage' then
             local radius_level = barrage_data.radius_level -- max radius of the strike area
             local count_level = barrage_data.count_level -- the number of poison capsules launched at the enemy
-            local radius = 5 + (radius_level * 3)
-            local count = (count_level - 1) * 5 + 3
+            local radius = 25 + (radius_level * 5)
+            local count = count_level  * 6
             local strikeCost = count * 4
 
             local name = item.name

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -921,8 +921,6 @@ function Public.init(config)
     return function(x, y, world)
         return map(x, y, world)
     end
-
-    
 end
 
 return Public

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -790,10 +790,28 @@ local function init(config)
             {
                 price = 1000,
                 stack_limit = 1,
+                type= 'barrage',
+                name = 'barrage_damage',
+                name_label = {'command_description.crash_site_barrage_count_name_label', 1},
+                sprite = 'virtual-signal/signal-B',
+                description = {'command_description.crash_site_barrage_count', 1, 0, "n/a", "n/a"}
+            },
+            {
+                price = 1000,
+                stack_limit = 1,
+                type = 'barrage',
+                name = 'barrage_radius',
+                name_label = {'command_description.crash_site_barrage_radius_name_label', 1},
+                sprite = 'virtual-signal/signal-B',
+                description = {'command_description.crash_site_barrage_radius', 1, 0, 5}
+            },
+            {
+                price = 1000,
+                stack_limit = 1,
                 type = 'rocket_tanks',
                 name = 'rocket_tanks_fire_rate',
                 name_label = {'command_description.crash_site_rocket_tanks_name_label', 1},
-                sprite = 'virtual-signal/signal-T',
+                sprite = 'virtual-signal/signal-R',
                 description = {'command_description.crash_site_rocket_tanks_description'}
             },
             {name = 'wood', price = 1},
@@ -842,19 +860,22 @@ local function init(config)
         [1] = {
             market = market,
             chest = chest,
-            [15] = {entity = {name = 'market', force = 'neutral', callback = 'market'}},
-            [18] = {entity = {name = 'steel-chest', force = 'player', callback = 'chest'}}
+            [29] = {entity = {name = 'market', force = 'neutral', callback = 'market'}},
+            [32] = {entity = {name = 'steel-chest', force = 'player', callback = 'chest'}}
         },
         [2] = {
             force = 'player',
             factory = factory,
             inserter = inserter,
-            [13] = {entity = {name = 'burner-inserter', direction = 2, callback = 'inserter'}},
-            [15] = {entity = {name = 'electric-furnace', callback = 'factory'}}
+            chest = chest,
+            [3] = {entity = {name = 'logistic-chest-requester', force = 'player', callback = 'chest'}},
+            [25] = {entity = {name = 'burner-inserter', direction = 2, callback = 'inserter'}},
+            [27] = {entity = {name = 'electric-furnace', callback = 'factory'}},
+            [51] = {entity = {name = 'logistic-chest-requester', force = 'player', callback = 'chest'}}
         }
     }
 
-    local spawn_shape = outpost_builder.to_shape(spawn, 6, on_init)
+    local spawn_shape = outpost_builder.to_shape(spawn, 8, on_init)
     spawn_shape = b.change_tile(spawn_shape, false, 'stone-path')
     spawn_shape = b.change_map_gen_collision_hidden_tile(spawn_shape, 'water-tile', 'grass-1')
 
@@ -872,6 +893,11 @@ Global.register_init(
     {},
     function(tbl)
         game.create_force(cutscene_force_name)
+
+        -- Sprites for the spawn chests. Is there a better place for these?
+        rendering.draw_sprite{sprite = "item.poison-capsule", target = {2.5, -8.5}, surface = game.surfaces["redmew"], tint={1, 1, 1, 0.1}}
+        rendering.draw_sprite{sprite = "item.explosive-rocket", target = {2.5, -2.5}, surface = game.surfaces["redmew"], tint={1, 1, 1, 0.1}}
+
         local surface = game.surfaces[1]
         surface.map_gen_settings = {width = 2, height = 2}
         surface.clear()
@@ -895,6 +921,8 @@ function Public.init(config)
     return function(x, y, world)
         return map(x, y, world)
     end
+
+    
 end
 
 return Public

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -803,7 +803,8 @@ local function init(config)
                 name = 'barrage_radius',
                 name_label = {'command_description.crash_site_barrage_radius_name_label', 1},
                 sprite = 'virtual-signal/signal-B',
-                description = {'command_description.crash_site_barrage_radius', 1, 0, 5}
+                description = {'command_description.crash_site_barrage_radius', 1, 0, 25}
+
             },
             {
                 price = 1000,


### PR DESCRIPTION
- Changed spawn to add 2 more chests after feedback from Tigress about end-game use of strike command
- Added floating sprites above chests to indicate what to put in each. 
- Added barrage command and items in market
- Barrage sends explosive rockets at enemy nests. Players need to judge whether there are enough nests for it to be worth a strike and decide if there are too many nests and that the current level of barrage won't kill them all.
- First pass at balancing costs made.
