### PR TITLE
Duplicated end of game awards messages to respective channels

### DIFF
--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -213,10 +213,10 @@ function Public.control(config)
                 awards.fish_eaten.player = v.name
             end
         end
-
+        local statistics_message = {}
         local time_string = Core.format_time(game.ticks_played)
         if statistics.enemy_entities < 1000 then
-            local statistics_message = 'Crash Site map won!\\n\\n'
+            statistics_message = 'Crash Site map won!\\n\\n'
             .. 'Statistics:\\n'
             .. 'Map time: '..time_string..'\\n'
             .. 'Total kills: '..statistics.biters_killed..'\\n'
@@ -235,20 +235,17 @@ function Public.control(config)
             .. 'Furthest walked: '..awards.distance_walked.player..' ('..math.floor(awards.distance_walked.value)..')\\n'
             .. 'Most coins earned: '..awards.coins_earned.player..' ('..awards.coins_earned.value..')\\n'
             .. 'Seafood lover: '..awards.fish_eaten.player..' ('..awards.fish_eaten.value..' fish eaten)\\n'
-
-            Server.to_discord_named_embed(map_promotion_channel, statistics_message)
-            Server.to_discord_named_embed(crash_site_channel, statistics_message)
         else
-            local statistics_message = 'Crash Site map failed!\\n\\n'
+            statistics_message = 'Crash Site map failed!\\n\\n'
             .. 'Statistics:\\n'
             .. 'Map time: '..time_string..'\\n'
             .. 'Total kills: '..statistics.biters_killed..'\\n'
             .. 'Biters remaining on map: '..statistics.enemy_entities..'\\n'
             .. 'Players: '..statistics.total_players..'\\n'
-
-            Server.to_discord_named_embed(map_promotion_channel, statistics_message)
-            Server.to_discord_named_embed(crash_site_channel, statistics_message)
         end
+
+        Server.to_discord_named_embed(map_promotion_channel, statistics_message)
+        Server.to_discord_named_embed(crash_site_channel, statistics_message)
 
         local start_game_data = Restart.get_start_game_data()
         local new_map_name = start_game_data.name

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -17,9 +17,11 @@ local set_timeout_in_ticks = Task.set_timeout_in_ticks
 
 -- Use these settings for live
 local map_promotion_channel = Discord.channel_names.map_promotion
+local crash_site_channel = Discord.channel_names.crash_site
 local crash_site_role_mention = Discord.role_mentions.crash_site
 -- Use these settings for testing
 -- local map_promotion_channel = Discord.channel_names.bot_playground
+-- local crash_site_channel = Discord.channel_names.bot_playground
 -- local crash_site_role_mention = Discord.role_mentions.test
 
 local Public = {}
@@ -214,7 +216,7 @@ function Public.control(config)
 
         local time_string = Core.format_time(game.ticks_played)
         if statistics.enemy_entities < 1000 then
-            Server.to_discord_named_embed(map_promotion_channel, 'Crash Site map won!\\n\\n'
+            local statistics_message = 'Crash Site map won!\\n\\n'
             .. 'Statistics:\\n'
             .. 'Map time: '..time_string..'\\n'
             .. 'Total kills: '..statistics.biters_killed..'\\n'
@@ -233,15 +235,19 @@ function Public.control(config)
             .. 'Furthest walked: '..awards.distance_walked.player..' ('..math.floor(awards.distance_walked.value)..')\\n'
             .. 'Most coins earned: '..awards.coins_earned.player..' ('..awards.coins_earned.value..')\\n'
             .. 'Seafood lover: '..awards.fish_eaten.player..' ('..awards.fish_eaten.value..' fish eaten)\\n'
-            )
+
+            Server.to_discord_named_embed(map_promotion_channel, statistics_message)
+            Server.to_discord_named_embed(crash_site_channel, statistics_message)
         else
-             Server.to_discord_named_embed(map_promotion_channel, 'Crash Site map failed!\\n\\n'
+            local statistics_message = 'Crash Site map failed!\\n\\n'
             .. 'Statistics:\\n'
             .. 'Map time: '..time_string..'\\n'
             .. 'Total kills: '..statistics.biters_killed..'\\n'
             .. 'Biters remaining on map: '..statistics.enemy_entities..'\\n'
             .. 'Players: '..statistics.total_players..'\\n'
-            )
+
+            Server.to_discord_named_embed(map_promotion_channel, statistics_message)
+            Server.to_discord_named_embed(crash_site_channel, statistics_message)
         end
 
         local start_game_data = Restart.get_start_game_data()

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -213,7 +213,7 @@ function Public.control(config)
                 awards.fish_eaten.player = v.name
             end
         end
-        local statistics_message = {}
+        local statistics_message
         local time_string = Core.format_time(game.ticks_played)
         if statistics.enemy_entities < 1000 then
             statistics_message = 'Crash Site map won!\\n\\n'

--- a/map_gen/maps/danger_ores/modules/restart_command.lua
+++ b/map_gen/maps/danger_ores/modules/restart_command.lua
@@ -162,7 +162,6 @@ return function(config)
         'Most biters/spitters killed: '..awards.units_killed.player..' ('..awards.units_killed.value..')\\n'..
         'Most spawners killed: '..awards.spawners_killed.player..' ('..awards.spawners_killed.value..')\\n'..
         'Most worms killed: '..awards.worms_killed.player..' ('..awards.worms_killed.value..')\\n'
-        
 
         Server.to_discord_named_embed(map_promotion_channel, statistics_message)
         Server.to_discord_named_embed(danger_ores_channel, statistics_message)

--- a/map_gen/maps/danger_ores/modules/restart_command.lua
+++ b/map_gen/maps/danger_ores/modules/restart_command.lua
@@ -9,9 +9,11 @@ local format_number = require 'util'.format_number
 
 return function(config)
     local map_promotion_channel = Discord.channel_names.map_promotion
+    local danger_ores_channel = Discord.channel_names.danger_ores
     local danger_ore_role_mention = Discord.role_mentions.danger_ore
     -- Use these settings for testing
     --local map_promotion_channel = Discord.channel_names.bot_playground
+    --local danger_ores_channel = Discord.channel_names.bot_playground
     --local danger_ore_role_mention = Discord.role_mentions.test
 
     Restart.set_start_game_data({type = Restart.game_types.scenario, name = config.scenario_name or 'danger-ore-next'})
@@ -140,27 +142,30 @@ return function(config)
         ore_totals_message = ore_totals_message:sub(1, -3)..')' -- remove the last ", " and add a bracket
         ore_totals_message = "Total ore mined: "..format_number(total_ore, true).. "\\n"..ore_totals_message
 
-        Server.to_discord_named_embed(map_promotion_channel, 'Danger ores map completed!\\n\\n'
-        .. 'Statistics:\\n'
-        .. 'Map time: '..time_string..'\\n'
-        .. 'Total entities built: '..statistics.entities_built..'\\n'
-        .. 'Total ore mined:'..ore_totals_message..'\\n'
-        .. 'Total ore resources exhausted: '..statistics.resources_exhausted..'\\n'
-        .. 'Total ore hand mined: '..statistics.resources_hand_mined..'\\n'
-        .. 'Players: '..statistics.total_players..'\\n'
-        .. 'Enemies killed: '..statistics.biters_killed..'\\n\\n'
-        .. 'Awards:\\n'
-        .. 'Most ore hand mined:'..awards.resources_hand_mined.player..' ('..awards.resources_hand_mined.value..')\\n'
-        .. 'Most items crafted: '..awards.entities_crafted.player..' ('..awards.entities_crafted.value..')\\n'
-        .. 'Most entities built: '..awards.entities_built.player..' ('..awards.entities_built.value..')\\n'
-        .. 'Most time played: '..awards.time_played.player..' ('..Core.format_time(awards.time_played.value)..')\\n'
-        .. 'Furthest walked: '..awards.distance_walked.player..' ('..math.floor(awards.distance_walked.value)..')\\n'
-        .. 'Most deaths: '..awards.player_deaths.player..' ('..awards.player_deaths.value..')\\n'
-        .. 'Most kills overall: '..awards.total_kills.player..' ('..awards.total_kills.value..')\\n'
-        .. 'Most biters/spitters killed: '..awards.units_killed.player..' ('..awards.units_killed.value..')\\n'
-        .. 'Most spawners killed: '..awards.spawners_killed.player..' ('..awards.spawners_killed.value..')\\n'
-        .. 'Most worms killed: '..awards.worms_killed.player..' ('..awards.worms_killed.value..')\\n'
-        )
+      local statistics_message = 'Danger ores map completed!\\n\\n'..
+        'Statistics:\\n'..
+        'Map time: '..time_string..'\\n'..
+        'Total entities built: '..statistics.entities_built..'\\n'..
+        'Total ore mined:'..ore_totals_message..'\\n'..
+        'Total ore resources exhausted: '..statistics.resources_exhausted..'\\n'..
+        'Total ore hand mined: '..statistics.resources_hand_mined..'\\n'..
+        'Players: '..statistics.total_players..'\\n'..
+        'Enemies killed: '..statistics.biters_killed..'\\n\\n'..
+        'Awards:\\n'..
+        'Most ore hand mined:'..awards.resources_hand_mined.player..' ('..awards.resources_hand_mined.value..')\\n'..
+        'Most items crafted: '..awards.entities_crafted.player..' ('..awards.entities_crafted.value..')\\n'..
+        'Most entities built: '..awards.entities_built.player..' ('..awards.entities_built.value..')\\n'..
+        'Most time played: '..awards.time_played.player..' ('..Core.format_time(awards.time_played.value)..')\\n'..
+        'Furthest walked: '..awards.distance_walked.player..' ('..math.floor(awards.distance_walked.value)..')\\n'..
+        'Most deaths: '..awards.player_deaths.player..' ('..awards.player_deaths.value..')\\n'..
+        'Most kills overall: '..awards.total_kills.player..' ('..awards.total_kills.value..')\\n'..
+        'Most biters/spitters killed: '..awards.units_killed.player..' ('..awards.units_killed.value..')\\n'..
+        'Most spawners killed: '..awards.spawners_killed.player..' ('..awards.spawners_killed.value..')\\n'..
+        'Most worms killed: '..awards.worms_killed.player..' ('..awards.worms_killed.value..')\\n'
+        
+
+        Server.to_discord_named_embed(map_promotion_channel, statistics_message)
+        Server.to_discord_named_embed(danger_ores_channel, statistics_message)
 
         Server.set_data('danger_ores_data', tostring(end_epoch), statistics)
 

--- a/resources/discord.lua
+++ b/resources/discord.lua
@@ -6,7 +6,9 @@ return {
         bot_playground = 'bot-playground',
         map_promotion = 'map-promotion',
         moderation_log = 'moderation-log',
-        helpdesk = 'helpdesk'
+        helpdesk = 'helpdesk',
+        danger_ores = 'danger-ores',
+        crash_site = 'crash-site'
     },
     --- The strings that mention the discord role.
     -- Has to be used with features.server.to_discord_raw variants else the mention is sanitized server side.


### PR DESCRIPTION
- The awards being in the map-promotion channel is great because people see it when they're pinged and there being no chatter in there keeps it clean and easy to find/read.
- However, it doesn't foster community and discussion.
- This PR duplicates the embedded message so it's posted once to map-promotion and once to the respective channels for danger ores and crash site.
- Will give players somewhere to discuss post-match. I hope it will lead to more discussion of game play and some more friendly competition.