### PR TITLE
Add DangerOres Expanse preset

### DIFF
--- a/locale/en/redmew_maps.cfg
+++ b/locale/en/redmew_maps.cfg
@@ -179,3 +179,6 @@ satellite_launch=Launch another __1__ [item=satellite] to win the map.
 biters_disabled_k2=Launching the first [item=satellite] has killed all the biters. Build and activate the Intergalactic Transceiver to win the map.
 biters_disabled_ei=Launching the first [item=satellite] has killed all the biters. Launch more Exploration Satellites to the asteroids to unlock the final age.
 biters_disabled_py=Launching the first [item=satellite] has killed all the biters. Research [technology-name=pyrrhic] to win the game.
+chest_reset=The hungry chest has renewed its offers! __1__
+gps=[gps=__1__,__2__,__3__]
+tile_unlock=__1__ has unlocked new grounds! __2__

--- a/map_gen/maps/danger_ores/modules/expanse.lua
+++ b/map_gen/maps/danger_ores/modules/expanse.lua
@@ -32,10 +32,10 @@ local price_modifiers = {
 }
 
 ---@param config
----@field start_size              int, the width/height of the starting area. Will be ceiled to a multiple of a chunk
----@field chance_to_receive_token int, probability of coin rewards [0, 1]
----@field max_ore_price_modifier  int, max value for the ore_modifier after cmputing it with the distance_modifier
----@field price_distance_modifier int, how distance from {0,0} influence the request price
+---@field start_size              number, the width/height of the starting area. Will be ceiled to a multiple of a chunk
+---@field chance_to_receive_token number, probability of coin rewards [0, 1]
+---@field max_ore_price_modifier  number, max value for the ore_modifier after cmputing it with the distance_modifier
+---@field price_distance_modifier number, how distance from {0,0} influence the request price
 return function(config)
   Generate.enable_register_events = false
 
@@ -77,23 +77,6 @@ return function(config)
         end
       end
       surface.set_tiles(tiles, true)
-    end
-  end
-
-  local function reward_tokens(entity)
-    local chance = chance_to_receive_token % 1
-    local count = math.floor(chance_to_receive_token)
-
-    if chance > 0 then
-      chance = math.floor(chance * 1000)
-      if math.random(1, 1000) <= chance then
-        entity.surface.spill_item_stack(entity.position, { name = 'coin', count = 1 }, true, nil, false)
-      end
-    end
-    if count > 0 then
-      for _ = 1, count, 1 do
-        entity.surface.spill_item_stack(entity.position, { name = 'coin', count = 1 }, true, nil, false)
-      end
     end
   end
 
@@ -337,7 +320,9 @@ return function(config)
         end
       end
 
-      reward_tokens(entity)
+      if math.random() <= chance_to_receive_token then
+        entity.surface.spill_item_stack(entity.position, { name = 'coin', count = 1 }, true, nil, false)
+      end
       entity.destructible = true
       entity.die()
       return new_area

--- a/map_gen/maps/danger_ores/modules/expanse.lua
+++ b/map_gen/maps/danger_ores/modules/expanse.lua
@@ -320,7 +320,7 @@ return function(config)
         end
       end
 
-      if math.random() <= chance_to_receive_token then
+      if math.random() < chance_to_receive_token then
         entity.surface.spill_item_stack(entity.position, { name = 'coin', count = 1 }, true, nil, false)
       end
       entity.destructible = true

--- a/map_gen/maps/danger_ores/modules/expanse.lua
+++ b/map_gen/maps/danger_ores/modules/expanse.lua
@@ -1,0 +1,501 @@
+local b = require 'map_gen.shared.builders'
+local Event = require 'utils.event'
+local Generate = require 'map_gen.shared.generate'
+local Global = require 'utils.global'
+local Price_raffle = require 'map_gen.maps.danger_ores.modules.price_raffle'
+local RS = require 'map_gen.shared.redmew_surface'
+local table = require 'utils.table'
+local Task = require 'utils.task'
+local Token = require 'utils.token'
+
+local rendering = rendering
+local math_abs = math.abs
+
+local rock_resources = {
+  'iron-ore', 'iron-ore', 'iron-ore', 'iron-ore', 'iron-ore',
+  'copper-ore', 'copper-ore', 'copper-ore',
+  'coal'
+}
+local price_modifiers = {
+  ['cliff'] = -128,
+  ['deepwater-green'] = -5,
+  ['deepwater'] = -5,
+  ['simple-entity'] = 2,
+  ['tree'] = -8,
+  ['turret'] = -128,
+  ['unit-spawner'] = -256,
+  ['unit'] = -16,
+  ['water-green'] = -5,
+  ['water-mud'] = -6,
+  ['water-shallow'] = -6,
+  ['water'] = -5,
+}
+
+---@param config
+---@field start_size              int, the width/height of the starting area. Will be ceiled to a multiple of a chunk
+---@field chance_to_receive_token int, probability of coin rewards [0, 1]
+---@field max_ore_price_modifier  int, max value for the ore_modifier after cmputing it with the distance_modifier
+---@field price_distance_modifier int, how distance from {0,0} influence the request price
+return function(config)
+  Generate.enable_register_events = false
+
+  local cell_size = 32
+  local start_size = config.start_size
+  local chance_to_receive_token = config.chance_to_receive_token or 0.20
+  local max_ore_price_modifier  = config.max_ore_price_modifier  or 0.33
+  local price_distance_modifier = config.price_distance_modifier or 0.006
+
+  -- pad start_size to closest multiple of 32 for chunk alignment
+  if start_size % cell_size ~= 0 then
+    start_size = start_size + cell_size - start_size % cell_size
+  end
+
+  local surface
+  local primitives = { index = nil }
+  local chest_data = {}
+  local grid = {}
+
+  local bounds = b.rectangle(start_size, start_size)
+
+  local function on_chunk_generated(event)
+    if surface ~= event.surface then
+      return
+    end
+
+    local left_top = event.area.left_top
+    local x, y = left_top.x, left_top.y
+
+    if bounds(x + 0.5, y + 0.5) then
+      -- Starting area
+      Generate.do_chunk(event)
+    else
+      -- Outside starting area
+      local tiles = {}
+      for x1 = x, x + 31 do
+        for y1 = y, y + 31 do
+          tiles[#tiles + 1] = { name = 'out-of-map', position = { x1, y1 } }
+        end
+      end
+      surface.set_tiles(tiles, true)
+    end
+  end
+
+  local function reward_tokens(entity)
+    local chance = chance_to_receive_token % 1
+    local count = math.floor(chance_to_receive_token)
+
+    if chance > 0 then
+      chance = math.floor(chance * 1000)
+      if math.random(1, 1000) <= chance then
+        entity.surface.spill_item_stack(entity.position, { name = 'coin', count = 1 }, true, nil, false)
+      end
+    end
+    if count > 0 then
+      for _ = 1, count, 1 do
+        entity.surface.spill_item_stack(entity.position, { name = 'coin', count = 1 }, true, nil, false)
+      end
+    end
+  end
+
+  local function get_left_top(position)
+    local step = 3
+    local vectors = { { -step, 0 }, { step, 0 }, { 0, step }, { 0, -step } }
+    table.shuffle_table(vectors) --left, right, down, up
+
+    for _, v in pairs(vectors) do
+      local tile = surface.get_tile({ position.x + v[1], position.y + v[2] })
+
+      if tile.name == 'out-of-map' then
+        local left_top
+        left_top = {
+          x = position.x - position.x % cell_size,
+          y = position.y - position.y % cell_size,
+        }
+        return left_top
+      end
+    end
+    return
+  end
+
+  local function is_container_position_valid(position)
+    if game.tick == 0 then
+      return position.x == -start_size/2 or position.y == -start_size/2 or
+        position.x == start_size/2-1 or position.y == start_size/2-1
+    end
+
+    local left_top = get_left_top(position)
+    if not left_top then
+      return false
+    end
+
+    return surface.count_entities_filtered({
+      name = 'logistic-chest-requester',
+      force = 'neutral',
+      --area = { { left_top.x - 1, left_top.y - 1 }, { left_top.x + cell_size + 1, left_top.y + cell_size + 1 } },
+      area = { {left_top.x, left_top.y}, {left_top.x + cell_size - 1, left_top.y + cell_size - 1} },
+    }) == 0
+  end
+
+  local function remove_one_render(chest, key)
+    if rendering.is_valid(chest.price[key].render[1]) then
+      rendering.destroy(chest.price[key].render[1])
+    end
+    if rendering.is_valid(chest.price[key].render[2]) then
+      rendering.destroy(chest.price[key].render[2])
+    end
+  end
+
+  local function remove_old_renders(chest)
+    for key, _ in pairs(chest.price) do
+      remove_one_render(chest, key)
+    end
+  end
+
+  local function get_remaining_budget(chest)
+    local budget = 0
+    for _, item_stack in pairs(chest.price) do
+      budget = budget + (item_stack.count * Price_raffle.get_item_worth(item_stack.name))
+    end
+    return budget
+  end
+
+  local function get_cell_budget(left_top, src_entity)
+    local value = 8 * (cell_size ^ 2)
+    local area = { { left_top.x, left_top.y }, { left_top.x + cell_size - 1, left_top.y + cell_size - 1} }
+    local entities = surface.find_entities(area)
+    local tiles = surface.find_tiles_filtered({ area = area })
+
+    for _, tile in pairs(tiles) do
+      if price_modifiers[tile.name] then
+        value = value + price_modifiers[tile.name]
+      end
+    end
+    for _, entity in pairs(entities) do
+      if price_modifiers[entity.type] then
+        value = value + price_modifiers[entity.type]
+      end
+    end
+
+    local distance = math.sqrt(left_top.x ^ 2 + left_top.y ^ 2)
+    value = value * ((distance ^ 1.1) * price_distance_modifier)
+    local ore_modifier = distance * (price_distance_modifier / 20)
+    if ore_modifier > max_ore_price_modifier then
+      ore_modifier = max_ore_price_modifier
+    end
+
+    for _, entity in pairs(entities) do
+      if entity.type == 'resource' then
+        if entity.prototype.resource_category == 'basic-fluid' then
+          value = value + (entity.amount * ore_modifier * 0.01)
+        else
+          value = value + (entity.amount * ore_modifier)
+        end
+      end
+    end
+
+    value = math.floor(value)
+    if value < 16 then
+      value = 16
+    end
+
+    if _DEBUG and src_entity then
+      local gps_chest = '('..src_entity.position.x..','..src_entity.position.y..')'
+      local gps_area = '{('..area[1][1]..','..area[1][2]..'), ('..area[2][1]..','..area[2][2]..')}'
+      log('Chest: '..gps_chest..' | Area: '..gps_area..' | Value:'..value)
+    end
+    return value
+  end
+
+  local function create_costs_render(entity, name, offset)
+    local id = rendering.draw_sprite {
+      sprite = 'virtual-signal/signal-white',
+      surface = entity.surface,
+      target = entity,
+      x_scale = 1.1,
+      y_scale = 1.1,
+      render_layer = '190',
+      target_offset = { offset, -1.5 },
+      only_in_alt_mode = true,
+    }
+    local id2 = rendering.draw_sprite {
+      sprite = 'item/' .. name,
+      surface = entity.surface,
+      target = entity,
+      x_scale = 0.75,
+      y_scale = 0.75,
+      render_layer = '191',
+      target_offset = { offset, -1.5 },
+      only_in_alt_mode = true,
+    }
+    return { id, id2 }
+  end
+
+  local function init_chest(entity, budget)
+    local left_top = get_left_top(entity.position)
+    if not left_top then
+      return
+    end
+
+    local cell_value = budget or get_cell_budget(left_top, entity)
+    local item_stacks = {}
+    local roll_count = 3
+    for _ = 1, roll_count do
+      local value = math.floor(cell_value / roll_count)
+      local max_item_value = math.max(4, cell_value / (roll_count * 6))
+      for _, stack in pairs(Price_raffle.roll(value, 3, nil, max_item_value)) do
+        if not item_stacks[stack.name] then
+          item_stacks[stack.name] = stack.count
+        else
+          item_stacks[stack.name] = item_stacks[stack.name] + stack.count
+        end
+      end
+    end
+
+    local price = {}
+    local offset = -3
+    for k, v in pairs(item_stacks) do
+      table.insert(price, { name = k, count = v, render = create_costs_render(entity, k, offset) })
+      offset = offset + 1
+    end
+
+    chest_data[entity.unit_number] = { entity = entity, left_top = left_top, price = price }
+  end
+
+  local function process_chest(entity, budget)
+    if entity.name ~= 'logistic-chest-requester' then
+      return
+    end
+    if not chest_data[entity.unit_number] then
+      init_chest(entity, budget)
+    end
+
+    local container = chest_data[entity.unit_number]
+    if not container or not container.entity or not container.entity.valid then
+      chest_data[entity.unit_number] = nil
+      return
+    end
+
+    local inventory = container.entity.get_inventory(defines.inventory.chest)
+
+    if not inventory.is_empty() then
+      local contents = inventory.get_contents()
+      if contents['coin'] then
+        local count_removed = inventory.remove({ name = 'coin', count = 1 })
+        if count_removed > 0 then
+          remove_old_renders(container)
+          init_chest(entity, get_remaining_budget(container))
+          container = chest_data[entity.unit_number]
+          game.print({ 'danger_ores.chest_reset', { 'danger_ores.gps', math.floor(entity.position.x), math.floor(entity.position.y), entity.surface.name } })
+        end
+      end
+      if contents['infinity-chest'] then
+        remove_old_renders(container)
+        container.price = {}
+      end
+    end
+
+    for key, item_stack in pairs(container.price) do
+      local name = item_stack.name
+      local count_removed = inventory.remove({ name = name, count = item_stack.count })
+      container.price[key].count = container.price[key].count - count_removed
+      if container.price[key].count <= 0 then
+        remove_one_render(container, key)
+        table.remove(container.price, key)
+      end
+    end
+
+    if #container.price == 0 then
+      chest_data[entity.unit_number] = nil
+      if not inventory.is_empty() then
+        for name, count in pairs(inventory.get_contents()) do
+          entity.surface.spill_item_stack(entity.position, { name = name, count = count }, true, nil, false)
+        end
+      end
+      inventory.clear()
+
+      -- compute new chunk to unlock
+      local new_area
+      local step = 3
+      local vectors = { { -step, 0 }, { step, 0 }, { 0, step }, { 0, -step } }
+      table.shuffle_table(vectors) --left, right, down, up
+
+      for _, v in pairs(vectors) do
+        local tile = surface.get_tile({ entity.position.x + v[1], entity.position.y + v[2] })
+
+        if tile.name == 'out-of-map' then
+          local p = tile.position
+          new_area = {
+            left_top = {
+              x = p.x - p.x % cell_size,
+              y = p.y - p.y % cell_size,
+            },
+            right_bottom = {
+              x = p.x - p.x % cell_size + cell_size - 1,
+              y = p.y - p.y % cell_size + cell_size - 1,
+            }
+          }
+        end
+      end
+
+      reward_tokens(entity)
+      entity.destructible = true
+      entity.die()
+      return new_area
+    end
+
+    for slot = 1, 30 do
+      entity.clear_request_slot(slot)
+    end
+
+    for slot, item_stack in pairs(container.price) do
+      container.entity.set_request_slot(item_stack, slot)
+    end
+    return false
+  end
+
+  local function expand(left_top)
+    grid[tostring(left_top.x .. '_' .. left_top.y)] = true
+
+    if not surface then
+      return
+    end
+    surface.request_to_generate_chunks(left_top, 0)
+    surface.force_generate_chunk_requests()
+
+    local positions = {
+      { x = left_top.x + math.random(1, cell_size - 2), y = left_top.y },
+      { x = left_top.x, y = left_top.y + math.random(1, cell_size - 2) },
+      { x = left_top.x + math.random(1, cell_size - 2), y = left_top.y + (cell_size - 1) },
+      { x = left_top.x + (cell_size - 1), y = left_top.y + math.random(1, cell_size - 2) },
+    }
+
+    local chests = {}
+    for _, position in pairs(positions) do
+      if is_container_position_valid(position) then
+        local e = surface.create_entity({ name = 'logistic-chest-requester', position = position, force = 'neutral' })
+        e.destructible = false
+        e.minable = false
+        table.insert(chests, e)
+      end
+    end
+
+    return chests
+  end
+
+  local function on_chunk_unlocked(event)
+    local left_top = event.area and event.area.left_top
+    local right_bottom = event.area and event.area.right_bottom
+    if not (left_top and right_bottom) then
+      return
+    end
+
+    -- first, remove all adjacent chests & destroy those
+    local old_chests = surface.find_entities_filtered{name = 'logistic-chest-requester', force = 'neutral', area = {
+      left_top = {
+        x = left_top.x-1,
+        y = left_top.y-1,
+      },
+      right_bottom = {
+        x = right_bottom.x+1,
+        y = right_bottom.y+1,
+      }
+    }}
+    for _, entity in pairs(old_chests) do
+      chest_data[entity.unit_number] = nil
+      local inventory = entity.get_inventory(defines.inventory.chest)
+      if not inventory.is_empty() then
+        for name, count in pairs(inventory.get_contents()) do
+          entity.surface.spill_item_stack(entity.position, { name = name, count = count }, true, nil, false)
+        end
+      end
+      inventory.clear()
+      entity.destructible = true
+      entity.die()
+    end
+
+    -- then generate new expansion chests
+    local cell_budget = get_cell_budget(left_top)
+    for _, new_chest in pairs(expand(left_top)) do
+      process_chest(new_chest, cell_budget)
+    end
+  end
+
+  local function on_tick()
+    local idx, chest = next(chest_data, primitives.index)
+    if not (chest and chest.entity) then
+      primitives.index = nil
+      return
+    end
+
+    local position = chest.entity.position
+    local new_area = process_chest(chest.entity)
+    if new_area then
+      Generate.do_chunk({
+        area = new_area,
+        surface = surface,
+        position = { x = position.x, y = position.y}
+      })
+    end
+    primitives.index = idx
+  end
+
+  local function infinite_resource(event)
+    local entity = event.entity
+    if not (entity and entity.valid) then
+      return
+    end
+
+    if not (math_abs(entity.position.x) < 10 and math_abs(entity.position.y) < 10) then
+      return
+    end
+
+    if entity.type == 'tree' then
+      entity.surface.create_entity{name = 'tree-0'..math.random(9), position = entity.position}
+    elseif entity.type == 'simple-entity' then
+      local rock = entity.surface.create_entity{name = 'rock-huge', position = entity.position, move_stuck_players = true}
+      rock.graphics_variation = math.random(16)
+      entity.surface.spill_item_stack(entity.position, {name = rock_resources[math.random(#rock_resources)], count = math.random(80, 160)}, true, nil, true)
+      entity.surface.spill_item_stack(entity.position, {name = 'stone', count = math.random(5, 15)}, true, nil, true)
+    end
+  end
+
+  local delay_cost = Token.register(function()
+    local rs = RS.get_surface()
+    local chests = rs.find_entities_filtered{name = 'logistic-chest-requester', force = 'neutral'}
+    for _, chest in pairs(chests) do
+      if chest_data[chest.unit_number] then
+        remove_old_renders(chest_data[chest.unit_number])
+      end
+      init_chest(chest)
+    end
+  end)
+
+  Global.register_init({ chest_data = chest_data, primitives = primitives, grid = grid },
+  function(tbl)
+    local rs = RS.get_surface()
+    --[[
+      Always need to request starting map size + 1 chunk border to per-unlock adjacent chunks
+    ]]
+    rs.request_to_generate_chunks({0, 0}, start_size / 32 + 1)
+    rs.force_generate_chunk_requests()
+
+    rs.create_entity{name = 'tree-01', position = {0, -8}}
+    rs.create_entity{name = 'rock-huge', position = {0, 8}}
+    local oil = rs.create_entity{name = 'crude-oil', position = {-8, 0}}
+    oil.amount, oil.initial_amount = 3e5, 3e7
+
+    Task.set_timeout_in_ticks(30, delay_cost)
+    tbl.surface = rs
+  end, function(tbl)
+    surface = tbl.surface
+    chest_data = tbl.chest_data
+    primitives = tbl.primitives
+    grid = tbl.grid
+  end)
+
+  Event.on_nth_tick(1, on_tick)
+  Event.add(defines.events.on_chunk_generated, on_chunk_generated)
+  Event.add(Generate.events.on_chunk_generated, on_chunk_unlocked)
+  Event.add(defines.events.on_pre_player_mined_item, infinite_resource)
+  Event.add(defines.events.on_robot_pre_mined, infinite_resource)
+end

--- a/map_gen/maps/danger_ores/modules/map_poll.lua
+++ b/map_gen/maps/danger_ores/modules/map_poll.lua
@@ -189,7 +189,12 @@ local maps = {
         name = 'danger-ore-scrap',
         mod_pack = scrap_mod_pack,
         display_name = 'Scrapworld (no ores, all scraps)'
-    }
+    },
+    {
+        name = 'danger-ore-expanse',
+        mod_pack = normal_mod_pack,
+        display_name = 'Expanse (feed Hungry Chests to expand)'
+    },
 }
 
 Event.add(Server.events.on_server_started, function()

--- a/map_gen/maps/danger_ores/modules/price_raffle.lua
+++ b/map_gen/maps/danger_ores/modules/price_raffle.lua
@@ -1,0 +1,398 @@
+-- source: https://github.com/ComfyFactory/ComfyFactorio/blob/develop/maps/expanse/price_raffle.lua
+
+-- @usage PriceRaffle
+--[[
+  get_item_worth(name): int
+    name             - string
+
+  is_unlocked(name): bool
+    name             - string
+
+  roll_item_stack(remaining_budget, blacklist, value_blacklist): ItemStack | nil
+    remaining_budget - the value of the item stack
+    blacklist		     - optional list of item names that can not be rolled. example: {["substation"] = true, ["roboport"] = true,}
+    value_blacklist  - max value of an item for it to be included
+
+  roll(budget, max_slots, blacklist): table<ItemStack> | nil
+    budget		       - the total value of the item stacks combined
+    max_slots	       - the maximum amount of item stacks to return
+    blacklist		     - optional list of item names that can not be rolled. example: {["substation"] = true, ["roboport"] = true,}
+    value_blacklist  - max value of an item for it to be included
+]]
+
+local Global = require 'utils.global'
+local Event = require 'utils.event'
+local table = require 'utils.table'
+local Public = {}
+
+local table_shuffle_table = table.shuffle_table
+local table_insert = table.insert
+local math_random = math.random
+local math_floor = math.floor
+
+local item_worths = {
+  ['accumulator'] = 64,
+  ['advanced-circuit'] = 16,
+  ['arithmetic-combinator'] = 16,
+  ['artillery-shell'] = 128,
+  ['artillery-turret'] = 8192,
+  ['artillery-wagon'] = 16384,
+  ['assembling-machine-1'] = 32,
+  ['assembling-machine-2'] = 128,
+  ['assembling-machine-3'] = 512,
+  ['atomic-bomb'] = 16384,
+  ['automation-science-pack'] = 4,
+  ['battery-equipment'] = 128,
+  ['battery-mk2-equipment'] = 2048,
+  ['battery'] = 16,
+  ['beacon'] = 512,
+  ['belt-immunity-equipment'] = 256,
+  ['big-electric-pole'] = 64,
+  ['boiler'] = 8,
+  ['burner-inserter'] = 2,
+  ['burner-mining-drill'] = 8,
+  ['cannon-shell'] = 8,
+  ['car'] = 128,
+  ['cargo-wagon'] = 256,
+  ['centrifuge'] = 2048,
+  ['chemical-plant'] = 128,
+  ['chemical-science-pack'] = 128,
+  ['cliff-explosives'] = 256,
+  ['cluster-grenade'] = 64,
+  ['coal'] = 1,
+  ['combat-shotgun'] = 256,
+  ['concrete'] = 4,
+  ['constant-combinator'] = 16,
+  ['construction-robot'] = 256,
+  ['copper-cable'] = 1,
+  ['copper-ore'] = 1,
+  ['copper-plate'] = 1,
+  ['crude-oil-barrel'] = 8,
+  ['decider-combinator'] = 16,
+  ['defender-capsule'] = 16,
+  ['destroyer-capsule'] = 256,
+  ['discharge-defense-equipment'] = 2048,
+  ['discharge-defense-remote'] = 32,
+  ['distractor-capsule'] = 128,
+  ['effectivity-module-2'] = 512,
+  ['effectivity-module-3'] = 2048,
+  ['effectivity-module'] = 128,
+  ['electric-engine-unit'] = 64,
+  ['electric-furnace'] = 256,
+  ['electric-mining-drill'] = 32,
+  ['electronic-circuit'] = 4,
+  ['empty-barrel'] = 4,
+  ['energy-shield-equipment'] = 512,
+  ['energy-shield-mk2-equipment'] = 4096,
+  ['engine-unit'] = 8,
+  ['exoskeleton-equipment'] = 1024,
+  ['explosive-cannon-shell'] = 16,
+  ['explosive-rocket'] = 8,
+  ['explosive-uranium-cannon-shell'] = 64,
+  ['explosives'] = 4,
+  ['express-splitter'] = 256,
+  ['express-transport-belt'] = 64,
+  ['express-underground-belt'] = 256,
+  ['fast-inserter'] = 32,
+  ['fast-splitter'] = 64,
+  ['fast-transport-belt'] = 16,
+  ['fast-underground-belt'] = 64,
+  ['filter-inserter'] = 40,
+  ['firearm-magazine'] = 4,
+  ['flamethrower-ammo'] = 32,
+  ['flamethrower-turret'] = 2048,
+  ['flamethrower'] = 512,
+  ['fluid-wagon'] = 256,
+  ['flying-robot-frame'] = 128,
+  ['fusion-reactor-equipment'] = 8192,
+  ['gate'] = 16,
+  ['green-wire'] = 4,
+  ['grenade'] = 16,
+  ['gun-turret'] = 64,
+  ['hazard-concrete'] = 4,
+  ['heat-exchanger'] = 256,
+  ['heat-pipe'] = 128,
+  ['heavy-armor'] = 256,
+  ['heavy-oil-barrel'] = 16,
+  ['inserter'] = 8,
+  ['iron-chest'] = 8,
+  ['iron-gear-wheel'] = 2,
+  ['iron-ore'] = 1,
+  ['iron-plate'] = 1,
+  ['iron-stick'] = 1,
+  ['lab'] = 64,
+  ['land-mine'] = 8,
+  ['landfill'] = 12,
+  ['laser-turret'] = 1024,
+  ['light-armor'] = 32,
+  ['light-oil-barrel'] = 16,
+  ['locomotive'] = 512,
+  ['logistic-chest-active-provider'] = 256,
+  ['logistic-chest-buffer'] = 512,
+  ['logistic-chest-passive-provider'] = 256,
+  ['logistic-chest-requester'] = 512,
+  ['logistic-chest-storage'] = 256,
+  ['logistic-robot'] = 256,
+  ['logistic-science-pack'] = 16,
+  ['long-handed-inserter'] = 16,
+  ['low-density-structure'] = 64,
+  ['lubricant-barrel'] = 16,
+  ['medium-electric-pole'] = 32,
+  ['military-science-pack'] = 64,
+  ['modular-armor'] = 1024,
+  ['night-vision-equipment'] = 256,
+  ['nuclear-fuel'] = 1024,
+  ['nuclear-reactor'] = 8192,
+  ['offshore-pump'] = 16,
+  ['oil-refinery'] = 256,
+  ['personal-laser-defense-equipment'] = 2048,
+  ['personal-roboport-equipment'] = 512,
+  ['personal-roboport-mk2-equipment'] = 4096,
+  ['petroleum-gas-barrel'] = 16,
+  ['piercing-rounds-magazine'] = 8,
+  ['piercing-shotgun-shell'] = 16,
+  ['pipe-to-ground'] = 15,
+  ['pipe'] = 1,
+  ['pistol'] = 4,
+  ['plastic-bar'] = 8,
+  ['poison-capsule'] = 64,
+  ['power-armor-mk2'] = 32768,
+  ['power-armor'] = 4096,
+  ['power-switch'] = 16,
+  ['processing-unit'] = 128,
+  ['production-science-pack'] = 256,
+  ['productivity-module-2'] = 512,
+  ['productivity-module-3'] = 2048,
+  ['productivity-module'] = 128,
+  ['programmable-speaker'] = 32,
+  ['pump'] = 32,
+  ['pumpjack'] = 64,
+  ['radar'] = 32,
+  ['rail-chain-signal'] = 16,
+  ['rail-signal'] = 16,
+  ['rail'] = 8,
+  ['red-wire'] = 4,
+  ['refined-concrete'] = 16,
+  ['refined-hazard-concrete'] = 16,
+  ['repair-pack'] = 8,
+  ['roboport'] = 2048,
+  ['rocket-control-unit'] = 256,
+  ['rocket-fuel'] = 256,
+  ['rocket-launcher'] = 128,
+  ['rocket-silo'] = 65536,
+  ['rocket'] = 8,
+  ['satellite'] = 32768,
+  ['shotgun-shell'] = 4,
+  ['shotgun'] = 16,
+  ['slowdown-capsule'] = 16,
+  ['small-electric-pole'] = 4,
+  ['small-lamp'] = 16,
+  ['solar-panel-equipment'] = 256,
+  ['solar-panel'] = 64,
+  ['solid-fuel'] = 16,
+  ['space-science-pack'] = 512,
+  ['speed-module-2'] = 512,
+  ['speed-module-3'] = 2048,
+  ['speed-module'] = 128,
+  ['splitter'] = 16,
+  ['stack-filter-inserter'] = 160,
+  ['stack-inserter'] = 128,
+  ['steam-engine'] = 32,
+  ['steam-turbine'] = 256,
+  ['steel-chest'] = 64,
+  ['steel-furnace'] = 64,
+  ['steel-plate'] = 8,
+  ['stone'] = 1,
+  ['stone-brick'] = 2,
+  ['stone-furnace'] = 4,
+  ['stone-wall'] = 8,
+  ['storage-tank'] = 64,
+  ['submachine-gun'] = 32,
+  ['substation'] = 256,
+  ['sulfur'] = 4,
+  ['sulfuric-acid-barrel'] = 16,
+  ['tank'] = 4096,
+  ['train-stop'] = 64,
+  ['transport-belt'] = 4,
+  ['underground-belt'] = 16,
+  ['uranium-235'] = 1024,
+  ['uranium-238'] = 32,
+  ['uranium-cannon-shell'] = 64,
+  ['uranium-fuel-cell'] = 128,
+  ['uranium-ore'] = 4,
+  ['uranium-rounds-magazine'] = 64,
+  ['utility-science-pack'] = 256,
+  ['water-barrel'] = 4,
+  ['wooden-chest'] = 4,
+}
+local item_unlocked = {}
+local item_names = {}
+
+_G.item_unlocked_data =  item_unlocked
+
+Global.register({
+    item_unlocked = item_unlocked,
+    item_names = item_names,
+  },
+  function(tbl)
+    item_unlocked = tbl.item_unlocked
+    item_names = tbl.item_names
+  end)
+
+function Public.get_item_worth(name)
+  return item_worths[name] or 0
+end
+
+function Public.is_unlocked(name)
+  return item_unlocked[name] ~= nil
+end
+
+local function get_raffle_keys()
+  local raffle_keys = {}
+  for i = 1, #item_names do
+    raffle_keys[i] = i
+  end
+  table_shuffle_table(raffle_keys)
+  return raffle_keys
+end
+
+function Public.roll_item_stack(remaining_budget, blacklist, value_blacklist)
+  if remaining_budget <= 0 then
+    return
+  end
+
+  local raffle_keys = get_raffle_keys()
+  local item_name = false
+  local item_worth = 0
+  for _, index in pairs(raffle_keys) do
+    item_name = item_names[index]
+    item_worth = item_unlocked[item_name]
+    if not blacklist[item_name] and item_worth <= remaining_budget and item_worth <= value_blacklist then
+      break
+    end
+  end
+
+  local stack_size = game.item_prototypes[item_name].stack_size * 32
+
+  local item_count = 1
+
+  for c = 1, math_random(1, stack_size) do
+    local price = c * item_worth
+    if price <= remaining_budget then
+      item_count = c
+    else
+      break
+    end
+  end
+
+  return { name = item_name, count = item_count }
+end
+
+local function roll_item_stacks(remaining_budget, max_slots, blacklist, value_blacklist)
+  local item_stack_set = {}
+  local item_stack_set_worth = 0
+
+  for i = 1, max_slots do
+    if remaining_budget <= 0 then
+      break
+    end
+    local item_stack = Public.roll_item_stack(remaining_budget, blacklist, value_blacklist)
+    item_stack_set[i] = item_stack
+    remaining_budget = remaining_budget - item_stack.count * item_unlocked[item_stack.name]
+    item_stack_set_worth = item_stack_set_worth + item_stack.count * item_unlocked[item_stack.name]
+  end
+
+  return item_stack_set, item_stack_set_worth
+end
+
+function Public.roll(budget, max_slots, blacklist, value_blacklist)
+  if not budget then
+    return
+  end
+  if not max_slots then
+    return
+  end
+
+  local b, vb
+  if not blacklist then
+    b = {}
+  else
+    b = blacklist
+  end
+  if not value_blacklist then
+    vb = 65536
+  else
+    vb = value_blacklist
+  end
+
+  budget = math_floor(budget)
+  if budget == 0 then
+    return
+  end
+
+  local final_stack_set
+  local final_stack_set_worth = 0
+
+  for _ = 1, 5 do
+    local item_stack_set, item_stack_set_worth = roll_item_stacks(budget, max_slots, b, vb)
+    if item_stack_set_worth > final_stack_set_worth or item_stack_set_worth == budget then
+      final_stack_set = item_stack_set
+      final_stack_set_worth = item_stack_set_worth
+    end
+  end
+  return final_stack_set
+end
+
+local function add_recipe_products(recipe)
+  if not (recipe and recipe.enabled) then
+    return
+  end
+
+  for _, product in pairs(recipe.products) do
+    local name = product.name
+    if product.type == 'fluid' then
+      name = name .. '-barrel'
+    end
+
+    if game.item_prototypes[name] ~= nil then
+      item_unlocked[name] = item_worths[name]
+      if item_unlocked[name] ~= nil then
+        table_insert(item_names, name)
+      end
+    end
+  end
+end
+
+Event.on_init(function()
+  for _, recipe in pairs(game.forces.player.recipes) do
+    add_recipe_products(recipe)
+  end
+
+  for _, name in pairs({
+    'coal',
+    'copper-ore',
+    'fish',
+    'iron-ore',
+    'stone',
+    'wood',
+  }) do
+    item_unlocked[name] = item_worths[name]
+    if item_unlocked[name] ~= nil then
+      table_insert(item_names, name)
+    end
+  end
+end)
+
+Event.add(defines.events.on_research_finished, function(event)
+  for _, effect in pairs(event.research.effects or {}) do
+    if effect.recipe then
+      add_recipe_products(game.forces.player.recipes[effect.recipe])
+    end
+  end
+
+  if event.research.name == 'space-science-pack' then
+    item_unlocked['space-science-pack'] = item_worths['space-science-pack']
+  end
+end)
+
+return Public

--- a/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
@@ -11,7 +11,7 @@ ScenarioInfo.set_map_description([[
 
   Clear the ore to expand the base,
   focus mining efforts on specific sectors to ensure
-  proper material ratios, expand the map with pollution!
+  proper material ratios, consume as much resources as possible!
 
                             -- AND --
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
@@ -1,0 +1,150 @@
+local RS = require 'map_gen.shared.redmew_surface'
+local MGSP = require 'resources.map_gen_settings'
+local Event = require 'utils.event'
+local b = require 'map_gen.shared.builders'
+local Config = require 'config'
+
+local ScenarioInfo = require 'features.gui.info'
+ScenarioInfo.set_map_name('Danger Ore Expanse')
+ScenarioInfo.set_map_description([[
+  DangerOres meets The Expanse!
+
+  Clear the ore to expand the base,
+  focus mining efforts on specific sectors to ensure
+  proper material ratios, expand the map with pollution!
+
+                            -- AND --
+
+  Feed the hungry blue chests with the materials they require.
+  The Elder Tree and the Infinity Stone you find at spawn will
+  provide you with all the wood and ores you ever desired.
+]])
+ScenarioInfo.add_map_extra_info([[
+  This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
+  Each sector has a main resource and the other resources at a lower ratio.
+
+  You may not build the factory on ore patches. Exceptions:
+  [item=burner-mining-drill] [item=electric-mining-drill] [item=pumpjack] [item=small-electric-pole] [item=medium-electric-pole] [item=big-electric-pole] [item=substation] [item=car] [item=tank] [item=spidertron] [item=locomotive] [item=cargo-wagon] [item=fluid-wagon] [item=artillery-wagon]
+  [item=transport-belt] [item=fast-transport-belt] [item=express-transport-belt]  [item=underground-belt] [item=fast-underground-belt] [item=express-underground-belt] [item=rail] [item=rail-signal] [item=rail-chain-signal] [item=train-stop]
+
+  The map size is restricted by the Hugry Chests. Provide the requested matrials to unlock new chunks.
+  Use the Elder Tree [entity=tree-01], the Infinity Rock [entity=rock-huge], and the Precious Oil patch [entity=crude-oil] located at spawn [gps=0,0.redmew]
+  to draw more resources when in need, but always favor Danger Ores first if you can.
+  If you find yourself stuck with the requests, insert a Coin [item=coin] into the Hungry Chest [item=logistic-chest-requester] to reroll the request.
+  You can fulfill part of the request & then reroll to change the remeinig part (it will always reroll based on its remaining content to be fulfilled).
+  Unlocking new land may or may not reward you with another Coin.
+]])
+
+ScenarioInfo.set_new_info([[
+2024-04-08:
+  - Forked from DO/terraforming
+  - Added DO/expanse
+  - Lowered tech multiplier 25 > 5
+]])
+
+ScenarioInfo.add_extra_rule({'info.rules_text_danger_ore'})
+
+local map = require 'map_gen.maps.danger_ores.modules.map'
+local main_ores_config = require 'map_gen.maps.danger_ores.config.vanilla_ores'
+local resource_patches = require 'map_gen.maps.danger_ores.modules.resource_patches'
+local resource_patches_config = require 'map_gen.maps.danger_ores.config.vanilla_resource_patches'
+local water = require 'map_gen.maps.danger_ores.modules.water'
+local trees = require 'map_gen.maps.danger_ores.modules.trees'
+local enemy = require 'map_gen.maps.danger_ores.modules.enemy'
+--local dense_patches = require 'map_gen.maps.danger_ores.modules.dense_patches'
+
+local banned_entities = require 'map_gen.maps.danger_ores.modules.banned_entities'
+local allowed_entities = require 'map_gen.maps.danger_ores.config.vanilla_allowed_entities'
+banned_entities(allowed_entities)
+
+RS.set_map_gen_settings({
+    MGSP.grass_only,
+    MGSP.enable_water,
+    {terrain_segmentation = 'normal', water = 'normal'},
+    MGSP.starting_area_very_low,
+    MGSP.ore_oil_none,
+    MGSP.enemy_none,
+    MGSP.cliff_none,
+    MGSP.tree_none
+})
+
+Config.market.enabled = false
+Config.player_rewards.enabled = true
+Config.player_create.starting_items = {
+  {amount =  1, name = 'burner-mining-drill'},
+  {amount =  1, name = 'stone-furnace'},
+  {amount =  1, name = 'wood'},
+  {amount =  1, name = 'pistol'},
+  {amount = 20, name = 'firearm-magazine'},
+  {amount =  5, name = 'coin'},
+}
+Config.dump_offline_inventories = {
+    enabled = true,
+    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+}
+Config.paint.enabled = false
+
+Event.on_init(function()
+    game.draw_resource_selection = false
+    game.forces.player.technologies['mining-productivity-1'].enabled = false
+    game.forces.player.technologies['mining-productivity-2'].enabled = false
+    game.forces.player.technologies['mining-productivity-3'].enabled = false
+    game.forces.player.technologies['mining-productivity-4'].enabled = false
+
+    game.difficulty_settings.technology_price_multiplier = 5
+    game.forces.player.technologies.logistics.researched = true
+    game.forces.player.technologies.automation.researched = true
+
+    game.map_settings.enemy_evolution.time_factor = 0.000007 -- default 0.000004
+    game.map_settings.enemy_evolution.destroy_factor = 0.000010 -- default 0.002
+    game.map_settings.enemy_evolution.pollution_factor = 0.000000 -- Pollution has no affect on evolution default 0.0000009
+
+    game.forces.player.manual_mining_speed_modifier = 1
+
+    RS.get_surface().always_day = true
+end)
+
+local expanse = require 'map_gen.maps.danger_ores.modules.expanse'
+expanse({start_size = 8*32}) -- 8x32
+
+local rocket_launched = require 'map_gen.maps.danger_ores.modules.rocket_launched_simple'
+rocket_launched({win_satellite_count = 100})
+
+local restart_command = require 'map_gen.maps.danger_ores.modules.restart_command'
+restart_command({scenario_name = 'danger-ore-expanse'})
+
+local container_dump = require 'map_gen.maps.danger_ores.modules.container_dump'
+container_dump({entity_name = 'coal'})
+
+local concrete_on_landfill = require 'map_gen.maps.danger_ores.modules.concrete_on_landfill'
+concrete_on_landfill({tile = 'blue-refined-concrete'})
+
+local config = {
+    spawn_shape = b.circle(36),
+    start_ore_shape = b.circle(44),
+    no_resource_patch_shape = b.circle(80),
+    main_ores = main_ores_config,
+    main_ores_shuffle_order = true,
+    main_ores_rotate = 30,
+    resource_patches = resource_patches,
+    resource_patches_config = resource_patches_config,
+    water = water,
+    water_scale = 1 / 96,
+    water_threshold = 0.4,
+    deepwater_threshold = 0.45,
+    trees = trees,
+    trees_scale = 1 / 64,
+    trees_threshold = 0.4,
+    trees_chance = 0.875,
+    enemy = enemy,
+    enemy_factor = 10 / (768 * 32),
+    enemy_max_chance = 1 / 6,
+    enemy_scale_factor = 32,
+    fish_spawn_rate = 0.025,
+    --dense_patches = dense_patches,
+    dense_patches_scale = 1 / 48,
+    dense_patches_threshold = 0.55,
+    dense_patches_multiplier = 25
+}
+
+return map(config)

--- a/scenario_templates/danger-ore-expanse/map_selection.lua
+++ b/scenario_templates/danger-ore-expanse/map_selection.lua
@@ -1,0 +1,1 @@
+return require 'map_gen.maps.danger_ores.presets.danger_ore_expanse'


### PR DESCRIPTION
Add new scenario called DangerOre Expanse

>  DangerOres meets The Expanse!
>
>  Clear the ore to expand the base,
>  focus mining efforts on specific sectors to ensure
>  proper material ratios, expand the map with pollution!
>                            -- AND --
>  Feed the hungry blue chests with the materials they require.
>  The Elder Tree and the Infinity Stone you find at spawn will
>  provide you with all the wood and ores you ever desired.

# Previews

> A (reduced scale) preview of starting area

![Screenshot from 2024-04-10 16-31-35](https://github.com/Refactorio/RedMew/assets/93430988/8cbc187d-5231-429e-8751-ed4e2f1107d9)

> There are an infinite tree&rock that can be handmined at spawn to prevent resource softlocks

![Screenshot from 2024-04-10 16-31-44](https://github.com/Refactorio/RedMew/assets/93430988/740f8798-8b8d-408c-907a-f5f3400793f9)![Screenshot from 2024-04-10 16-32-22](https://github.com/Refactorio/RedMew/assets/93430988/1d4bdd91-c3b0-4c94-b792-a41cc17fb3a9)

> To unlock new chunks simply feed the chests the requested items (based on available/craftable items in game & amount is based on resource in the chest's chunk)

![Screenshot from 2024-04-10 16-32-55](https://github.com/Refactorio/RedMew/assets/93430988/1146067c-cec5-4e96-bc3d-e1fecc869305)

> Once a request is fulfilled, the new chunk is unlocked and a new requester will be created at one of the empty borders. The chest will spill excess items not absorbed and have a 20% chance of giving 1 additional coin. Coins can be used to reroll the chest requests if needed.

![Screenshot from 2024-04-10 16-33-49](https://github.com/Refactorio/RedMew/assets/93430988/9766ddb0-18b8-42dc-9f81-928fc0772339)
