### PR TITLE
Crash site spawn chest changed to requester chest

### DIFF
--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -929,7 +929,7 @@ local function init(config)
             chest = chest,
             [4] = {entity = {name = 'logistic-chest-requester', force = 'player', callback = 'chest'}},
             [29] = {entity = {name = 'market', force = 'neutral', callback = 'market'}},
-            [32] = {entity = {name = 'steel-chest', force = 'player', callback = 'chest'}}
+            [32] = {entity = {name = 'logistic-chest-requester', force = 'player', callback = 'chest'}}
         },
         [2] = {
             force = 'player',


### PR DESCRIPTION
The requester chest can be used to pool all the coins to one place. In addition players can set items late game that help them get on their feet faster after respawn. 