### PR TITLE
Rich item copy for inventory drops

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -85,6 +85,7 @@ global.config = {
     dump_offline_inventories = {
         enabled = false,
         offline_timout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
+        ignored_items = {} -- list of prototype names that remain in the player inventory
     },
     -- enables players to create and prioritize tasks
     tasklist = {

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -26,9 +26,10 @@ end)
 local function move_items(source, target)
     if not source.is_empty() then
         for i = 1, #source do
-            if source[i].valid_for_read and not ignored_items_set[source[i].name] then
-                target.insert(source[i])
-                source[i].clear()
+            local stack = source[i]
+            if stack.valid_for_read and not ignored_items_set[stack.name] then
+                target.insert(stack)
+                stack.clear()
             end
         end
     end

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -27,7 +27,7 @@ local function move_items(source, target)
     if not source.is_empty() then
         for i = 1, #source do
             local stack = source[i]
-            if stack.valid_for_read and not ignored_items_set[stack.name] then
+            if stack.valid_for_read and not stack.is_selection_tool() and not stack.is_blueprint_book() and not ignored_items_set[stack.name] then
                 target.insert(stack)
                 stack.clear()
             end

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -12,7 +12,7 @@ local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local config = Config.dump_offline_inventories
 
 local ignored_items_set = {}
-for _ , k in pairs(config.ignored_items)
+for _ , k in pairs(config.ignored_items) do
     ignored_items_set[k] = true
 end
 

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -29,25 +29,13 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
     local inv_main = player.get_inventory(defines.inventory.character_main)
     local inv_trash = player.get_inventory(defines.inventory.character_trash)
 
-    local inv_main_contents
-    if inv_main and inv_main.valid then
-        inv_main_contents = inv_main.get_contents()
-    end
-
-    local inv_trash_contents
-    if inv_trash and inv_trash.valid then
-        inv_trash_contents = inv_trash.get_contents()
-    end
-
     local inv_corpse_size = 0
-    if inv_main_contents then
+    if inv_main and inv_main.valid and not inv_main.is_empty() then
         inv_corpse_size = inv_corpse_size + (#inv_main - inv_main.count_empty_stacks())
     end
-
-    if inv_trash_contents then
+    if inv_trash and inv_trash.valid and not inv_trash.is_empty() then
         inv_corpse_size = inv_corpse_size + (#inv_trash - inv_trash.count_empty_stacks())
     end
-
     if inv_corpse_size <= 0 then
         return
     end
@@ -63,17 +51,23 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
 
     local inv_corpse = corpse.get_inventory(defines.inventory.character_corpse)
 
-    for item_name, count in pairs(inv_main_contents or {}) do
-        inv_corpse.insert({name = item_name, count = count})
-    end
-    for item_name, count in pairs(inv_trash_contents or {}) do
-        inv_corpse.insert({name = item_name, count = count})
-    end
-
-    if inv_main_contents then
+    local i = 1 -- corpse inventory counter
+    if not inv_main.is_empty() then
+        for j = 1, #inv_main do
+            if inv_main[j].valid_to_read then
+                inv_corpse[i].transfer_stack(inv_main[j])
+                i = i + 1
+            end
+        end
         inv_main.clear()
     end
-    if inv_trash_contents then
+    if not inv_trash.is_empty() then
+        for j = 1, #inv_trash do
+            if inv_trash[j].valid_to_read then
+                inv_corpse[i].transfer_stack(inv_trash[j])
+                i = i + 1
+            end
+        end
         inv_trash.clear()
     end
 

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -59,7 +59,6 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
                 i = i + 1
             end
         end
-        inv_main.clear()
     end
     if not inv_trash.is_empty() then
         for j = 1, #inv_trash do
@@ -68,7 +67,6 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
                 i = i + 1
             end
         end
-        inv_trash.clear()
     end
 
     local text = player.name .. "'s inventory (offline)"

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -26,7 +26,7 @@ end)
 local function move_items(source, target)
     if not source.is_empty() then
         for i = 1, #source do
-            if source[i].valid_to_read and not ignored_items_set[source[i].name] then
+            if source[i].valid_for_read and not ignored_items_set[source[i].name] then
                 target.insert(source[i])
                 source[i].clear()
             end


### PR DESCRIPTION
Any item-with-data now keeps that when being moved to the corpse. This preserves equipment grids, spidertron remote settings, etc.

Adds an option to exclude items from dropping.

Selection tool items (blueprints, deconstruction planner, upgrade planner) and blue print books are always excluded from dropping.