### PR TITLE
Enhance tasklist GUI with updated number of tasks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -42,7 +42,7 @@
 --[Set Defaults]--
 -------------------------------------------------------------------------------
 local LINE_LENGTH = false -- It is 2017 limits on length are a waste
-local IGNORE = {'21./%w+_$', '21./^_%w+$', '213/[ijk]', '213/index', '213/key'}
+local IGNORE = {'21./%w+_$', '21./^_%w+$', '213/[ijk]', '213/index', '213/key', '58[1-2]'}
 local NOT_GLOBALS = {'coroutine', 'io', 'socket', 'dofile', 'loadfile'} -- These globals are not available to the factorio API
 
 local STD_CONTROL = 'lua52c+factorio+factorio_control+stdlib+factorio_defines'

--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -213,7 +213,7 @@ end
 local function update_top_gui(player)
     local button = player.gui.top[main_button_name]
     if button and button.valid then
-        button.number = table_size(tasks) or 0
+        button.number = #tasks or 0
     end
 end
 
@@ -630,7 +630,7 @@ local function player_created(event)
             name = main_button_name,
             sprite = 'item/repair-pack',
             tooltip = {'tasklist.tooltip'},
-            number = table_size(tasks) or 0,
+            number = #tasks or 0,
         }
     )
 end
@@ -1117,8 +1117,6 @@ Gui.on_click(
             elseif notify then
                 draw_main_frame(left, p)
             end
-
-            update_top_gui(p)
 
             if notify then
                 p.print(message)

--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -210,6 +210,13 @@ local function update_volunteer_button(button, task)
     end
 end
 
+local function update_top_gui(player)
+    local button = player.gui.top[main_button_name]
+    if button and button.valid then
+        button.number = table_size(tasks) or 0
+    end
+end
+
 local function redraw_tasks(data, enabled)
     local parent = data.tasks_content
     Gui.clear(parent)
@@ -563,6 +570,8 @@ local function create_new_tasks(task_name, player)
             draw_main_frame(left, p)
         end
 
+        update_top_gui(p)
+
         if notify then
             p.print(message)
         end
@@ -620,7 +629,8 @@ local function player_created(event)
             type = 'sprite-button',
             name = main_button_name,
             sprite = 'item/repair-pack',
-            tooltip = {'tasklist.tooltip'}
+            tooltip = {'tasklist.tooltip'},
+            number = table_size(tasks) or 0,
         }
     )
 end
@@ -689,13 +699,15 @@ local function on_tick()
                 label.tooltip = get_task_label_tooltip(tasks[task_index], game_tick)
             end
         end
+
+        update_top_gui(p)
     end
 end
 
 Event.add(defines.events.on_player_created, player_created)
 Event.add(defines.events.on_player_joined_game, player_joined)
 Event.add(defines.events.on_player_left_game, player_left)
-Event.on_nth_tick(3600, on_tick)
+Event.on_nth_tick(60*59, on_tick)
 
 Gui.on_click(main_button_name, toggle)
 
@@ -868,6 +880,8 @@ Gui.on_click(
             elseif notify then
                 draw_main_frame(left, p)
             end
+
+            update_top_gui(p)
 
             if notify then
                 p.print(message)
@@ -1103,6 +1117,8 @@ Gui.on_click(
             elseif notify then
                 draw_main_frame(left, p)
             end
+
+            update_top_gui(p)
 
             if notify then
                 p.print(message)


### PR DESCRIPTION
Enhance tasklist GUI by adding the current number of tasks displayed on top of the icon
Following the suggestion on discord [discord/RedMew/devtalk](https://discord.com/channels/432567222481846283/432570869039104012/1194789531694682152)

Future improvements ideas (not included):
- add setting to display, instead, only the # on **new** tasks not read (notification system)
- add setting to display, instead, only the # of tasks which dont have volunteers yet (allocation system)

Here's a quick reference of hot it looks, pretty simple

![Screenshot from 2024-01-12 12-26-01](https://github.com/Refactorio/RedMew/assets/93430988/b66a9c37-f714-426c-a760-fec4a55ce468)
