### PR TITLE
Change on_destroy message on danger_ores

### DIFF
--- a/map_gen/maps/danger_ores/modules/banned_entities.lua
+++ b/map_gen/maps/danger_ores/modules/banned_entities.lua
@@ -29,7 +29,35 @@ return function(allowed_entities, message)
     local function on_destroy(event)
         local p = event.player
         if p and p.valid then
-            p.print(message or 'You cannot build that on top of ores, only belts, mining drills, and power poles are allowed.')
+            if message then
+                p.print(message)
+                return
+            end
+            local items = {}
+            local len = 0
+            for _, v in pairs(allowed_entities) do
+                local entity = game.entity_prototypes[v]
+                for _, v in pairs(entity.items_to_place_this) do
+                    if not (items[v.name] ~= nil) then --- Avoid duplication for straight-rail and curved-rail, which both use rail
+                        items[v.name] = v
+                        len = len + 1
+                    end
+                end
+            end
+            local i = 1
+            local str = "You cannot build that on top of ores, only "
+            for k, v in pairs(items) do
+                str = str.."[img=item." .. k .."]"
+                if len == i then
+                    str = str.."."
+                elseif i == len - 1 then
+                    str = str.." and "
+                else
+                    str = str..", "
+                end
+                i = i + 1
+            end
+            p.print(str)
         end
     end
 

--- a/map_gen/maps/danger_ores/modules/banned_entities.lua
+++ b/map_gen/maps/danger_ores/modules/banned_entities.lua
@@ -35,8 +35,9 @@ return function(allowed_entities, message)
             end
             local items = {}
             local len = 0
-            for _, v in pairs(allowed_entities) do
-                local entity = game.entity_prototypes[v]
+            local entities = RestrictEntities.get_allowed()
+            for k in pairs(entities) do
+                local entity = game.entity_prototypes[k]
                 for _, v in pairs(entity.items_to_place_this) do
                     if not items[v.name] then --- Avoid duplication for straight-rail and curved-rail, which both use rail
                         items[v.name] = v

--- a/map_gen/maps/danger_ores/modules/banned_entities.lua
+++ b/map_gen/maps/danger_ores/modules/banned_entities.lua
@@ -46,7 +46,7 @@ return function(allowed_entities, message)
             end
             local str = "You cannot build that on top of ores, only "
             local strs = {};
-            for k, v in pairs(items) do
+            for k in pairs(items) do
                 table.insert(strs, "[img=item." .. k .."]")
             end
             p.print(str..table.concat(strs, " "))

--- a/map_gen/maps/danger_ores/modules/banned_entities.lua
+++ b/map_gen/maps/danger_ores/modules/banned_entities.lua
@@ -44,20 +44,12 @@ return function(allowed_entities, message)
                     end
                 end
             end
-            local i = 1
             local str = "You cannot build that on top of ores, only "
+            local strs = {};
             for k, v in pairs(items) do
-                str = str.."[img=item." .. k .."]"
-                if len == i then
-                    str = str.."."
-                elseif i == len - 1 then
-                    str = str.." and "
-                else
-                    str = str..", "
-                end
-                i = i + 1
+                table.insert(strs, "[img=item." .. k .."]")
             end
-            p.print(str)
+            p.print(str..table.concat(strs, " "))
         end
     end
 

--- a/map_gen/maps/danger_ores/modules/banned_entities.lua
+++ b/map_gen/maps/danger_ores/modules/banned_entities.lua
@@ -38,7 +38,7 @@ return function(allowed_entities, message)
             for _, v in pairs(allowed_entities) do
                 local entity = game.entity_prototypes[v]
                 for _, v in pairs(entity.items_to_place_this) do
-                    if not (items[v.name] ~= nil) then --- Avoid duplication for straight-rail and curved-rail, which both use rail
+                    if not items[v.name] then --- Avoid duplication for straight-rail and curved-rail, which both use rail
                         items[v.name] = v
                         len = len + 1
                     end

--- a/map_gen/shared/entity_placement_restriction.lua
+++ b/map_gen/shared/entity_placement_restriction.lua
@@ -311,6 +311,12 @@ function Public.remove_anti_grief_callback()
     primitives.anti_grief_callback = nil
 end
 
+--- Get the list of allowed entities
+-- @return allowed_entities <table> array of string entity names
+function Public.get_allowed()
+    return allowed_entities
+end
+
 --- Adds to the list of allowed entities
 -- @param ents <table> array of string entity names
 function Public.add_allowed(ents)


### PR DESCRIPTION
Before, the message was hardcoded. Now, the message is generated from the list
of entities actually whitelisted, and prints the list of icons

It now looks like this on `map_gen.maps.danger_ores.presets.danger_ore_gradient`
![image](https://user-images.githubusercontent.com/13930958/170889553-bc5b66be-2684-4550-9d2c-39733e8bdd64.png)
