### PR TITLE
Resolves #1421 and modded train colors

### DIFF
--- a/features/redmew_qol.lua
+++ b/features/redmew_qol.lua
@@ -29,7 +29,7 @@ end)
 --- When placed, locomotives will get a random color
 local random_train_color = Token.register(function(event)
     local entity = event.created_entity
-    if entity and entity.valid and entity.name == 'locomotive' then
+    if entity and entity.valid and entity.type == 'locomotive' then
         entity.color = Utils.random_RGB()
     end
 end)

--- a/features/train_saviour.lua
+++ b/features/train_saviour.lua
@@ -25,7 +25,7 @@ Global.register(saved_players, function(tbl)
     saved_players = tbl
 end)
 
-local train_names = {['locomotive'] = true, ['cargo-wagon'] = true, ['fluid-wagon'] = true, ['artillery-wagon'] = true}
+local train_types = {['locomotive'] = true, ['cargo-wagon'] = true, ['fluid-wagon'] = true, ['artillery-wagon'] = true}
 
 local function save_player(player)
     player.character.health = 1
@@ -44,7 +44,7 @@ local function on_pre_death(event)
         return
     end
 
-    if not train_names[cause.name] then
+    if not train_types[cause.type] then
         return
     end
 


### PR DESCRIPTION
- [x] fixed train savior not working with modded trains (https://github.com/Refactorio/RedMew/issues/1421)
- [x] fixes locomotive random colors not working with modded trains 