### PR TITLE
Add popup chat feature

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -449,6 +449,11 @@ global.config = {
             no_handcraft = false,
         },
         modes = {},
+    },
+    popup_chat = {
+        enabled = true,
+        min_lifetime = 06 * 60, --  6s
+        max_lifetime = 20 * 60, -- 20s
     }
 }
 

--- a/config.lua
+++ b/config.lua
@@ -450,10 +450,13 @@ global.config = {
         },
         modes = {},
     },
+    -- display chat messages on map surface too, as temporarily popups attached on top o players
     popup_chat = {
         enabled = true,
         min_lifetime = 06 * 60, --  6s
         max_lifetime = 20 * 60, -- 20s
+        min_length = 40, -- messages shorter than this value will still be displayed for the min_lifetime
+        max_length = 92, -- messages longer than this value will be trimmed
     }
 }
 

--- a/control.lua
+++ b/control.lua
@@ -120,6 +120,9 @@ end
 if config.permissions.enabled then
     require 'features.permissions'
 end
+if config.popup_chat.enabled then
+    require 'features.popup_chat'
+end
 
 -- GUIs
 -- The order determines the order they appear from left to right.

--- a/features/popup_chat.lua
+++ b/features/popup_chat.lua
@@ -5,6 +5,7 @@ local config = global.config.popup_chat
 local MIN_LIFETIME = config.min_lifetime or 06 * 60 -- 06s
 local MAX_LIFETIME = config.max_lifetime or 20 * 60 -- 20s
 local MIN_MESSAGE_LENGTH = 40
+local MAX_MESSAGE_LENGTH = 92
 local TIME_PER_CHAR = 3 -- about +1 sec every 20 chars (60/20 ticks/chars)
 
 local data = {
@@ -23,6 +24,15 @@ local function message_lifetime(message)
   end
   local extra_time = math.floor((length - MIN_MESSAGE_LENGTH) * TIME_PER_CHAR)
   return math.min(MIN_LIFETIME + extra_time, MAX_LIFETIME)
+end
+
+---@param message string
+local function safe_message(message)
+  local length = message:len()
+  if length <= MAX_MESSAGE_LENGTH then
+    return message
+  end
+  return string.sub(message, 1, MAX_MESSAGE_LENGTH) .. '[...]'
 end
 
 ---@param event defines.event.on_console_chat
@@ -48,10 +58,10 @@ local function on_console_chat(event)
   color.a = 0.9
 
   popup_ID = rendering.draw_text({
-    text = message,
+    text = safe_message(message),
     surface = player.surface,
     target = player.character,
-    target_offset = {0, -3},
+    target_offset = {0, -4},
     color = color,
     font = 'compilatron-message-font',
     scale = 1.75,

--- a/features/popup_chat.lua
+++ b/features/popup_chat.lua
@@ -1,0 +1,66 @@
+local Event = require 'utils.event'
+local Global = require 'utils.global'
+
+local config = global.config.popup_chat
+local MIN_LIFETIME = config.min_lifetime or 06 * 60 -- 06s
+local MAX_LIFETIME = config.max_lifetime or 20 * 60 -- 20s
+local MIN_MESSAGE_LENGTH = 40
+local TIME_PER_CHAR = 3 -- about +1 sec every 20 chars (60/20 ticks/chars)
+
+local data = {
+  popup_chat = {}
+}
+
+Global.register(data, function(tbl)
+  data = tbl
+end)
+
+---@param message string
+local function message_lifetime(message)
+  local length = message:len()
+  if length <= MIN_MESSAGE_LENGTH then
+    return MIN_LIFETIME
+  end
+  local extra_time = math.floor((length - MIN_MESSAGE_LENGTH) * TIME_PER_CHAR)
+  return math.min(MIN_LIFETIME + extra_time, MAX_LIFETIME)
+end
+
+---@param event defines.event.on_console_chat
+local function on_console_chat(event)
+  local index = event.player_index
+  local message = event.message
+  if not (index and message) then
+    return
+  end
+
+  local player = game.players[event.player_index]
+  if not (player and player.character) then
+    return
+  end
+
+  local popup_ID = data.popup_chat[index]
+  if popup_ID then
+    rendering.destroy(popup_ID)
+    data.popup_chat[popup_ID] = nil
+  end
+
+  local color = table.deepcopy(player.color)
+  color.a = 0.9
+
+  popup_ID = rendering.draw_text({
+    text = message,
+    surface = player.surface,
+    target = player.character,
+    target_offset = {0, -3},
+    color = color,
+    font = 'compilatron-message-font',
+    scale = 1.75,
+    time_to_live = message_lifetime(message),
+    forces = { player.force },
+    alignment  = 'center',
+    use_rich_text = true,
+  })
+  data.popup_chat[index] = popup_ID
+end
+
+Event.add(defines.events.on_console_chat, on_console_chat)


### PR DESCRIPTION
Add chat message to map surface too as temporarily popups attached to the player and with the same color.

Configurable by `config`
- `enabled`: true/false
- `min_lifetime`: 5s
- `max_lifetime`: 20s
- allows rich-text 

The longer the message is, the longer it lasts (clamped between min/max config values).

![Screenshot from 2024-01-18 19-15-25](https://github.com/Refactorio/RedMew/assets/93430988/42627645-3fd9-439c-9c86-3f7e4a3bf756)

---

![Screenshot from 2024-01-18 19-15-57](https://github.com/Refactorio/RedMew/assets/93430988/3906975e-37b0-4f13-a307-a150ef1f5dba)

---

![Screenshot from 2024-01-18 19-16-35](https://github.com/Refactorio/RedMew/assets/93430988/30ce9ddd-1532-41ab-93d3-665609cc1df0)

