### PR TITLE
Fixed error in multiline barrage command

### DIFF
--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -34,7 +34,7 @@ crash_site_barrage_radius_name_label=Rocket Barrage Radius __1__
 crash_site_barrage_count_name_label=Rocket Barrage Damage __1__
 crash_site_barrage_not_researched=You have not researched Barrage yet. Visit the market at the spawn [gps=-3,-3,redmew]
 crash_site_barrage_insufficient_currency_error=To send a rocket barrage, load __1__ more explosive rockets into the payment chest [gps=2.5,-1.5,redmew]
-crash_site_barrage_no_nests=No nests found, what a waste of rockets!
+crash_site_barrage_no_nests=No nests found at these coordinates ([gps=__1__,__2__,__3__]), what a waste of rockets!
 crash_site_barrage_damage_upgrade_success=__1__ has upgraded Rocket Barrage Damage to level __2__
 crash_site_barrage_radius_upgrade_success=__1__ has updgraded Rocket Barrage Radius to level __2__
 crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -546,23 +546,22 @@ function Public.control(config)
             inv.remove({name = "explosive-rocket", count = strikeCost})
             if nest_count == 0 then
                 player.print({'command_description.crash_site_barrage_no_nests',}, Color.fail)
-                return
+            else
+
+                player.force.chart(s, {{xpos - 32, ypos - 32}, {xpos + 32, ypos + 32}})
+
+                -- draw radius
+                set_timeout_in_ticks(60, map_chart_tag_place_callback, {player = player, xpos = xpos, ypos = ypos, item = 'explosive-rocket'})
+                render_radius({position = {x = xpos, y = ypos}, player = player, radius = radius, color = {r = 0.1, g = 0, b = 0, a = 0.1}})
+                for _, nest in pairs(nests) do
+                    render_crosshair({position = {x = nest.position.x, y = nest.position.y}, player = player, item = "explosive-rocket"})
+                end
+
+                for j = 1, count do
+                    set_timeout_in_ticks(60 * j + math.random(0, 30), spawn_rocket_callback, {s = s, xpos = nests[(j%nest_count)+1].position.x, ypos = nests[(j%nest_count)+1].position.y})
+                    set_timeout_in_ticks(60 * j, chart_area_callback, {player = player, xpos = xpos, ypos = ypos})
+                end
             end
-
-            player.force.chart(s, {{xpos - 32, ypos - 32}, {xpos + 32, ypos + 32}})
-
-            -- draw radius
-            set_timeout_in_ticks(60, map_chart_tag_place_callback, {player = player, xpos = xpos, ypos = ypos, item = 'explosive-rocket'})
-            render_radius({position = {x = xpos, y = ypos}, player = player, radius = radius, color = {r = 0.1, g = 0, b = 0, a = 0.1}})
-            for _, nest in pairs(nests) do
-                render_crosshair({position = {x = nest.position.x, y = nest.position.y}, player = player, item = "explosive-rocket"})
-            end
-
-            for j = 1, count do
-                set_timeout_in_ticks(60 * j + math.random(0, 30), spawn_rocket_callback, {s = s, xpos = nests[(j%nest_count)+1].position.x, ypos = nests[(j%nest_count)+1].position.y})
-                set_timeout_in_ticks(60 * j, chart_area_callback, {player = player, xpos = xpos, ypos = ypos})
-            end
-
             -- move to the next set of coordinates
             i = i + 2
             xpos = coords[i]

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -545,7 +545,7 @@ function Public.control(config)
             local nest_count = #nests
             inv.remove({name = "explosive-rocket", count = strikeCost})
             if nest_count == 0 then
-                player.print({'command_description.crash_site_barrage_no_nests',}, Color.fail)
+                player.print({'command_description.crash_site_barrage_no_nests',xpos, ypos,s.name}, Color.fail)
             else
 
                 player.force.chart(s, {{xpos - 32, ypos - 32}, {xpos + 32, ypos + 32}})


### PR DESCRIPTION
- Reported by Clinkstur
- If the barrage antigrief found no nests in an area then it returned from the function
- This broke the command if the player used a multi-coordinate barrage to barrage more than one location
- New behaviour is that it just skips that location and continues to next coordinates
- I looked at how strike works and it seems it doesn't have any anti-grief so no changes to that one