### PR TITLE
Fixes for incorrect chest behaviors in DO:Expanse

### DIFF
--- a/map_gen/maps/danger_ores/modules/expanse.lua
+++ b/map_gen/maps/danger_ores/modules/expanse.lua
@@ -353,8 +353,8 @@ return function(config)
     surface.request_to_generate_chunks(left_top, 0)
     surface.force_generate_chunk_requests()
 
-    local max_side = cell_size - RADIUS + 1
-    local min_side = RADIUS - 1
+    local max_side = cell_size - 1 - RADIUS
+    local min_side = RADIUS
     local positions = {
       { x = left_top.x + math.random(min_side, max_side), y = left_top.y }, -- north
       { x = left_top.x, y = left_top.y + math.random(min_side, max_side) }, -- west

--- a/map_gen/maps/danger_ores/modules/expanse.lua
+++ b/map_gen/maps/danger_ores/modules/expanse.lua
@@ -89,7 +89,6 @@ return function(config)
   end
 
   local function get_empty_neighbour_left_top(entity_position)
-    local find_empty_chunk = out_of_map or (out_of_map == nil)
     local vectors = { { -RADIUS, 0 }, { RADIUS, 0 }, { 0, RADIUS }, { 0, -RADIUS } }
     --table.shuffle_table(vectors) --left, right, down, up
 
@@ -435,7 +434,7 @@ return function(config)
     end
 
     if entity.type == 'tree' then
-      for ___, corpse in pairs(surface.find_entities_filtered{
+      for _, corpse in pairs(surface.find_entities_filtered{
         position = entity.position,
         radius = 1,
         type = 'corpse'}

--- a/map_gen/maps/danger_ores/modules/expanse.lua
+++ b/map_gen/maps/danger_ores/modules/expanse.lua
@@ -405,6 +405,11 @@ return function(config)
   end
 
   local function on_tick()
+    if primitives.index ~= nil and chest_data[primitives.index] == nil then
+      primitives.index = nil
+      return
+    end
+
     local idx, chest = next(chest_data, primitives.index)
     if not (chest and chest.entity) then
       primitives.index = nil

--- a/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
@@ -40,6 +40,11 @@ ScenarioInfo.set_new_info([[
   - Forked from DO/terraforming
   - Added DO/expanse
   - Lowered tech multiplier 25 > 5
+2024-04-17:
+  - Fixed incorrect request computation
+  - Fixed persistent chests on new chunk unlocks
+  - Added chests for each new expansion border
+  - Reduced pre_multiplier from 0.33 >s 0.20
 ]])
 
 ScenarioInfo.add_extra_rule({'info.rules_text_danger_ore'})
@@ -102,6 +107,7 @@ Event.on_init(function()
     game.forces.player.manual_mining_speed_modifier = 1
 
     RS.get_surface().always_day = true
+    RS.get_surface().peaceful_mode = true
 end)
 
 local expanse = require 'map_gen.maps.danger_ores.modules.expanse'


### PR DESCRIPTION
Scenario changes:
 - `max_ore_multiplier` dropped from 0.33 to 0.20 (meaning 20% resources will be devolved into expansion)
 - `peaceful = true`

Then mainly bugfixes for incorrect chest behaviors & chunk position computation that lead into map locks during 1st run