### PR TITLE
Remove debug functionality that was removed in Factorio 1.1.107

### DIFF
--- a/features/gui/debug/model.lua
+++ b/features/gui/debug/model.lua
@@ -104,28 +104,6 @@ function Public.dump_ignore_builder(ignore)
     end
 end
 
-function Public.dump_function(func)
-    local res = {'upvalues:\n'}
-
-    local i = 1
-    while true do
-        local n, v = debug.getupvalue(func, i)
-
-        if n == nil then
-            break
-        elseif n ~= '_ENV' then
-            res[#res + 1] = n
-            res[#res + 1] = ' = '
-            res[#res + 1] = dump(v)
-            res[#res + 1] = '\n'
-        end
-
-        i = i + 1
-    end
-
-    return concat(res)
-end
-
 function Public.dump_text(text, player)
     local func = loadstring('return ' .. text)
     if not func then

--- a/features/gui/debug/package_view.lua
+++ b/features/gui/debug/package_view.lua
@@ -1,6 +1,5 @@
 local Gui = require 'utils.gui'
 local Color = require 'resources.color_presets'
-local Model = require 'features.gui.debug.model'
 
 local loaded = _G.package.loaded
 
@@ -146,7 +145,7 @@ Gui.on_click(
 
         element.style.font_color = Color.orange
         data.selected_variable_label = element
-        
+
         text_box.text = tostring(variable)
     end
 )

--- a/features/gui/debug/package_view.lua
+++ b/features/gui/debug/package_view.lua
@@ -2,7 +2,6 @@ local Gui = require 'utils.gui'
 local Color = require 'resources.color_presets'
 local Model = require 'features.gui.debug.model'
 
-local dump_function = Model.dump_function
 local loaded = _G.package.loaded
 
 local Public = {}
@@ -111,8 +110,6 @@ Gui.on_click(
                     top_panel.add({type = 'flow'}).add {type = 'label', name = variable_label_name, caption = k}
                 Gui.set_data(label, v)
             end
-        elseif file_type == 'function' then
-            text_box.text = dump_function(file)
         else
             text_box.text = tostring(file)
         end
@@ -149,12 +146,8 @@ Gui.on_click(
 
         element.style.font_color = Color.orange
         data.selected_variable_label = element
-
-        if variable_type == 'function' then
-            text_box.text = dump_function(variable)
-        else
-            text_box.text = tostring(variable)
-        end
+        
+        text_box.text = tostring(variable)
     end
 )
 

--- a/utils/debug.lua
+++ b/utils/debug.lua
@@ -3,7 +3,6 @@ local format = string.format
 local match = string.match
 local gsub = string.gsub
 local serialize = serpent.line
-local debug_getupvalue = debug.getupvalue
 
 -- this
 local Debug = {}
@@ -138,26 +137,6 @@ end
 function Debug.cheat(callback)
     if _CHEATS then
         callback()
-    end
-end
-
---- Returns true if the function is a closure, false otherwise.
--- A closure is a function that contains 'upvalues' or in other words
--- has a reference to a local variable defined outside the function's scope.
--- @param  func<function>
--- @return boolean
-function Debug.is_closure(func)
-    local i = 1
-    while true do
-        local n = debug_getupvalue(func, i)
-
-        if n == nil then
-            return false
-        elseif n ~= '_ENV' then
-            return true
-        end
-
-        i = i + 1
     end
 end
 

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -280,10 +280,6 @@ function Event.add_removable_function(event_name, func)
         error('func must be a function', 2)
     end
 
-    if Debug.is_closure(func) then
-        error('func cannot be a closure as that is a desync risk. Consider using Event.add_removable(event_name, token) instead.', 2)
-    end
-
     local funcs = function_handlers[event_name]
     if not funcs then
         function_handlers[event_name] = {func}
@@ -385,10 +381,6 @@ function Event.add_removable_nth_tick_function(tick, func)
     end
     if type(func) ~= 'function' then
         error('func must be a function', 2)
-    end
-
-    if Debug.is_closure(func) then
-        error('func cannot be a closure as that is a desync risk. Consider using Event.add_removable_nth_tick(tick, token) instead.', 2)
     end
 
     local funcs = function_nth_tick_handlers[tick]

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -98,7 +98,6 @@
 local EventCore = require 'utils.event_core'
 local Global = require 'utils.global'
 local Token = require 'utils.token'
-local Debug = require 'utils.debug'
 
 local table_remove = table.remove
 local core_add = EventCore.add


### PR DESCRIPTION
`debug.getupvalue` is no longer supported.