### PR TITLE
GUIs refactor using mod-gui

### DIFF
--- a/features/cutscene/cutscene_controller.lua
+++ b/features/cutscene/cutscene_controller.lua
@@ -6,6 +6,7 @@ local Command = require 'utils.command'
 local Debug = require 'utils.debug'
 local Gui = require 'utils.gui'
 local Settings = require 'utils.redmew_settings'
+local Styles = require 'resources.styles'
 
 local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local debug_print = Debug.print
@@ -14,6 +15,7 @@ local skip_btn_name = Gui.uid_name()
 local backward_btn_name = Gui.uid_name()
 local forward_btn_name = Gui.uid_name()
 local auto_play_cutscene_checkbox_name = Gui.uid_name()
+local flow_name = Gui.uid_name()
 
 local Public = {}
 local handler
@@ -243,23 +245,26 @@ function Public.register_running_cutscene(player_index, identifier, final_transi
         final_transition_time = final_transition_time
     }
 
-    local flow = player.gui.top.add {type = 'flow'}
+    local flow = Gui.add_top_element(player, { type = 'flow', name = flow_name })
     running_cutscene.btn = flow
 
-    local btn = flow.add {type = 'sprite-button', name = skip_btn_name, caption = 'Skip cutscene'}
-    btn.style.minimal_height = 28
+    local btn = flow.add {type = 'sprite-button', name = skip_btn_name, caption = 'Skip cutscene', style = Styles.default_top_element.name }
+    btn.style.minimal_height = 36
+    btn.style.maximal_height = 36
     btn.style.minimal_width = 150
     btn.style.font = 'default-large-bold'
     btn.style.font_color = {r = 255, g = 215, b = 0}
 
-    local back_btn = flow.add {type = 'sprite-button', name = backward_btn_name, caption = 'Go back'}
-    back_btn.style.minimal_height = 28
+    local back_btn = flow.add {type = 'sprite-button', name = backward_btn_name, caption = 'Go back', style = Styles.default_top_element.name }
+    back_btn.style.minimal_height = 36
+    back_btn.style.maximal_height = 36
     back_btn.style.minimal_width = 100
     back_btn.style.font = 'default-large-bold'
     back_btn.style.font_color = {r = 255, g = 215, b = 0}
 
-    local forward_btn = flow.add {type = 'sprite-button', name = forward_btn_name, caption = 'Go forward'}
-    forward_btn.style.minimal_height = 28
+    local forward_btn = flow.add {type = 'sprite-button', name = forward_btn_name, caption = 'Go forward', style = Styles.default_top_element.name }
+    forward_btn.style.minimal_height = 36
+    forward_btn.style.maximal_height = 36
     forward_btn.style.minimal_width = 100
     forward_btn.style.font = 'default-large-bold'
     forward_btn.style.font_color = {r = 255, g = 215, b = 0}

--- a/features/gui/autofill.lua
+++ b/features/gui/autofill.lua
@@ -22,12 +22,12 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add {
+    Gui.add_top_element(player, {
         type = 'sprite-button',
         name = main_button_name,
         sprite = 'item/piercing-rounds-magazine',
         tooltip = {'autofill.main_button_tooltip'}
-    }
+    })
 end
 
 local function update_ammo_button(button, name, enabled)
@@ -42,23 +42,12 @@ end
 local function toggle_main_frame(event)
     local player = event.player
     local player_index = player.index
-    local gui = player.gui
-    local left = gui.left
-    local frame = left[main_frame_name]
-    local main_button = gui.top[main_button_name]
+    local frame = Gui.get_left_element(player, main_frame_name)
 
     if frame then
         Gui.destroy(frame)
-        main_button.style = 'slot_button'
     else
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
-
-        frame =
-            left.add {type = 'frame', name = main_frame_name, caption = {'autofill.frame_name'}, direction = 'vertical'}
+        frame = Gui.add_left_element(player, { type = 'frame', name = main_frame_name, caption = {'autofill.frame_name'}, direction = 'vertical' })
 
         local enabled_checkbox =
             frame.add {
@@ -160,7 +149,7 @@ local function settings_changed(event)
             return
         end
 
-        local frame = player.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(player, main_frame_name)
         if not frame then
             return
         end
@@ -176,7 +165,7 @@ local function settings_changed(event)
             return
         end
 
-        local frame = player.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(player, main_frame_name)
         if not frame then
             return
         end

--- a/features/gui/autofill.lua
+++ b/features/gui/autofill.lua
@@ -26,7 +26,8 @@ local function player_created(event)
         type = 'sprite-button',
         name = main_button_name,
         sprite = 'item/piercing-rounds-magazine',
-        tooltip = {'autofill.main_button_tooltip'}
+        tooltip = {'autofill.main_button_tooltip'},
+        auto_toggle = true,
     })
 end
 
@@ -46,6 +47,8 @@ local function toggle_main_frame(event)
 
     if frame then
         Gui.destroy(frame)
+        local main_button = Gui.get_top_element(player, main_button_name)
+        main_button.toggled = false
     else
         frame = Gui.add_left_element(player, { type = 'frame', name = main_frame_name, caption = {'autofill.frame_name'}, direction = 'vertical' })
 

--- a/features/gui/evolution_progress.lua
+++ b/features/gui/evolution_progress.lua
@@ -65,7 +65,7 @@ local function get_alien_name(evolution_factor)
 end
 
 local function update_gui(player)
-    local button = player.gui.top[main_button_name]
+    local button = Gui.get_top_element(player, main_button_name)
     if button and button.valid then
         local evolution_factor = get_evolution_percentage()
         local evolution_button_number = evolution_factor * 100
@@ -88,7 +88,7 @@ local function player_created(event)
     local evolution_factor = get_evolution_percentage()
     local alien_name = get_alien_name(evolution_factor)
 
-    player.gui.top.add(
+    Gui.add_top_element(player,
         {
             name = main_button_name,
             type = 'sprite-button',

--- a/features/gui/info.lua
+++ b/features/gui/info.lua
@@ -594,7 +594,6 @@ end
 local function close_main_frame(frame, player)
     upload_changelog(player)
     Gui.destroy(frame)
-    player.gui.top[main_button_name].style = 'slot_button'
 end
 
 local function reward_player(player, index, message)
@@ -625,17 +624,10 @@ local function toggle(event)
     local gui = player.gui
     local center = gui.center
     local main_frame = center[main_frame_name]
-    local main_button = gui.top[main_button_name]
 
     if main_frame then
         close_main_frame(main_frame, player)
     else
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
-
         draw_main_frame(center, player)
     end
 end
@@ -646,7 +638,7 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add({
+    Gui.add_top_element(player, {
         type = 'sprite-button',
         name = main_button_name,
         sprite = 'virtual-signal/signal-info',

--- a/features/gui/info.lua
+++ b/features/gui/info.lua
@@ -627,6 +627,8 @@ local function toggle(event)
 
     if main_frame then
         close_main_frame(main_frame, player)
+        local main_button = Gui.get_top_element(player, main_button_name)
+        main_button.toggled = false
     else
         draw_main_frame(center, player)
     end
@@ -642,7 +644,8 @@ local function player_created(event)
         type = 'sprite-button',
         name = main_button_name,
         sprite = 'virtual-signal/signal-info',
-        tooltip = {'info.tooltip'}
+        tooltip = {'info.tooltip'},
+        auto_toggle = true,
     })
 
     rewarded_players[player.index] = 0

--- a/features/gui/paint.lua
+++ b/features/gui/paint.lua
@@ -89,7 +89,7 @@ local function player_build_tile(event)
         return
     end
 
-    if not player.gui.left[main_frame_name] then
+    if not Gui.get_left_element(player, main_frame_name) then
         refund_tiles(player, event.tiles)
         return
     end
@@ -193,7 +193,7 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add(
+    local b = Gui.add_top_element(player,
         {
             name = main_button_name,
             type = 'sprite-button',
@@ -201,6 +201,7 @@ local function player_created(event)
             tooltip = {'paint.tooltip'}
         }
     )
+    b.style.padding = 2
 end
 
 local function draw_filters_table(event)
@@ -242,28 +243,17 @@ end
 
 local function toggle(event)
     local player = event.player
-    local gui = player.gui
-    local left = gui.left
-    local main_frame = left[main_frame_name]
-    local main_button = gui.top[main_button_name]
+    local main_frame = Gui.get_left_element(player, main_frame_name)
 
     if main_frame and main_frame.valid then
         Gui.destroy(main_frame)
-        main_button.style = 'slot_button'
     else
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
-
-        main_frame =
-            left.add {
+        main_frame = Gui.add_left_element(player,  {
             type = 'frame',
             name = main_frame_name,
             direction = 'vertical',
             caption = {'paint.frame_name'}
-        }
+        })
 
         local top_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
 

--- a/features/gui/paint.lua
+++ b/features/gui/paint.lua
@@ -198,7 +198,8 @@ local function player_created(event)
             name = main_button_name,
             type = 'sprite-button',
             sprite = 'utility/spray_icon',
-            tooltip = {'paint.tooltip'}
+            tooltip = {'paint.tooltip'},
+            auto_toggle = true,
         }
     )
     b.style.padding = 2
@@ -247,6 +248,8 @@ local function toggle(event)
 
     if main_frame and main_frame.valid then
         Gui.destroy(main_frame)
+        local main_button = Gui.get_top_element(player, main_button_name)
+        main_button.toggled = false
     else
         main_frame = Gui.add_left_element(player,  {
             type = 'frame',

--- a/features/gui/player_list.lua
+++ b/features/gui/player_list.lua
@@ -669,28 +669,19 @@ end
 
 local function toggle(event)
     local player = event.player
-    local gui = player.gui
-    local left = gui.left
+    local left = Gui.get_left_flow(player)
     local main_frame = left[main_frame_name]
-    local main_button = gui.top[main_button_name]
 
     if main_frame then
         remove_main_frame(main_frame, player)
-        main_button.style = 'slot_button'
     else
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
-
         draw_main_frame(left, player)
     end
 end
 
 local function tick()
     for _, p in ipairs(game.connected_players) do
-        local frame = p.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(p, main_frame_name)
 
         if frame and frame.valid then
             local data = Gui.get_data(frame)
@@ -705,19 +696,19 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add(
+    Gui.add_top_element(player,
         {
             type = 'sprite-button',
             name = main_button_name,
             sprite = 'entity/character',
-            tooltip = {'player_list.tooltip'}
+            tooltip = {'player_list.tooltip'},
         }
     )
 end
 
 local function update_player_list()
     for _, p in ipairs(game.connected_players) do
-        local frame = p.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(p, main_frame_name)
 
         if frame and frame.valid then
             local data = Gui.get_data(frame)
@@ -802,7 +793,7 @@ Gui.on_click(
         local message = concat({'>> ', player.name, ' has poked ', poke_player.name, ' with ', poke_str, ' <<'})
 
         for _, p in ipairs(game.connected_players) do
-            local frame = p.gui.left[main_frame_name]
+            local frame = Gui.get_left_element(p, main_frame_name)
             if frame and frame.valid then
                 local frame_data = Gui.get_data(frame)
                 local poke_bottons = frame_data.poke_buttons
@@ -868,7 +859,7 @@ Event.add(
 
         no_notify_players[player_index] = no_notify
 
-        local frame = player.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(player, main_frame_name)
         if not frame then
             return
         end

--- a/features/gui/player_list.lua
+++ b/features/gui/player_list.lua
@@ -674,6 +674,8 @@ local function toggle(event)
 
     if main_frame then
         remove_main_frame(main_frame, player)
+        local main_button = Gui.get_top_element(player, main_button_name)
+        main_button.toggled = false
     else
         draw_main_frame(left, player)
     end
@@ -702,6 +704,7 @@ local function player_created(event)
             name = main_button_name,
             sprite = 'entity/character',
             tooltip = {'player_list.tooltip'},
+            auto_toggle = true,
         }
     )
 end

--- a/features/gui/poll.lua
+++ b/features/gui/poll.lua
@@ -463,6 +463,8 @@ local function toggle(event)
 
     if main_frame then
         remove_main_frame(main_frame, left, event.player)
+        local main_button = Gui.get_top_element(player, main_button_name)
+        main_button.toggled = false
     else
         draw_main_frame(left, event.player)
     end
@@ -855,6 +857,7 @@ local function player_created(event)
             name = main_button_name,
             sprite = 'item/programmable-speaker',
             tooltip = {'poll.tooltip'},
+            auto_toggle = true,
         }
     )
 end

--- a/features/gui/poll.lua
+++ b/features/gui/poll.lua
@@ -458,22 +458,13 @@ end
 
 local function toggle(event)
     local player = event.player
-    local gui = player.gui
-    local left = gui.left
+    local left = Gui.get_left_flow(player)
     local main_frame = left[main_frame_name]
-    local main_button = gui.top[main_button_name]
 
     if main_frame then
         remove_main_frame(main_frame, left, event.player)
-        main_button.style = 'slot_button'
     else
         draw_main_frame(left, event.player)
-
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
     end
 end
 
@@ -691,7 +682,7 @@ local function show_new_poll(poll_data)
         table.concat {poll_data.created_by.name, ' has created a new Poll #', poll_data.id, ': ', poll_data.question}
 
     for _, p in pairs(game.connected_players) do
-        local left = p.gui.left
+        local left = Gui.get_left_flow(p)
         local frame = left[main_frame_name]
         if no_notify_players[p.index] then
             if frame and frame.valid then
@@ -820,7 +811,7 @@ local function vote(event)
     local vote_button_count, vote_button_tooltip = update_vote(voters, answer, 1)
 
     for _, p in pairs(game.connected_players) do
-        local frame = p.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(p, main_frame_name)
         if frame and frame.valid then
             local data = Gui.get_data(frame)
 
@@ -858,12 +849,12 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add(
+    Gui.add_top_element(player,
         {
             type = 'sprite-button',
             name = main_button_name,
             sprite = 'item/programmable-speaker',
-            tooltip = {'poll.tooltip'}
+            tooltip = {'poll.tooltip'},
         }
     )
 end
@@ -874,7 +865,7 @@ local function player_joined(event)
         return
     end
 
-    local frame = player.gui.left[main_frame_name]
+    local frame = Gui.get_left_element(player, main_frame_name)
     if frame and frame.valid then
         local data = Gui.get_data(frame)
         update_poll_viewer(data)
@@ -883,7 +874,7 @@ end
 
 local function tick()
     for _, p in pairs(game.connected_players) do
-        local frame = p.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(p, main_frame_name)
         if frame and frame.valid then
             local data = Gui.get_data(frame)
             local poll = polls[data.poll_index]
@@ -925,7 +916,7 @@ Gui.on_click(
     create_poll_button_name,
     function(event)
         local player = event.player
-        local left = player.gui.left
+        local left = Gui.get_left_flow(player)
         local frame = left[create_poll_frame_name]
         if frame and frame.valid then
             remove_create_poll_frame(frame, player.index)
@@ -939,7 +930,7 @@ Gui.on_click(
     poll_view_edit_name,
     function(event)
         local player = event.player
-        local left = player.gui.left
+        local left = Gui.get_left_flow(player)
         local frame = left[create_poll_frame_name]
 
         if frame and frame.valid then
@@ -1076,7 +1067,7 @@ Gui.on_click(
                 p.print(message)
             end
 
-            local main_frame = p.gui.left[main_frame_name]
+            local main_frame = Gui.get_left_element(player, main_frame_name)
             if main_frame and main_frame.valid then
                 local main_frame_data = Gui.get_data(main_frame)
                 local poll_index = main_frame_data.poll_index
@@ -1183,7 +1174,8 @@ Gui.on_click(
         local message = table.concat {player.name, ' has edited Poll #', poll.id, ': ', poll.question}
 
         for _, p in pairs(game.connected_players) do
-            local main_frame = p.gui.left[main_frame_name]
+            local left = Gui.get_left_flow(p)
+            local main_frame = left[main_frame_name]
 
             if no_notify_players[p.index] then
                 if main_frame and main_frame.valid then
@@ -1197,7 +1189,7 @@ Gui.on_click(
                     main_frame_data.poll_index = poll_index
                     update_poll_viewer(main_frame_data)
                 else
-                    draw_main_frame(p.gui.left, p)
+                    draw_main_frame(left, p)
                 end
             end
         end
@@ -1286,7 +1278,7 @@ Event.add(
 
         no_notify_players[player_index] = no_notify
 
-        local frame = player.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(player, main_frame_name)
         if not frame then
             return
         end

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -11,18 +11,13 @@ local main_frame_name = Gui.uid_name()
 
 local Public = {}
 
-local function close_main_frame(frame, player)
-    Gui.destroy(frame)
-    player.gui.top[main_button_name].style = 'slot_button'
-end
-
 local function player_created(event)
     local player = game.get_player(event.player_index)
     if not player or not player.valid then
         return
     end
 
-    player.gui.top.add(
+    Gui.add_top_element(player,
         {
             type = 'sprite-button',
             name = main_button_name,
@@ -41,7 +36,7 @@ local function player_joined(event)
     local main_frame = player.gui.center[main_frame_name]
 
     if main_frame and main_frame.valid then
-        close_main_frame(main_frame, player)
+        Gui.destroy(main_frame)
     end
 end
 
@@ -180,18 +175,11 @@ local function toggle(event)
     local gui = player.gui
     local center = gui.center
     local main_frame = center[main_frame_name]
-    local main_button = gui.top[main_button_name]
 
     if main_frame then
-        close_main_frame(main_frame, player)
+        Gui.destroy(main_frame)
     else
         draw_main_frame(center, player)
-
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
     end
 end
 
@@ -239,7 +227,7 @@ local function save_changes(event)
     local main_frame = player.gui.center[main_frame_name]
 
     if main_frame then
-        close_main_frame(main_frame, player)
+        Gui.destroy(main_frame)
     end
 end
 
@@ -282,7 +270,7 @@ end
 Gui.on_custom_close(
     main_frame_name,
     function(event)
-        close_main_frame(event.element, event.player)
+        Gui.destroy(event.element)
     end
 )
 

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -175,11 +175,15 @@ local function toggle(event)
     local gui = player.gui
     local center = gui.center
     local main_frame = center[main_frame_name]
+    local main_button = Gui.get_top_element(player, main_button_name)
+
 
     if main_frame then
+        main_button.toggled = false
         Gui.destroy(main_frame)
     else
         draw_main_frame(center, player)
+        main_button.toggled = true
     end
 end
 
@@ -229,6 +233,9 @@ local function save_changes(event)
     if main_frame then
         Gui.destroy(main_frame)
     end
+
+    local main_button = Gui.get_top_element(player, main_button_name)
+    main_button.toggled = false
 end
 
 local function setting_set(event)

--- a/features/gui/score.lua
+++ b/features/gui/score.lua
@@ -3,6 +3,7 @@ local Event = require 'utils.event'
 local Token = require 'utils.token'
 local Schedule = require 'utils.task'
 local Gui = require 'utils.gui'
+local Styles = require 'resources.styles'
 local Color = require 'resources.color_presets'
 local Server = require 'features.server'
 local ScoreTracker = require 'utils.score_tracker'
@@ -107,9 +108,14 @@ end
 
 local function score_show(top)
     local scores = get_global_score_labels()
-    local frame = top.add { type = 'frame', name = main_frame_name, style = 'finished_game_subheader_frame' }
+    local frame = top.add {
+        type = 'frame',
+        name = main_frame_name,
+        style = 'finished_game_subheader_frame',
+        index = top[main_button_name].get_index_in_parent() + 1
+    }
     frame.location = { x = 1, y = 38 }
-	Gui.set_style(frame, { minimal_height = 36, maximal_height = 36 })
+	Gui.set_style(frame, { natural_height = Styles.default_top_element.style.minimal_height, height = Styles.default_top_element.style.minimal_height })
 
     local score_table = frame.add {type = 'table', name = 'score_table', column_count = table_size(scores)}
     local style = score_table.style

--- a/features/gui/score.lua
+++ b/features/gui/score.lua
@@ -51,7 +51,7 @@ local do_redraw_score =
 
         for i = 1, #players do
             local player = players[i]
-            local frame = player.gui.top[main_frame_name]
+            local frame = Gui.get_top_element(player, main_frame_name)
 
             if frame and frame.valid then
                 local score_table = frame.score_table
@@ -88,7 +88,7 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add(
+    Gui.add_top_element(player,
         {
             type = 'sprite-button',
             name = main_button_name,
@@ -106,8 +106,11 @@ end
 
 local function score_show(top)
     local scores = get_global_score_labels()
-    local frame = top.add {type = 'frame', name = main_frame_name}
-    local score_table = frame.add {type = 'table', name = 'score_table', column_count = 8}
+    local frame = top.add { type = 'frame', name = main_frame_name, style = 'finished_game_subheader_frame' }
+    frame.location = { x = 1, y = 38 }
+	Gui.set_style(frame, { minimal_height = 36, maximal_height = 36 })
+
+    local score_table = frame.add {type = 'table', name = 'score_table', column_count = table_size(scores)}
     local style = score_table.style
     style.vertical_spacing = 4
     style.horizontal_spacing = 16
@@ -158,21 +161,13 @@ Gui.on_click(
     main_button_name,
     function(event)
         local player = event.player
-        local top = player.gui.top
+        local top = Gui.get_top_flow(player)
         local frame = top[main_frame_name]
-        local main_button = top[main_button_name]
 
         if not frame then
             score_show(top)
-
-            main_button.style = 'highlighted_tool_button'
-            local style = main_button.style
-            style.width = 40
-            style.height = 40
-            style.padding = 0
         else
             frame.destroy()
-            main_button.style = 'slot_button'
         end
     end
 )

--- a/features/gui/score.lua
+++ b/features/gui/score.lua
@@ -93,7 +93,8 @@ local function player_created(event)
             type = 'sprite-button',
             name = main_button_name,
             sprite = get_score_sprite(),
-            tooltip = {'score.tooltip'}
+            tooltip = {'score.tooltip'},
+            auto_toggle = true,
         }
     )
 end

--- a/features/gui/tag_group.lua
+++ b/features/gui/tag_group.lua
@@ -147,7 +147,8 @@ local function player_created(event)
             name = main_button_name,
             type = 'sprite-button',
             caption = 'tag',
-            tooltip = {'tag_group.tooltip'}
+            tooltip = {'tag_group.tooltip'},
+            auto_toggle = true,
         }
     )
 end
@@ -306,6 +307,8 @@ local function toggle(event)
 
     if main_frame then
         Gui.destroy(main_frame)
+        local main_button = Gui.get_top_element(player, main_button_name)
+        main_button.toggled = false
     else
         draw_main_frame(event.player)
     end

--- a/features/gui/tag_group.lua
+++ b/features/gui/tag_group.lua
@@ -142,7 +142,7 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add(
+    Gui.add_top_element(player,
         {
             name = main_button_name,
             type = 'sprite-button',
@@ -219,14 +219,12 @@ local function draw_main_frame_content(parent)
 end
 
 local function draw_main_frame(player)
-    local left = player.gui.left
-    local main_frame =
-        left.add {
+    local main_frame = Gui.add_left_element(player, {
         type = 'frame',
         name = main_frame_name,
         caption = {'tag_group.choose_your_tag'},
         direction = 'vertical'
-    }
+    })
 
     main_frame.style.maximal_height = 500
     main_frame.style.maximal_width = 500
@@ -276,7 +274,7 @@ end
 
 local function redraw_main_frame()
     for _, p in pairs(game.players) do
-        local main_frame = p.gui.left[main_frame_name]
+        local main_frame = Gui.get_left_element(p, main_frame_name)
         if main_frame and main_frame.valid then
             local content = main_frame[main_frame_content_name]
 
@@ -291,7 +289,7 @@ local function redraw_main_frame()
 end
 
 local function redraw_main_button(player, path)
-    local main_button = player.gui.top[main_button_name]
+    local main_button = Gui.get_top_element(player, main_button_name)
 
     if path == '' or path == nil then
         main_button.sprite = 'utility/pump_cannot_connect_icon'
@@ -304,22 +302,12 @@ end
 
 local function toggle(event)
     local player = event.player
-    local gui = player.gui
-    local left = gui.left
-    local main_frame = left[main_frame_name]
-    local main_button = gui.top[main_button_name]
+    local main_frame = Gui.get_left_element(player, main_frame_name)
 
     if main_frame then
         Gui.destroy(main_frame)
-        main_button.style = 'slot_button'
     else
         draw_main_frame(event.player)
-
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
     end
 end
 
@@ -772,7 +760,7 @@ Event.add(
 
         no_notify_players[player_index] = no_notify
 
-        local frame = player.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(player, main_frame_name)
         if not frame then
             return
         end

--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -211,7 +211,7 @@ local function update_volunteer_button(button, task)
 end
 
 local function update_top_gui(player)
-    local button = player.gui.top[main_button_name]
+    local button = Gui.get_top_element(player, main_button_name)
     if button and button.valid then
         button.number = #tasks or 0
     end
@@ -444,10 +444,8 @@ end
 
 local function toggle(event)
     local player = event.player
-    local gui = player.gui
-    local left = gui.left
+    local left = Gui.get_left_flow(player)
     local frame = left[main_frame_name]
-    local main_button = gui.top[main_button_name]
 
     if frame and frame.valid then
         Gui.destroy(frame)
@@ -459,16 +457,8 @@ local function toggle(event)
         if frame and frame.valid then
             Gui.destroy(frame)
         end
-
-        main_button.style = 'slot_button'
     else
         draw_main_frame(left, player)
-
-        main_button.style = 'highlighted_tool_button'
-        local style = main_button.style
-        style.width = 40
-        style.height = 40
-        style.padding = 0
     end
 end
 
@@ -513,7 +503,7 @@ local function update_announcements(player)
             p.print(update_message)
         end
 
-        local left = p.gui.left
+        local left = Gui.get_left_flow(p)
         local frame = left[main_frame_name]
         if frame and frame.valid then
             local data = Gui.get_data(frame)
@@ -558,7 +548,7 @@ local function create_new_tasks(task_name, player)
 
     for _, p in ipairs(game.connected_players) do
         local notify = not no_notify_players[p.index]
-        local left = p.gui.left
+        local left = Gui.get_left_flow(p)
         local frame = left[main_frame_name]
         if frame and frame.valid then
             local frame_data = Gui.get_data(frame)
@@ -624,7 +614,7 @@ local function player_created(event)
         return
     end
 
-    player.gui.top.add(
+    Gui.add_top_element(player,
         {
             type = 'sprite-button',
             name = main_button_name,
@@ -641,7 +631,7 @@ local function player_joined(event)
         return
     end
 
-    local frame = player.gui.left[main_frame_name]
+    local frame = Gui.get_left_element(player, main_frame_name)
     if frame and frame.valid then
         local text = announcements.edit_text
         local last_edit_message = get_announcements_updated_by_message()
@@ -661,7 +651,7 @@ local function player_joined(event)
     local tasks_for_player = player_tasks[player.index]
     if tasks_for_player and next(tasks_for_player) then
         for _, p in ipairs(game.connected_players) do
-            local main_frame = p.gui.left[main_frame_name]
+            local main_frame = Gui.get_left_element(p, main_frame_name)
             if main_frame then
                 local data = Gui.get_data(main_frame)
                 local volunteer_buttons = data.volunteer_buttons
@@ -676,9 +666,10 @@ end
 
 local function player_left(event)
     local player = game.get_player(event.player_index)
-    local left = player.gui.left
-
-    local frame = left[edit_announcements_frame_name]
+    if not (player and player.valid) then
+        return
+    end
+    local frame = Gui.get_left_element(player, edit_announcements_frame_name)
     if frame and frame.valid then
         close_edit_announcements_frame(frame)
     end
@@ -686,8 +677,7 @@ end
 
 local function on_tick()
     for _, p in ipairs(game.connected_players) do
-        local left = p.gui.left
-        local frame = left[main_frame_name]
+        local frame = Gui.get_left_element(p, main_frame_name)
 
         if frame then
             local data = Gui.get_data(frame)
@@ -715,22 +705,20 @@ Gui.on_click(
     announcements_edit_button_name,
     function(event)
         local player = event.player
-        local left = player.gui.left
 
-        local frame = left[edit_announcements_frame_name]
+        local frame = Gui.get_left_element(player, edit_announcements_frame_name)
         if frame then
             return
         end
 
         local data = {}
 
-        frame =
-            left.add {
+        frame = Gui.add_left_element(player, {
             type = 'frame',
             name = edit_announcements_frame_name,
             caption = 'Edit Announcements',
             direction = 'vertical'
-        }
+        })
         frame.style.width = 470
 
         Gui.set_data(frame, data)
@@ -871,7 +859,7 @@ Gui.on_click(
 
         for _, p in ipairs(game.connected_players) do
             local notify = not no_notify_players[p.index]
-            local left = p.gui.left
+            local left = Gui.get_left_flow(p)
             local frame = left[main_frame_name]
             if frame and frame.valid then
                 local data = Gui.get_data(frame)
@@ -894,7 +882,7 @@ Gui.on_click(
     edit_task_button_name,
     function(event)
         local previous_task = Gui.get_data(event.element)
-        local left = event.player.gui.left
+        local left = Gui.get_left_flow(event.player)
         local frame = left[create_task_frame_name]
 
         if frame then
@@ -929,7 +917,7 @@ local function do_direction(event, sign)
     table.insert(tasks, new_index, task)
 
     for _, p in ipairs(game.connected_players) do
-        local frame = p.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(p, main_frame_name)
         if frame and frame.valid then
             local data = Gui.get_data(frame)
             local enabled = Rank.equal_or_greater_than(p.name, Ranks.regular)
@@ -980,7 +968,7 @@ Gui.on_click(
         end
 
         for _, p in ipairs(game.connected_players) do
-            local frame = p.gui.left[main_frame_name]
+            local frame = Gui.get_left_element(p, main_frame_name)
             if frame and frame.valid then
                 local data = Gui.get_data(frame)
                 local volunteer_buttons = data.volunteer_buttons
@@ -994,7 +982,7 @@ Gui.on_click(
 Gui.on_click(
     add_task_button_name,
     function(event)
-        local left = event.player.gui.left
+        local left = Gui.get_left_flow(event.player)
         local frame = left[create_task_frame_name]
 
         if frame then
@@ -1105,7 +1093,7 @@ Gui.on_click(
 
         for _, p in ipairs(game.connected_players) do
             local notify = not no_notify_players[p.index]
-            local left = p.gui.left
+            local left = Gui.get_left_flow(p)
             local main_frame = left[main_frame_name]
 
             if main_frame then
@@ -1150,7 +1138,7 @@ Event.add(
 
         no_notify_players[player_index] = no_notify
 
-        local frame = player.gui.left[main_frame_name]
+        local frame = Gui.get_left_element(player, main_frame_name)
         if not frame then
             return
         end

--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -457,6 +457,8 @@ local function toggle(event)
         if frame and frame.valid then
             Gui.destroy(frame)
         end
+        local main_button = Gui.get_top_element(player, main_button_name)
+        main_button.toggled = false
     else
         draw_main_frame(left, player)
     end
@@ -621,6 +623,7 @@ local function player_created(event)
             sprite = 'item/repair-pack',
             tooltip = {'tasklist.tooltip'},
             number = #tasks or 0,
+            auto_toggle = true,
         }
     )
 end

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -31,6 +31,7 @@ Global.register(
     'toast'
 )
 
+local toast_flow_name = Gui.uid_name()
 local toast_frame_name = Gui.uid_name()
 local toast_container_name = Gui.uid_name()
 local toast_progress_name = Gui.uid_name()
@@ -80,7 +81,7 @@ end
 ---@param duration number in seconds
 ---@param sound string sound to play, nil to not play anything
 local function toast_to(player, duration, sound)
-    local frame_holder = player.gui.left.add({type = 'flow'})
+    local frame_holder = Gui.add_left_element(player, { type = 'flow', name = toast_flow_name })
 
     local frame =
         frame_holder.add({type = 'frame', name = toast_frame_name, direction = 'vertical', style = 'captionless_frame'})

--- a/features/player_create.lua
+++ b/features/player_create.lua
@@ -43,11 +43,6 @@ local function player_created(event)
         return
     end
 
-    -- ensure the top menu is correctly styled
-    local gui = player.gui
-    gui.top.style = 'slot_table_spacing_horizontal_flow'
-    gui.left.style = 'slot_table_spacing_vertical_flow'
-
     if not config.cutscene then
         Public.show_start_up(player)
     end

--- a/features/snake/gui.lua
+++ b/features/snake/gui.lua
@@ -11,10 +11,11 @@ local function show_gui_for_player(player)
         return
     end
 
-    local top = player.gui.top
-    if not top[main_button_name] then
-        top.add {type = 'button', name = main_button_name, caption = {'snake.name'}}
-    end
+    Gui.get_top_element(player, {
+        type = 'button',
+        name = main_button_name,
+        caption = {'snake.name'}
+    })
 end
 
 local function player_created(event)
@@ -34,7 +35,7 @@ end
 
 function Public.destroy()
     for _, player in pairs(game.players) do
-        local button = player.gui.top[main_button_name]
+        local button = Gui.get_top_element(player, main_button_name)
         if button and button.valid then
             button.destroy()
         end

--- a/features/snake/gui.lua
+++ b/features/snake/gui.lua
@@ -11,7 +11,7 @@ local function show_gui_for_player(player)
         return
     end
 
-    Gui.get_top_element(player, {
+    Gui.add_top_element(player, {
         type = 'button',
         name = main_button_name,
         caption = {'snake.name'}

--- a/map_gen/maps/diggy/feature/experience.lua
+++ b/map_gen/maps/diggy/feature/experience.lua
@@ -495,6 +495,10 @@ function Experience.toggle(event)
 
     if (frame and event.trigger == nil) then
         Gui.destroy(frame)
+        local main_button = Gui.get_top_element(player, 'Diggy.Experience.Button')
+        if main_button then
+            main_button.toggled = false
+        end
         return
     elseif (frame) then
         local data = Gui.get_data(frame)
@@ -548,7 +552,8 @@ local function on_player_created(event)
             name = 'Diggy.Experience.Button',
             type = 'sprite-button',
             sprite = 'entity/market',
-            tooltip = {'diggy.gui_experience_button_tip'}
+            tooltip = {'diggy.gui_experience_button_tip'},
+            auto_toggle = true,
         }
     )
 end

--- a/map_gen/maps/diggy/feature/experience.lua
+++ b/map_gen/maps/diggy/feature/experience.lua
@@ -491,14 +491,10 @@ end
 
 function Experience.toggle(event)
     local player = event.player
-    local gui = player.gui
-    local left = gui.left
-    local frame = left['Diggy.Experience.Frame']
-    local main_button = gui.top['Diggy.Experience.Button']
+    local frame = Gui.get_left_element(player, 'Diggy.Experience.Frame')
 
     if (frame and event.trigger == nil) then
         Gui.destroy(frame)
-        main_button.style = 'slot_button'
         return
     elseif (frame) then
         local data = Gui.get_data(frame)
@@ -508,13 +504,7 @@ function Experience.toggle(event)
         return
     end
 
-    main_button.style = 'highlighted_tool_button'
-    local style = main_button.style
-    style.width = 40
-    style.height = 40
-    style.padding = 0
-
-    frame = left.add({name = 'Diggy.Experience.Frame', type = 'frame', direction = 'vertical'})
+    frame = Gui.add_left_element(player, {name = 'Diggy.Experience.Frame', type = 'frame', direction = 'vertical'})
 
     local experience_progressbars = frame.add({type = 'flow', direction = 'vertical'})
     local experience_list_heading = frame.add({type = 'flow', direction = 'horizontal'})
@@ -548,7 +538,12 @@ function Experience.toggle(event)
 end
 
 local function on_player_created(event)
-    game.get_player(event.player_index).gui.top.add(
+    local player= game.get_player(event.player_index)
+    if not (player and player.valid) then
+        return
+    end
+
+    Gui.add_top_element(player,
         {
             name = 'Diggy.Experience.Button',
             type = 'sprite-button',
@@ -573,7 +568,7 @@ local function update_gui()
     local players = game.connected_players
     for i = #players, 1, -1 do
         local p = players[i]
-        local frame = p.gui.left['Diggy.Experience.Frame']
+        local frame = Gui.get_left_element(p, 'Diggy.Experience.Frame')
 
         if frame and frame.valid then
             local data = {player = p, trigger = 'update_gui'}

--- a/map_gen/maps/quadrants/switch_team.lua
+++ b/map_gen/maps/quadrants/switch_team.lua
@@ -160,7 +160,7 @@ end
 
 local function toggle(event)
     local player = event.player
-    local left = player.gui.left
+    local left = Gui.get_left_flow(player)
     local frame = left['Quadrants.Switch_Team']
 
     if (frame and event.trigger == nil) then
@@ -238,7 +238,7 @@ local function update_gui(force_update)
     local players = game.connected_players
     for i = #players, 1, -1 do
         local p = players[i]
-        local frame = p.gui.left['Quadrants.Switch_Team']
+        local frame = Gui.get_left_element(p, 'Quadrants.Switch_Team')
         local data = {player = p}
 
         if frame and frame.valid and (abs(p.position.x) >= 160 or abs(p.position.y) >= 160) then

--- a/map_gen/maps/tetris/view.lua
+++ b/map_gen/maps/tetris/view.lua
@@ -30,7 +30,7 @@ local button_pretty_names = {
 
 local sprites = {
     [uids.ccw_button] = 'utility/reset',
-    [uids.noop_button] = 'utility/clear',
+    [uids.noop_button] = 'utility/close_fat',
     [uids.cw_button] = 'utility/reset',
     [uids.left_button] = 'utility/left_arrow',
     [uids.down_button] = 'utility/speed_down',
@@ -114,19 +114,17 @@ local function toggle(player)
     if not player then
         return
     end
-    local left = player.gui.left
-    local main_frame = left[main_frame_name]
+    local main_frame = Gui.get_left_element(player, main_frame_name)
 
     if main_frame and main_frame.valid then
         Gui.destroy(main_frame)
     else
-        main_frame =
-            left.add {
+        main_frame = Gui.add_left_element(player, {
             type = 'frame',
             name = main_frame_name,
             direction = 'vertical',
             caption = 'Tetris'
-        }
+        })
         main_frame.style.width = 250
         main_frame.add {
             type = 'label',
@@ -189,13 +187,16 @@ end
 
 local function player_joined(event)
     local player = game.get_player(event.player_index)
-
-    if player.gui.top[main_button_name] ~= nil then
+    if not (player and player.valid) then
         return
     end
 
-    player.gui.top.add {name = main_button_name, type = 'sprite-button', sprite = 'utility/force_editor_icon'}
-    toggle(game.get_player(event.player_index))
+    if Gui.get_top_element(player, main_button_name) ~= nil then
+        return
+    end
+
+    Gui.add_top_element(player, { name = main_button_name, type = 'sprite-button', sprite = 'utility/force_editor_icon' })
+    toggle(player)
 end
 
 Gui.on_click(
@@ -219,7 +220,7 @@ end
 function Module.set_points(points)
     primitives.points = points
     for _, player in pairs(game.players) do
-        local mf = player.gui.left[main_frame_name]
+        local mf = Gui.get_left_element(player, main_frame_name)
         if mf then
             local data = Gui.get_data(mf)
             if data then
@@ -242,7 +243,7 @@ end
 -- @param vote_button_id string the uid of the button that the players name will be added to
 -- @param[opt] old_vote_button_id string the uid of the button that the players name will be removed from
 function Module.set_player_vote(player, vote_button_id, old_vote_button_id)
-    local mf = player.gui.left[main_frame_name]
+    local mf = Gui.get_left_element(player, main_frame_name)
     if mf then
         local vote_buttons = Gui.get_data(mf).vote_buttons
         if vote_button_id then
@@ -266,7 +267,7 @@ end
 function Module.enable_vote_buttons(enable)
     primitives.buttons_enabled = enable
     for _, player in pairs(game.players) do
-        local mf = player.gui.left[main_frame_name]
+        local mf = Gui.get_left_element(player, main_frame_name)
         if mf then
             local data = Gui.get_data(mf)
             if data then
@@ -302,7 +303,7 @@ end
 function Module.set_progress(progress)
     primitives.progress = progress
     for _, player in pairs(game.players) do
-        local mf = player.gui.left[main_frame_name]
+        local mf = Gui.get_left_element(player, main_frame_name)
         if mf then
             local data = Gui.get_data(mf)
             if data then

--- a/resources/styles.lua
+++ b/resources/styles.lua
@@ -11,8 +11,8 @@ Public.default_top_element = {
     style = {
         font_color = { 165, 165, 165 },
         font = 'heading-3',
-        minimal_height = 36,
-        maximal_height = 36,
+        minimal_height = 40,
+        maximal_height = 40,
         minimal_width = 40,
         padding = -2,
     }

--- a/resources/styles.lua
+++ b/resources/styles.lua
@@ -6,4 +6,34 @@ function Public.default_close(style)
     style.font_color = {0, 0, 0}
 end
 
+Public.default_top_element = {
+    name = 'side_menu_button',
+    style = {
+        font_color = { 165, 165, 165 },
+        font = 'heading-3',
+        minimal_height = 36,
+        maximal_height = 36,
+        minimal_width = 40,
+        padding = -2,
+    }
+}
+
+Public.default_left_element = {
+    style = {
+        padding = 2,
+        font_color = { 165, 165, 165 },
+        font = 'heading-3',
+        use_header_filler = false
+    }
+}
+
+Public.default_pusher = {
+    style = {
+        top_margin = 0,
+        bottom_margin = 0,
+        left_margin = 0,
+        right_margin = 0,
+    }
+}
+
 return Public

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -2,6 +2,11 @@ local Token = require 'utils.token'
 local Event = require 'utils.event'
 local Global = require 'utils.global'
 local Styles = require 'resources.styles'
+local mod_gui = require '__core__.lualib.mod-gui'
+--[[
+    player.gui.top.mod_gui_top_frame.mod_gui_inner_frame[element_name]
+    player.gui.left.mod_gui_frame_flow[element_name]
+]]
 
 local tostring = tostring
 local next = next
@@ -70,6 +75,20 @@ function Gui.get_data(element)
     return values[element.index]
 end
 
+---@param element LuaGuiElement
+---@param style string|table
+function Gui.set_style(element, style)
+    if type(style) == string then
+        element.style = style
+    else
+        local element_style = element.style
+        for k, v in pairs(style) do
+            element_style[k] = v
+        end
+    end
+    return element
+end
+
 local remove_data_recursively
 -- Removes data associated with LuaGuiElement and its children recursively.
 function Gui.remove_data_recursively(element)
@@ -114,6 +133,85 @@ end
 function Gui.clear(element)
     remove_children_data(element)
     element.clear()
+end
+
+---@param player LuaPlayer
+function Gui.init_gui_style(player)
+    local mod_gui_top_frame = Gui.get_top_flow(player).parent
+    Gui.set_style(mod_gui_top_frame, { padding = 2 })
+end
+
+---@param player LuaPlayer
+---@return LuaGuiElement
+function Gui.get_top_flow(player)
+    return mod_gui.get_button_flow(player)
+end
+
+---@param player LuaPlayer
+---@param element_name string
+---@return LuaGuiElement?
+function Gui.get_top_element(player, element_name)
+	return Gui.get_top_flow(player)[element_name]
+end
+
+---@param player LuaPlayer
+---@param child table
+---@return LuaGuiElement
+function Gui.add_top_element(player, child)
+    local flow = Gui.get_top_flow(player)
+    local element = flow[child.name]
+	if element and element.valid then
+        return element
+	end
+	if (child.type == 'button' or child.type == 'sprite-button') and child.style == nil then
+        child.style = Styles.default_top_element.name
+        return Gui.set_style(flow.add(child), Styles.default_top_element.style)
+    else
+        return flow.add(child)
+	end
+end
+
+---@param player LuaPlayer
+function Gui.get_left_flow(player)
+    return mod_gui.get_frame_flow(player)
+end
+
+---@param player LuaPlayer
+---@param element_name string
+---@return LuaGuiElement?
+function Gui.get_left_element(player, element_name)
+    return Gui.get_left_flow(player)[element_name]
+end
+
+---@param player LuaPlayer
+---@param child table
+---@return LuaGuiElement
+function Gui.add_left_element(player, child)
+    local flow = Gui.get_left_flow(player)
+    local element = flow[child.name]
+    if element and element.valid then
+        return element
+    end
+    if child.type == 'frame' and child.style == nil then
+        return Gui.set_style(flow.add(child), Styles.default_left_element.style)
+    else
+        return flow.add(child)
+    end
+end
+
+---@param parent LuaGuiElement
+---@param direction? string, default: horizontal
+---@return LuaGuiElement
+function Gui.add_pusher(parent, direction)
+    local pusher = parent.add { type = 'empty-widget' }
+    Gui.set_style(pusher, Styles.default_pusher.style)
+    pusher.ignored_by_interaction = true
+    if direction == 'vertical' then
+        pusher.style.vertically_stretchable = true
+    else
+        pusher.style.horizontally_stretchable = true
+    end
+    return pusher
 end
 
 local function handler_factory(event_id)
@@ -242,21 +340,24 @@ Event.add(
             return
         end
 
-        local b =
-            player.gui.top.add {
+        Gui.init_gui_style(player)
+
+        local b = Gui.add_top_element(player, {
             type = 'button',
             name = toggle_button_name,
             caption = '<',
             tooltip = {'gui_util.button_tooltip'}
-        }
-        local style = b.style
-        style.width = 18
-        style.height = 40
-        style.left_padding = 0
-        style.top_padding = 0
-        style.right_padding = 0
-        style.bottom_padding = 0
-        style.font = 'default-small-bold'
+        })
+
+        Gui.set_style(b, {
+            width = 18,
+            height = 36,
+            left_padding = 0,
+            top_padding = 0,
+            right_padding = 0,
+            bottom_padding = 0,
+            font = 'default-small-bold',
+        })
     end
 )
 
@@ -265,7 +366,7 @@ Gui.on_click(
     function(event)
         local button = event.element
         local player = event.player
-        local top = player.gui.top
+        local top = Gui.get_top_flow(player)
 
         if button.caption == '<' then
             for i = 1, #top_elements do
@@ -280,7 +381,7 @@ Gui.on_click(
             end
 
             button.caption = '>'
-            button.style.height = 24
+            --button.style.height = 24
         else
             for i = 1, #top_elements do
                 local name = top_elements[i]
@@ -294,7 +395,7 @@ Gui.on_click(
             end
 
             button.caption = '<'
-            button.style.height = 38
+            --button.style.height = 38
         end
     end
 )

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -381,7 +381,6 @@ Gui.on_click(
             end
 
             button.caption = '>'
-            --button.style.height = 24
         else
             for i = 1, #top_elements do
                 local name = top_elements[i]
@@ -395,7 +394,6 @@ Gui.on_click(
             end
 
             button.caption = '<'
-            --button.style.height = 38
         end
     end
 )

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -351,7 +351,7 @@ Event.add(
 
         Gui.set_style(b, {
             width = 18,
-            height = 36,
+            height = Styles.default_top_element.style.minimal_height,
             left_padding = 0,
             top_padding = 0,
             right_padding = 0,

--- a/utils/gui_tests.lua
+++ b/utils/gui_tests.lua
@@ -11,12 +11,21 @@ Declare.module({'utils', 'Gui'}, function()
             return #Gui.get_top_flow(player).children + #Gui.get_left_flow(player).children + #player.gui.center.children
         end
 
+        local function is_ignored_element(element)
+            local tooltip = element.tooltip
+            if type(tooltip) == 'table' and tooltip[1] == 'evolution_progress.tooltip' then
+                return true
+            end
+
+            return false
+        end
+
         for _, name in pairs(Gui._top_elements) do
             Declare.test(Gui.names and Gui.names[name] or name, function(context)
                 local player = context.player
-                local element = player.gui.top[name]
+                local element = Gui.get_top_flow(player)[name]
 
-                if not element.enabled then
+                if not element.enabled or is_ignored_element(element) then
                     return
                 end
 

--- a/utils/gui_tests.lua
+++ b/utils/gui_tests.lua
@@ -5,8 +5,10 @@ local Helper = require 'utils.test.helper'
 
 Declare.module({'utils', 'Gui'}, function()
     Declare.module('can toggle top buttons', function()
-        local function count_gui_elements(gui)
-            return #gui.top.children + #gui.left.children + #gui.center.children
+        local function count_gui_elements(player)
+            -- local gui = player.gui
+            -- return #gui.top.children + #gui.left.children + #gui.center.children
+            return #Gui.get_top_flow(player).children + #Gui.get_left_flow(player).children + #player.gui.center.children
         end
 
         for _, name in pairs(Gui._top_elements) do
@@ -22,16 +24,16 @@ Declare.module({'utils', 'Gui'}, function()
                     Helper.click(element)
                 end
 
-                local before_count = count_gui_elements(player.gui)
+                local before_count = count_gui_elements(player)
 
                 -- Open
                 click_action()
-                local after_open_count = count_gui_elements(player.gui)
+                local after_open_count = count_gui_elements(player)
                 Assert.is_true(after_open_count > before_count, 'after open count should be greater than before count.')
 
                 -- Close
                 context:next(click_action):next(function()
-                    local after_close_count = count_gui_elements(player.gui)
+                    local after_close_count = count_gui_elements(player)
                     Assert.equal(before_count, after_close_count, 'after close count should be equal to before count.')
                 end)
             end)


### PR DESCRIPTION
# Description
Base game offers `core/mod-gui.lua` as a collective system to register buttons and frames in `gui.top` and `gui.left`. I think it looks cleaner overall so I took the chance to renovate the whole look (note: for the theme, we could also switch to light mode and have light-grey buttons over the darker background, but I think this looks more up-to-date...)

# Migration
`mod-gui` adds a few more nested GuiElements, so

I. `gui.left` -> `gui.left.mod_gui_frame_flow`
II. `gui.top` -> `gui.top.mod_gui_top_frame.mod_gui_inner_frame`

overall, the lib itself takes care of ensuring that those children are always present when adding to them, so our `utils/gui.lua` lib simply relies on it and replaces all instances of `player.gui.top[element_name]` with `Gui.get_top_element(element_name)` (same for left, both with `get` and `add` methods).

> To get the "new actual" `gui.top` element, `Gui.get_top_flow(player)` is used instead (same for left).
> The new system requires the top-level-child to have a name when adding to mod-gui, so I've added UIDs to those few flows that didnt have it

# Changes
- [x] new left flow is now horizontally instead of vertical
- [x] changed `utils/gui.lua` lib and added default styles for all top/left elements
- [x] changed all top buttons (and score frame) to new system
- [x] top buttons do not change button style to "highlighted" version when toggled
- [x] changed all left frames t new system
- [x] changed `gui.test`, in particular

```
local function count_gui_elements(player)
    -- local gui = player.gui
    -- return #gui.top.children + #gui.left.children + #gui.center.children
     return #Gui.get_top_flow(player).children + #Gui.get_left_flow(player).children + #player.gui.center.children
end
```

I hope this maintains the same logic as before? Counting the actual added children? Also `gui.screen` was not present and I did not add, don't know if that was on purpose

- [x] Fixed Tetris map with invalid `utility/clear` sprite 
- [x] Changed cutscene buttons
- [x] Removed top gui restyle from `player_create.lua` and moved to `gui.lua` instead at same event ID

# Test
- [x] I've tested all the common top Gui buttons and their linked left-frame actions
- [x] Tested Quadrant map
- [x] Tested Tetris map
- [x] Tested Crash Site map
- [x] Tested Danger Ores map
- [x] Tested Diggy map

Here's a preview of the changes: I plan to come back and maybe refactor some of the left frames as well to make them more "factorio-like" in the future instead of plain grey windows.

![Screenshot from 2024-08-01 10-55-08](https://github.com/user-attachments/assets/cb3587b6-3d80-4b42-a244-abd264e318ac)
