### PR TITLE
Fix toast gui

### DIFF
--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -83,7 +83,7 @@ end
 local function toast_to(player, duration, sound)
     local frame_holder = Gui.add_left_element(player, { type = 'flow', name = toast_flow_name, direction = 'vertical' })
 
-    local flow_frame = frame_holder.add { type = 'flow', direction = 'vertical' } 
+    local flow_frame = frame_holder.add { type = 'flow', direction = 'vertical' }
 
     local frame =
         flow_frame.add({type = 'frame', name = toast_frame_name, direction = 'vertical', style = 'captionless_frame'})

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -81,10 +81,12 @@ end
 ---@param duration number in seconds
 ---@param sound string sound to play, nil to not play anything
 local function toast_to(player, duration, sound)
-    local frame_holder = Gui.add_left_element(player, { type = 'flow', name = toast_flow_name })
+    local frame_holder = Gui.add_left_element(player, { type = 'flow', name = toast_flow_name, direction = 'vertical' })
+
+    local flow_frame = frame_holder.add { type = 'flow', direction = 'vertical' } 
 
     local frame =
-        frame_holder.add({type = 'frame', name = toast_frame_name, direction = 'vertical', style = 'captionless_frame'})
+        flow_frame.add({type = 'frame', name = toast_frame_name, direction = 'vertical', style = 'captionless_frame'})
     frame.style.width = 300
 
     local container = frame.add({type = 'flow', name = toast_container_name, direction = 'horizontal'})
@@ -104,7 +106,7 @@ local function toast_to(player, duration, sound)
     end
 
     Gui.set_data(
-        frame_holder,
+        flow_frame,
         {
             toast_id = id,
             progressbar = progressbar,
@@ -117,7 +119,7 @@ local function toast_to(player, duration, sound)
         Event.add_removable_nth_tick(2, on_tick)
     end
 
-    active_toasts[id] = frame_holder
+    active_toasts[id] = flow_frame
 
     if sound then
         player.play_sound({path = sound, volume_modifier = Settings.get(player.index, toast_volume_name)})


### PR DESCRIPTION
I broke the toast GUI with the GUI update, so here's the fix: needed to double-nest the unique toast frame 2 flows deep otherwise it tries to create a named GuiElement in parent resulting in  error `Gui element with name Redmew_7 already present in the parent element.`

Here's the result after fix, correctly creating unique toast frames in vertical disposition
![Screenshot from 2024-08-12 13-38-43](https://github.com/user-attachments/assets/82fa7b98-5ca2-46b6-9a67-a811ad59c185)
