### PR TITLE
Eating fish causes a little flying text to show other players you're …

### DIFF
--- a/features/fish_burps.lua
+++ b/features/fish_burps.lua
@@ -11,10 +11,8 @@ local function capsule_used(event)
         return
     end
 
-    local dx = math.abs(event.position.x - player.position.x)
-    local dy = math.abs(event.position.y - player.position.y)
-
-    if dx > 0.5 or dy > 1 then  -- Only want to create the flying text if the player clicks near their character for healing
+    local health_ratio = player.character.get_health_ratio()
+    if health_ratio == 1 then -- to stop people spamming it
         return
     end
 

--- a/features/fish_burps.lua
+++ b/features/fish_burps.lua
@@ -7,7 +7,7 @@ local function capsule_used(event)
     end
 
     local player =  game.get_player(event.player_index)
-    if not player or not player.valid then
+    if not player or not player.valid or not player.character or not player.character.valid then
         return
     end
 

--- a/features/fish_burps.lua
+++ b/features/fish_burps.lua
@@ -1,0 +1,29 @@
+-- A feature to add cute flying text of a fish when a player uses a fish to heal themselves. Useful for teamwork.
+local Event = require 'utils.event'
+
+local function capsule_used(event)
+    if event.item.name ~= "raw-fish" then
+        return
+    end
+
+    local player =  game.get_player(event.player_index)
+    if not player or not player.valid then
+        return
+    end
+
+    local dx = math.abs(event.position.x - player.position.x)
+    local dy = math.abs(event.position.y - player.position.y)
+
+    if dx > 0.5 or dy > 1 then  -- Only want to create the flying text if the player clicks near their character for healing
+        return
+    end
+
+    player.surface.create_entity {
+        name = 'tutorial-flying-text',
+        text = '[img=item.raw-fish]',
+        position = {player.position.x,player.position.y-3} -- creates the fish just above players head
+    }
+
+end
+
+Event.add(defines.events.on_player_used_capsule, capsule_used)

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -3,6 +3,7 @@ require 'map_gen.maps.crash_site.events'
 require 'map_gen.maps.crash_site.weapon_balance'
 require 'map_gen.maps.crash_site.features.rocket_tanks'
 require 'map_gen.maps.crash_site.features.vehicle_repair_beams'
+require 'features.fish_burps'
 
 local b = require 'map_gen.shared.builders'
 local Global = require('utils.global')


### PR DESCRIPTION
Eating fish causes a little flying fish to appear above the player. Allows other players to see who's trying to heal themselves so they can focus on helping that player if needed.