### PR TITLE
DangerOre Krastorio2 preset

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -210,6 +210,7 @@ stds.factorio_control = {
         -- (http://lua-api.factorio.com/latest/LuaBootstrap.html)
         script = {
             fields = {
+                'active_mods',
                 'on_configuration_changed',
                 'raise_event',
                 'raise_console_chat',

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1131,6 +1131,7 @@ stds.factorio_defines = {
                         'on_rocket_launched',
                         'on_runtime_mod_setting_changed',
                         'on_script_path_request_finished',
+                        'on_script_trigger_effect',
                         'on_sector_scanned',
                         'on_selected_entity_changed',
                         'on_surface_cleared',

--- a/features/autofill.lua
+++ b/features/autofill.lua
@@ -19,6 +19,13 @@ local ammo_locales = {
     ['piercing-rounds-magazine'] = {'item-name.piercing-rounds-magazine'},
     ['firearm-magazine'] = {'item-name.firearm-magazine'}
 }
+local k2_ammo_locales = {
+    ['rifle-magazine'] = {'item-name.rifle-magazine'},
+    ['armor-piercing-rifle-magazine'] = {'item-name.armor-piercing-rifle-magazine'},
+    ['uranium-rifle-magazine'] = {'item-name.uranium-rifle-magazine'},
+    ['imersite-rifle-magazine'] = {'item-name.imersite-rifle-magazine'}
+}
+if script.active_mods["Krastorio2"] then ammo_locales = k2_ammo_locales end
 Public.ammo_locales = ammo_locales
 
 local player_ammos = {} -- player_index -> dict of name -> bool
@@ -35,6 +42,14 @@ local default_ammos = {
     ['piercing-rounds-magazine'] = true,
     ['firearm-magazine'] = true
 }
+
+local k2_default_ammos = {
+    ['rifle-magazine'] = true,
+    ['armor-piercing-rifle-magazine'] = true,
+    ['uranium-rifle-magazine'] = true,
+    ['imersite-rifle-magazine'] = true
+}
+if script.active_mods["Krastorio2"] then default_ammos = k2_default_ammos end
 
 local function copy(tbl)
     local result = {}

--- a/locale/en/redmew_maps.cfg
+++ b/locale/en/redmew_maps.cfg
@@ -177,4 +177,5 @@ biters_disabled=Launching the first [item=satellite] has killed all the biters. 
 win=Congratulations! The map has been won. Restart the map with /restart
 satellite_launch=Launch another __1__ [item=satellite] to win the map.
 satellite_logger=Already launched __1__ [item=satellite]
+biters_disabled_k2=Launching the first [item=satellite] has killed all the biters. Build and activate the intergalactic transceiver to win the map.
 

--- a/locale/en/redmew_maps.cfg
+++ b/locale/en/redmew_maps.cfg
@@ -176,4 +176,5 @@ anti_grief_jail_reason=You have spilled too many items on the ground, contact an
 biters_disabled=Launching the first [item=satellite] has killed all the biters. Launch __1__ [item=satellite] to win the map.
 win=Congratulations! The map has been won. Restart the map with /restart
 satellite_launch=Launch another __1__ [item=satellite] to win the map.
+satellite_logger=Already launched __1__ [item=satellite]
 

--- a/locale/en/redmew_maps.cfg
+++ b/locale/en/redmew_maps.cfg
@@ -176,6 +176,5 @@ anti_grief_jail_reason=You have spilled too many items on the ground, contact an
 biters_disabled=Launching the first [item=satellite] has killed all the biters. Launch __1__ [item=satellite] to win the map.
 win=Congratulations! The map has been won. Restart the map with /restart
 satellite_launch=Launch another __1__ [item=satellite] to win the map.
-satellite_logger=Already launched __1__ [item=satellite]
 biters_disabled_k2=Launching the first [item=satellite] has killed all the biters. Build and activate the intergalactic transceiver to win the map.
 

--- a/map_gen/maps/danger_ores/config/krastorio2.lua
+++ b/map_gen/maps/danger_ores/config/krastorio2.lua
@@ -1,0 +1,70 @@
+local b = require 'map_gen.shared.builders'
+local start_value = b.euclidean_value(0, 0.35)
+local value = b.exponential_value(0, 0.06, 1.55)
+
+return {
+    {
+        name = 'copper-ore',
+        ['tiles'] = {
+            [1] = 'landfill'
+        },
+        ['start'] = start_value,
+        ['weight'] = 1,
+        ['ratios'] = {
+            {resource = b.resource(b.full_shape, 'iron-ore', value), weight = 13},
+            {resource = b.resource(b.full_shape, 'copper-ore', value), weight = 64},
+            {resource = b.resource(b.full_shape, 'stone', value), weight = 9},
+            {resource = b.resource(b.full_shape, 'coal', value), weight = 4},
+            {resource = b.resource(b.full_shape, 'rare-metals', value), weight = 8},
+            {resource = b.resource(b.full_shape, 'uranium-ore', value), weight = 2},
+        }
+    },
+    {
+        name = 'coal',
+        ['tiles'] = {
+            [1] = 'landfill'
+        },
+        ['start'] = start_value,
+        ['weight'] = 1,
+        ['ratios'] = {
+            {resource = b.resource(b.full_shape, 'iron-ore', value), weight = 14},
+            {resource = b.resource(b.full_shape, 'copper-ore', value), weight = 9},
+            {resource = b.resource(b.full_shape, 'stone', value), weight = 7},
+            {resource = b.resource(b.full_shape, 'coal', value), weight = 60},
+            {resource = b.resource(b.full_shape, 'rare-metals', value), weight = 8},
+            {resource = b.resource(b.full_shape, 'uranium-ore', value), weight = 2},
+        }
+    },
+    {
+        name = 'iron-ore',
+        ['tiles'] = {
+            [1] = 'landfill'
+        },
+        ['start'] = start_value,
+        ['weight'] = 1,
+        ['ratios'] = {
+            {resource = b.resource(b.full_shape, 'iron-ore', value), weight = 67},
+            {resource = b.resource(b.full_shape, 'copper-ore', value), weight = 15},
+            {resource = b.resource(b.full_shape, 'stone', value), weight = 6},
+            {resource = b.resource(b.full_shape, 'coal', value), weight = 2},
+            {resource = b.resource(b.full_shape, 'rare-metals', value), weight = 8},
+            {resource = b.resource(b.full_shape, 'uranium-ore', value), weight = 2},
+        }
+    },
+    {
+        name = 'stone',
+        ['tiles'] = {
+            [1] = 'landfill'
+        },
+        ['start'] = start_value,
+        ['weight'] = 1,
+        ['ratios'] = {
+            {resource = b.resource(b.full_shape, 'iron-ore', value), weight = 23},
+            {resource = b.resource(b.full_shape, 'copper-ore', value), weight = 9},
+            {resource = b.resource(b.full_shape, 'stone', value), weight = 54},
+            {resource = b.resource(b.full_shape, 'coal', value), weight = 4},
+            {resource = b.resource(b.full_shape, 'rare-metals', value), weight = 8},
+            {resource = b.resource(b.full_shape, 'uranium-ore', value), weight = 2},
+        }
+    },
+}

--- a/map_gen/maps/danger_ores/config/krastorio2_allowed_entities.lua
+++ b/map_gen/maps/danger_ores/config/krastorio2_allowed_entities.lua
@@ -1,0 +1,46 @@
+return {
+  -- belts
+  'transport-belt',
+  'fast-transport-belt',
+  'express-transport-belt',
+  'kr-advanced-transport-belt',
+  'kr-superior-transport-belt',
+  -- undergrounds
+  'underground-belt',
+  'fast-underground-belt',
+  'express-underground-belt',
+  'kr-advanced-underground-belt',
+  'kr-superior-underground-belt',
+  -- poles
+  'small-electric-pole',
+  'medium-electric-pole',
+  'big-electric-pole',
+  'substation',
+  'kr-substation-mk2',
+  -- drills
+  'electric-mining-drill',
+  'electric-mining-drill-2',
+  'electric-mining-drill-3',
+  'burner-mining-drill',
+  'pumpjack',
+  'kr-electric-mining-drill-mk2',
+  'kr-electric-mining-drill-mk3',
+  'kr-quarry-drill',
+  'kr-mineral-water-pumpjack',
+  -- vehicles
+  'car',
+  'tank',
+  'kr-advanced-tank',
+  'spidertron',
+  -- rails
+  'straight-rail',
+  'curved-rail',
+  'rail-signal',
+  'rail-chain-signal',
+  'train-stop',
+  'locomotive',
+  'kr-nuclear-locomotive',
+  'cargo-wagon',
+  'fluid-wagon',
+  'artillery-wagon'
+}

--- a/map_gen/maps/danger_ores/config/krastorio2_allowed_recipes.lua
+++ b/map_gen/maps/danger_ores/config/krastorio2_allowed_recipes.lua
@@ -33,7 +33,7 @@ local items = {
   'plastic-bar',
   'rare-metals',
   'steel-plate',
-  'stone',
+  'stone-brick',
   -- intermediates
   'electronic-components',
   'electronic-circuit',

--- a/map_gen/maps/danger_ores/config/krastorio2_allowed_recipes.lua
+++ b/map_gen/maps/danger_ores/config/krastorio2_allowed_recipes.lua
@@ -43,7 +43,7 @@ local items = {
 
 local allowed_recipes = {}
 
-for ___, k in pairs(items) do 
+for _, k in pairs(items) do
   allowed_recipes['deadlock-stacks-stack-'   .. k] = true
   allowed_recipes['deadlock-stacks-unstack-' .. k] = true
 end

--- a/map_gen/maps/danger_ores/config/krastorio2_allowed_recipes.lua
+++ b/map_gen/maps/danger_ores/config/krastorio2_allowed_recipes.lua
@@ -1,0 +1,51 @@
+local items = {
+  -- raws
+  'coal',
+  'compact-raw-rare-metals',
+  'copper-ore',
+  'iron-ore',
+  'raw-imersite',
+  'raw-rare-metals',
+  'stone',
+  'uranium-ore',
+  'wood',
+  -- processed
+  'coke',
+  'enriched-copper',
+  'enriched-iron',
+  'enriched-rare-metals',
+  'fluoride',
+  'imersite-crystal',
+  'imersite-powder',
+  'lithium-chloride',
+  'lithium',
+  'quartz',
+  'sand',
+  'silicon',
+  'solid-fuel',
+  'sulfur',
+  'yellowcake',
+  -- plates
+  'copper-plate',
+  'glass',
+  'imersium-plate',
+  'iron-plate',
+  'plastic-bar',
+  'rare-metals',
+  'steel-plate',
+  'stone',
+  -- intermediates
+  'electronic-components',
+  'electronic-circuit',
+  'advanced-circuit',
+  'processing-unit',
+}
+
+local allowed_recipes = {}
+
+for ___, k in pairs(items) do 
+  allowed_recipes['deadlock-stacks-stack-'   .. k] = true
+  allowed_recipes['deadlock-stacks-unstack-' .. k] = true
+end
+
+return allowed_recipes

--- a/map_gen/maps/danger_ores/modules/map_poll.lua
+++ b/map_gen/maps/danger_ores/modules/map_poll.lua
@@ -17,10 +17,12 @@ end)
 
 local normal_mod_pack = 'normal_mod_pack'
 local bobs_mod_pack = 'bobs_mod_pack'
+local krastorio_mod_pack = 'krastorio_mod_pack'
 
 local mod_packs = {
     normal_mod_pack = 'danger_ore29',
-    bobs_mod_pack = 'danger_ore_bobs3'
+    bobs_mod_pack = 'danger_ore_bobs3',
+    krastorio_mod_pack = 'danger_ore_krastorio'
 }
 
 local maps = {
@@ -123,6 +125,11 @@ local maps = {
         name = 'danger-bobs-ores',
         mod_pack = bobs_mod_pack,
         display_name = 'bob\'s mod (default map)'
+    },
+    {
+        name = 'danger-ore-krastorio2',
+        mod_pack = krastorio_mod_pack,
+        display_name = 'Krastorio2 mod (LazyB + landfill + terraforming)'
     }
 }
 

--- a/map_gen/maps/danger_ores/modules/map_poll.lua
+++ b/map_gen/maps/danger_ores/modules/map_poll.lua
@@ -129,7 +129,7 @@ local maps = {
     {
         name = 'danger-ore-krastorio2',
         mod_pack = krastorio_mod_pack,
-        display_name = 'Krastorio2 mod (LazyB + landfill + terraforming)'
+        display_name = 'Krastorio2 mod (landfill + terraforming)'
     }
 }
 

--- a/map_gen/maps/danger_ores/modules/rocket_launched_krastorio2.lua
+++ b/map_gen/maps/danger_ores/modules/rocket_launched_krastorio2.lua
@@ -3,11 +3,9 @@ local RS = require 'map_gen.shared.redmew_surface'
 local Server = require 'features.server'
 local ShareGlobals = require 'map_gen.maps.danger_ores.modules.shared_globals'
 
-return function(config)
+return function()
     ShareGlobals.data.biters_disabled = false
     ShareGlobals.data.map_won = false
-
-    local win_satellite_count = config.win_satellite_count or 1000
 
     local function disable_biters()
         if ShareGlobals.data.biters_disabled then
@@ -26,12 +24,6 @@ return function(config)
         }
         game.print({'danger_ores.biters_disabled_k2'})
         Server.to_discord_bold(message)
-    end
-
-    local function print_satellite_message(count)
-        -- Just log the no. of satellite(s) launched
-        game.print({'danger_ores.satellite_logger', count})
-        Server.to_discord_bold('Already launched ' .. tostring(count) .. ' satellie(s)')
     end
 
     local function rocket_launched(event)
@@ -56,10 +48,6 @@ return function(config)
 
         if satellite_count == 1 then
             disable_biters()
-        end
-
-        if (satellite_count % 50) == 0 then
-            print_satellite_message(satellite_count)
         end
     end
 

--- a/map_gen/maps/danger_ores/modules/rocket_launched_krastorio2.lua
+++ b/map_gen/maps/danger_ores/modules/rocket_launched_krastorio2.lua
@@ -1,0 +1,92 @@
+local Event = require 'utils.event'
+local RS = require 'map_gen.shared.redmew_surface'
+local Server = require 'features.server'
+local ShareGlobals = require 'map_gen.maps.danger_ores.modules.shared_globals'
+
+return function(config)
+    ShareGlobals.data.biters_disabled = false
+    ShareGlobals.data.map_won = false
+
+    local win_satellite_count = config.win_satellite_count or 1000
+
+    local function disable_biters()
+        if ShareGlobals.data.biters_disabled then
+            return
+        end
+
+        ShareGlobals.data.biters_disabled = true
+        game.forces.enemy.kill_all_units()
+        for _, enemy_entity in pairs(RS.get_surface().find_entities_filtered({force = 'enemy'})) do
+            enemy_entity.destroy()
+        end
+
+        local message = table.concat {
+            'Launching the first satellite has killed all the biters. ',
+            'Launch ',
+            win_satellite_count,
+            ' satellites to win the map.'
+        }
+        game.print({'danger_ores.biters_disabled', win_satellite_count})
+        Server.to_discord_bold(message)
+    end
+
+    local function print_satellite_message(count)
+        -- Just log the no. of satellite(s) launched
+        game.print({'danger_ores.satellite_logger', count})
+        Server.to_discord_bold('Already launched ' .. tostring(count) .. ' satellie(s)')
+    end
+
+    local function rocket_launched(event)
+        if ShareGlobals.data.map_won then
+            return
+        end
+
+        local entity = event.rocket
+        if not entity or not entity.valid or not entity.force == 'player' then
+            return
+        end
+
+        local inventory = entity.get_inventory(defines.inventory.rocket)
+        if not inventory or not inventory.valid then
+            return
+        end
+
+        local satellite_count = game.forces.player.get_item_launched('satellite')
+        if satellite_count == 0 then
+            return
+        end
+
+        if satellite_count == 1 then
+            disable_biters()
+        end
+
+        --if satellite_count == win_satellite_count then
+        --    win()
+        --    return
+        --end
+
+        if (satellite_count % 50) == 0 then
+            print_satellite_message(satellite_count)
+        end
+    end
+
+    local function win()
+        if ShareGlobals.data.map_won then
+            return
+        end
+
+        ShareGlobals.data.map_won = true
+        local message = 'Congratulations! The map has been won. Restart the map with /restart'
+        game.print({'danger_ores.win'})
+        Server.to_discord_bold(message)
+    end
+
+    local function on_transceiver_built(event)
+        if event.effect_id ~= "k2-transciever-activated" then return end
+        win()
+    end
+
+    Event.add(defines.events.on_rocket_launched, rocket_launched)
+    Event.add(defines.events.on_script_trigger_effect, on_transceiver_built)
+end
+

--- a/map_gen/maps/danger_ores/modules/rocket_launched_krastorio2.lua
+++ b/map_gen/maps/danger_ores/modules/rocket_launched_krastorio2.lua
@@ -22,11 +22,9 @@ return function(config)
 
         local message = table.concat {
             'Launching the first satellite has killed all the biters. ',
-            'Launch ',
-            win_satellite_count,
-            ' satellites to win the map.'
+            'Build and activate the intergalactic transceiver to win the map.'
         }
-        game.print({'danger_ores.biters_disabled', win_satellite_count})
+        game.print({'danger_ores.biters_disabled_k2'})
         Server.to_discord_bold(message)
     end
 
@@ -59,11 +57,6 @@ return function(config)
         if satellite_count == 1 then
             disable_biters()
         end
-
-        --if satellite_count == win_satellite_count then
-        --    win()
-        --    return
-        --end
 
         if (satellite_count % 50) == 0 then
             print_satellite_message(satellite_count)

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -1,0 +1,230 @@
+local RS = require 'map_gen.shared.redmew_surface'
+local MGSP = require 'resources.map_gen_settings'
+local Event = require 'utils.event'
+local Token = require 'utils.token'
+local Task = require 'utils.task'
+local b = require 'map_gen.shared.builders'
+local Config = require 'config'
+
+local ScenarioInfo = require 'features.gui.info'
+ScenarioInfo.set_map_name('Danger Ore Krastorio2')
+ScenarioInfo.set_map_description([[
+Clear the ore to expand the base,
+focus mining efforts on specific sectors to ensure
+proper material ratios, expand the map with pollution!
+]])
+ScenarioInfo.add_map_extra_info([[
+This map is split in four sectors [item=iron-ore] [item=copper-ore] [item=coal] [item=stone].
+Each sector has a main resource and the other resources at a lower ratio.
+
+You may not build the factory on ore patches. Exceptions:
+ [item=burner-mining-drill] [item=electric-mining-drill] [item=kr-electric-mining-drill-mk2] [item=kr-electric-mining-drill-mk3] [item=pumpjack] [item=kr-mineral-water-pumpjack] [item=kr-quarry-drill] 
+ [item=small-electric-pole] [item=medium-electric-pole] [item=big-electric-pole] [item=substation] [item=kr-substation-mk2]
+ [item=car] [item=tank] [item=kr-advanced-tank] [item=spidertron] 
+ [item=locomotive] [item=kr-nuclear-locomotive] [item=cargo-wagon] [item=fluid-wagon] [item=artillery-wagon]
+ [item=transport-belt] [item=fast-transport-belt] [item=express-transport-belt] [item=kr-advanced-transport-belt] [item=kr-superior-transport-belt]
+ [item=underground-belt] [item=fast-underground-belt] [item=express-underground-belt] [item=kr-advanced-underground-belt] [item=kr-superior-underground-belt] 
+ [item=rail] [item=rail-signal] [item=rail-chain-signal] [item=train-stop]
+
+The map size is restricted to the pollution generated. A significant amount of
+pollution must affect a section of the map before it is revealed. Pollution
+does not affect biter evolution.
+
+Handcrafting is disabled.]])
+
+ScenarioInfo.set_new_info([[
+2023-10-01:
+ - Added K2 preset
+
+2023-06-27:
+ - disabled Crafting
+ - added Starting Equipment
+
+2019-04-24:
+ - Stone ore density reduced by 1/2
+ - Ore quadrants randomized
+ - Increased time factor of biter evolution from 5 to 7
+ - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
+
+2019-03-30:
+ - Uranium ore patch threshold increased slightly
+ - Bug fix: Cars and tanks can now be placed onto ore!
+ - Starting minimum pollution to expand map set to 650
+    View current pollution via Debug Settings [F4] show-pollution-values,
+    then open map and turn on pollution via the red box.
+ - Starting water at spawn increased from radius 8 to radius 16 circle.
+
+2019-03-27:
+ - Ore arranged into quadrants to allow for more controlled resource gathering.
+
+2020-09-02:
+ - Destroyed chests dump their content as coal ore.
+
+2020-12-28:
+ - Changed win condition. First satellite kills all biters, launch 500 to win the map.
+
+2021-04-06:
+ - Rail signals and train stations now allowed on ore.
+]])
+
+ScenarioInfo.add_extra_rule({'info.rules_text_danger_ore'})
+
+global.config.redmew_qol.loaders = false
+
+local map = require 'map_gen.maps.danger_ores.modules.map'
+local main_ores_config = require 'map_gen.maps.danger_ores.config.krastorio2'
+-- local resource_patches = require 'map_gen.maps.danger_ores.modules.resource_patches'
+-- local resource_patches_config = require 'map_gen.maps.danger_ores.config.deadlock_beltboxes_resource_patches'
+local trees = require 'map_gen.maps.danger_ores.modules.trees'
+local enemy = require 'map_gen.maps.danger_ores.modules.enemy'
+-- local dense_patches = require 'map_gen.maps.danger_ores.modules.dense_patches'
+
+local banned_entities = require 'map_gen.maps.danger_ores.modules.banned_entities'
+local allowed_entities = require 'map_gen.maps.danger_ores.config.krastorio2_allowed_entities'
+banned_entities(allowed_entities)
+
+local ore_oil_none = { autoplace_controls = {} }
+for _, v in pairs({
+    'coal',
+    'crude-oil',
+    'iron-ore',
+    'copper-ore',
+    'uranium-ore',
+    'stone',
+    'rare-metals',
+    'mineral-water',
+    'imersite',
+}) do 
+    ore_oil_none.autoplace_controls[v] = { frequency = 1, richness = 1, size = 0 }
+end
+
+RS.set_map_gen_settings({
+    MGSP.grass_only,
+    MGSP.enable_water,
+    {terrain_segmentation = 'normal', water = 'normal'},
+    MGSP.starting_area_very_low,
+    ore_oil_none,
+    MGSP.enemy_none,
+    MGSP.cliff_none,
+    {autoplace_controls = {trees = {frequency = 1, richness = 1, size = 1}}}
+})
+-- Config.lazy_bastard.enabled = true
+Config.market.enabled = false
+Config.player_rewards.enabled = false
+Config.player_create.starting_items = {
+    {name = 'wood', count = 50},
+    {name = 'steel-furnace', count = 1},
+    {name = 'electric-mining-drill', count = 2},
+    {name = 'medium-electric-pole', count = 1},
+    {name = 'offshore-pump', count = 1},
+    {name = 'boiler', count = 2},
+    {name = 'steam-turbine', count = 1},
+    {name = 'assembling-machine-2', count = 1},
+    {name = 'fast-inserter', count = 1},
+    {name = 'long-handed-inserter', count = 1},
+    {name = 'steel-chest', count = 1},
+    {name = 'kr-medium-container', count = 1},
+    {name = 'lab', count = 1},
+    {name = 'radar', count = 1},
+    {name = 'early-construction-light-armor', count = 1},
+    {name = 'early-construction-equipment', count = 1},
+    {name = 'early-construction-robot', count = 100},
+    {name = 'rocket-fuel', count = 1}
+}
+Config.dump_offline_inventories = {
+    enabled = true,
+    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+}
+Config.paint.enabled = false
+
+local kr_remote = Token.register(function()
+    -- enable creep on Redmew surface
+    if remote.interfaces["kr-creep"] and remote.interfaces["kr-creep"]["set_creep_on_surface"] then
+        remote.call( "kr-creep", "set_creep_on_surface", game.surfaces.redmew.index, true )
+    end
+    -- disable K2 radioactivity (if uranium is mixed with all the ores)
+    if remote.interfaces["kr-radioactivity"] and remote.interfaces["kr-radioactivity"]["set_enabled"] then
+        remote.call( "kr-radioactivity", "set_enabled", false )
+    end
+end)
+
+Event.on_init(function()
+    game.permissions.get_group("Default").set_allows_action(defines.input_action.craft, false)
+    -- game.draw_resource_selection = false
+
+    local p = game.forces.player
+    p.technologies['mining-productivity-1'].enabled = false
+    p.technologies['mining-productivity-2'].enabled = false
+    p.technologies['mining-productivity-3'].enabled = false
+    p.technologies['mining-productivity-4'].enabled = false
+    p.technologies['mining-productivity-11'].enabled = false
+    p.technologies['mining-productivity-16'].enabled = false
+    p.technologies['kr-decorations'].enabled = false
+
+    p.manual_mining_speed_modifier = 1
+
+    game.difficulty_settings.technology_price_multiplier = 20
+
+    game.map_settings.enemy_evolution.time_factor = 0.000007 -- default 0.000004
+    game.map_settings.enemy_evolution.destroy_factor = 0.000010 -- default 0.002
+    game.map_settings.enemy_evolution.pollution_factor = 0.000000 -- Pollution has no affect on evolution default 0.0000009
+
+    RS.get_surface().always_day = true
+    RS.get_surface().peaceful_mode = true
+
+    Task.set_timeout_in_ticks(60, kr_remote)
+end)
+
+local terraforming = require 'map_gen.maps.danger_ores.modules.terraforming'
+terraforming({start_size = 8 * 32, min_pollution = 600, max_pollution = 24000, pollution_increment = 9})
+
+--[[ Win condition in K2: build intergalactic transceiver ]]
+-- local rocket_launched = require 'map_gen.maps.danger_ores.modules.rocket_launched_simple'
+-- rocket_launched({win_satellite_count = 1000})
+
+local restart_command = require 'map_gen.maps.danger_ores.modules.restart_command'
+restart_command({scenario_name = 'danger-ore-krastorio2'})
+
+local container_dump = require 'map_gen.maps.danger_ores.modules.container_dump'
+container_dump({entity_name = 'coal'})
+
+-- local concrete_on_landfill = require 'map_gen.maps.danger_ores.modules.concrete_on_landfill'
+-- concrete_on_landfill({tile = 'blue-refined-concrete'})
+
+local whitelist_stacked_recipes = require 'map_gen.maps.danger_ores.modules.remove_non_ore_stacked_recipes'
+local allowed_recipes = require 'map_gen.maps.danger_ores.config.krastorio2_allowed_recipes'
+whitelist_stacked_recipes(allowed_recipes)
+
+require 'map_gen.maps.danger_ores.modules.biter_drops'
+
+require 'map_gen.maps.danger_ores.modules.map_poll'
+
+local config = {
+    spawn_shape = b.circle(36),
+    start_ore_shape = b.circle(44),
+    no_resource_patch_shape = b.circle(80),
+    spawn_tile = 'landfill',
+    main_ores = main_ores_config,
+    main_ores_shuffle_order = true,
+    main_ores_rotate = 30,
+    -- resource_patches = resource_patches,
+    -- resource_patches_config = resource_patches_config,
+    water_scale = 1 / 96,
+    water_threshold = 0.4,
+    deepwater_threshold = 0.45,
+    trees = trees,
+    trees_scale = 1 / 64,
+    trees_threshold = 0.4,
+    trees_chance = 0.875,
+    enemy = enemy,
+    enemy_factor = 10 / (768 * 32),
+    enemy_max_chance = 1 / 6,
+    enemy_scale_factor = 32,
+    fish_spawn_rate = 0.025,
+    -- dense_patches = dense_patches,
+    dense_patches_scale = 1 / 48,
+    dense_patches_threshold = 0.55,
+    dense_patches_multiplier = 25
+}
+
+return map(config)

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -152,7 +152,7 @@ local kr_remote = Token.register(function()
 end)
 
 Event.on_init(function()
-    game.permissions.get_group("Default").set_allows_action(defines.input_action.craft, false)
+    -- game.permissions.get_group("Default").set_allows_action(defines.input_action.craft, false)
     -- game.draw_resource_selection = false
 
     local p = game.forces.player

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -182,8 +182,10 @@ local terraforming = require 'map_gen.maps.danger_ores.modules.terraforming'
 terraforming({start_size = 8 * 32, min_pollution = 600, max_pollution = 24000, pollution_increment = 9})
 
 --[[ Win condition in K2: build intergalactic transceiver ]]
--- local rocket_launched = require 'map_gen.maps.danger_ores.modules.rocket_launched_simple'
--- rocket_launched({win_satellite_count = 1000})
+local rocket_launched = require 'map_gen.maps.danger_ores.modules.rocket_launched_krastorio2'
+local win_condition = settings.startup['k2-danger-ores:win_condition']
+local satellite_count = win_condition and win_condition.value or 1000
+rocket_launched({win_satellite_count = satellite_count})
 
 local restart_command = require 'map_gen.maps.danger_ores.modules.restart_command'
 restart_command({scenario_name = 'danger-ore-krastorio2'})

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -18,12 +18,12 @@ This map is split in four sectors [item=iron-ore] [item=copper-ore] [item=coal] 
 Each sector has a main resource and the other resources at a lower ratio.
 
 You may not build the factory on ore patches. Exceptions:
- [item=burner-mining-drill] [item=electric-mining-drill] [item=kr-electric-mining-drill-mk2] [item=kr-electric-mining-drill-mk3] [item=pumpjack] [item=kr-mineral-water-pumpjack] [item=kr-quarry-drill] 
+ [item=burner-mining-drill] [item=electric-mining-drill] [item=kr-electric-mining-drill-mk2] [item=kr-electric-mining-drill-mk3] [item=pumpjack] [item=kr-mineral-water-pumpjack] [item=kr-quarry-drill]
  [item=small-electric-pole] [item=medium-electric-pole] [item=big-electric-pole] [item=substation] [item=kr-substation-mk2]
- [item=car] [item=tank] [item=kr-advanced-tank] [item=spidertron] 
+ [item=car] [item=tank] [item=kr-advanced-tank] [item=spidertron]
  [item=locomotive] [item=kr-nuclear-locomotive] [item=cargo-wagon] [item=fluid-wagon] [item=artillery-wagon]
  [item=transport-belt] [item=fast-transport-belt] [item=express-transport-belt] [item=kr-advanced-transport-belt] [item=kr-superior-transport-belt]
- [item=underground-belt] [item=fast-underground-belt] [item=express-underground-belt] [item=kr-advanced-underground-belt] [item=kr-superior-underground-belt] 
+ [item=underground-belt] [item=fast-underground-belt] [item=express-underground-belt] [item=kr-advanced-underground-belt] [item=kr-superior-underground-belt]
  [item=rail] [item=rail-signal] [item=rail-chain-signal] [item=train-stop]
 
 The map size is restricted to the pollution generated. A significant amount of
@@ -94,7 +94,7 @@ for _, v in pairs({
     'rare-metals',
     'mineral-water',
     'imersite',
-}) do 
+}) do
     ore_oil_none.autoplace_controls[v] = { frequency = 1, richness = 1, size = 0 }
 end
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -29,8 +29,7 @@ You may not build the factory on ore patches. Exceptions:
 The map size is restricted to the pollution generated. A significant amount of
 pollution must affect a section of the map before it is revealed. Pollution
 does not affect biter evolution.
-
-Handcrafting is disabled.]])
+]])
 
 ScenarioInfo.set_new_info([[
 2023-10-01:

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -112,25 +112,28 @@ RS.set_map_gen_settings({
 Config.market.enabled = false
 Config.player_rewards.enabled = false
 Config.player_create.starting_items = {
-    {name = 'wood', count = 50},
-    {name = 'steel-furnace', count = 1},
-    {name = 'electric-mining-drill', count = 2},
-    {name = 'medium-electric-pole', count = 1},
-    {name = 'offshore-pump', count = 1},
-    {name = 'boiler', count = 2},
-    {name = 'steam-turbine', count = 1},
     {name = 'assembling-machine-2', count = 1},
+    {name = 'boiler', count = 2},
+    {name = 'electric-mining-drill', count = 2},
     {name = 'fast-inserter', count = 1},
-    {name = 'long-handed-inserter', count = 1},
-    {name = 'steel-chest', count = 1},
     {name = 'kr-medium-container', count = 1},
     {name = 'lab', count = 1},
+    {name = 'long-handed-inserter', count = 1},
+    {name = 'medium-electric-pole', count = 1},
+    {name = 'offshore-pump', count = 1},
     {name = 'radar', count = 1},
-    {name = 'early-construction-light-armor', count = 1},
-    {name = 'early-construction-equipment', count = 1},
-    {name = 'early-construction-robot', count = 100},
-    {name = 'rocket-fuel', count = 1}
+    {name = 'rocket-fuel', count = 1},
+    {name = 'steam-turbine', count = 1},
+    {name = 'steel-chest', count = 1},
+    {name = 'steel-furnace', count = 1},
+    {name = 'wood', count = 50},
 }
+if script.active_mods["early_construction"] then
+    table.insert(Config.player_create.starting_items, {name = 'early-construction-light-armor', count = 1})
+    table.insert(Config.player_create.starting_items, {name = 'early-construction-equipment', count = 1})
+    table.insert(Config.player_create.starting_items, {name = 'early-construction-robot', count = 100})
+end
+
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -166,7 +166,7 @@ Event.on_init(function()
 
     p.manual_mining_speed_modifier = 1
 
-    game.difficulty_settings.technology_price_multiplier = 20
+    game.difficulty_settings.technology_price_multiplier = game.difficulty_settings.technology_price_multiplier * 10
 
     game.map_settings.enemy_evolution.time_factor = 0.000007 -- default 0.000004
     game.map_settings.enemy_evolution.destroy_factor = 0.000010 -- default 0.002

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -119,7 +119,7 @@ Config.player_create.starting_items = {
     {name = 'iron-plate', count = 400},
     {name = 'kr-medium-container', count = 1},
     {name = 'kr-sentinel', count = 5},
-    {name = 'kr-wind-turbine', count = 1},    
+    {name = 'kr-wind-turbine', count = 5},
     {name = 'lab', count = 1},
     {name = 'medium-electric-pole', count = 5},
     {name = 'steel-chest', count = 1},

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -112,20 +112,19 @@ RS.set_map_gen_settings({
 Config.market.enabled = false
 Config.player_rewards.enabled = false
 Config.player_create.starting_items = {
-    {name = 'assembling-machine-2', count = 1},
-    {name = 'boiler', count = 2},
-    {name = 'electric-mining-drill', count = 2},
-    {name = 'fast-inserter', count = 1},
+    {name = 'assembling-machine-1', count = 1},
+    {name = 'burner-mining-drill', count = 1},
+    {name = 'copper-cable', count = 200},
+    {name = 'electronic-circuit', count = 25},
+    {name = 'iron-gear-wheel', count = 35},
+    {name = 'iron-plate', count = 400},
     {name = 'kr-medium-container', count = 1},
+    {name = 'kr-sentinel', count = 5},
+    {name = 'kr-wind-turbine', count = 1},    
     {name = 'lab', count = 1},
-    {name = 'long-handed-inserter', count = 1},
-    {name = 'medium-electric-pole', count = 1},
-    {name = 'offshore-pump', count = 1},
-    {name = 'radar', count = 1},
-    {name = 'rocket-fuel', count = 1},
-    {name = 'steam-turbine', count = 1},
+    {name = 'medium-electric-pole', count = 5},
     {name = 'steel-chest', count = 1},
-    {name = 'steel-furnace', count = 1},
+    {name = 'stone-furnace', count = 1},
     {name = 'wood', count = 50},
 }
 if script.active_mods["early_construction"] then

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -181,9 +181,7 @@ terraforming({start_size = 8 * 32, min_pollution = 600, max_pollution = 24000, p
 
 --[[ Win condition in K2: build intergalactic transceiver ]]
 local rocket_launched = require 'map_gen.maps.danger_ores.modules.rocket_launched_krastorio2'
-local win_condition = settings.startup['k2-danger-ores:win_condition']
-local satellite_count = win_condition and win_condition.value or 1000
-rocket_launched({win_satellite_count = satellite_count})
+rocket_launched()
 
 local restart_command = require 'map_gen.maps.danger_ores.modules.restart_command'
 restart_command({scenario_name = 'danger-ore-krastorio2'})

--- a/scenario_templates/danger-ore-krastorio2/map_selection.lua
+++ b/scenario_templates/danger-ore-krastorio2/map_selection.lua
@@ -1,0 +1,1 @@
+return require 'map_gen.maps.danger_ores.presets.danger_ore_krastorio2'


### PR DESCRIPTION
Hi, I would like to contribute with a DangerOre-Krastorio2 compatible preset.

The commits involve two major changes:
1. Compatibility added to the turret-autofill shared module 
2. A map preset for DangerOres to be used with [Krastorio2](https://mods.factorio.com/mod/Krastorio2) and [k2-danger-ores](https://github.com/RedRafe/k2-danger-ores) mods

The development was based off Redmew's the already present preset "[danger_ore_lazy_one_beltboxes_ore_only](https://github.com/Refactorio/RedMew/blob/develop/map_gen/maps/danger_ores/presets/danger_ore_lazy_one_beltboxes_ore_only.lua)", and still features:

- terraforming
- landfill everything
- no handcrafting
- no oil
- 10x tech cost multiplier
- 1000 rocket launches to win
- deadlock's loaders&beltboxes compatibility for essential raw/processed items

Some changes were necessarily made at data-stage by the side mod [k2-danger-ores](https://github.com/RedRafe/k2-danger-ores), which is kinda required to run the map with K2 mod, but presents adjustable settings for some features to be enabled/disabled at one's preferences.