### PR TITLE
Fix restart bottlenecks

### DIFF
--- a/map_gen/maps/frontier/modules/market.lua
+++ b/map_gen/maps/frontier/modules/market.lua
@@ -1,9 +1,7 @@
 local math = require 'utils.math'
 local PriceRaffle = require 'features.price_raffle'
-local RS = require 'map_gen.shared.redmew_surface'
 local Table = require 'utils.table'
 local Public = require 'map_gen.maps.frontier.shared.core'
-local this = Public.get()
 local math_ceil = math.ceil
 local math_clamp = math.clamp
 local math_min = math.min
@@ -17,6 +15,7 @@ Market.cheap_items = {}
 Market.expensive_items = {}
 
 do
+  local this = Public.get()
   local market_items = PriceRaffle.get_items_worth()
   for k, _ in pairs(this.banned_items) do
     market_items[k] = nil
@@ -38,6 +37,7 @@ do
 end
 
 function Market.spawn_exchange_market(position)
+  local this = Public.get()
   if position.x < this.left_boundary * 32 + this.wall_width then
     return
   end
@@ -46,7 +46,7 @@ function Market.spawn_exchange_market(position)
     return
   end
 
-  local surface = RS.get_surface()
+  local surface = Public.surface()
   local market = surface.create_entity {
     name = 'market',
     position = position,

--- a/map_gen/maps/frontier/shared/core.lua
+++ b/map_gen/maps/frontier/shared/core.lua
@@ -1,5 +1,6 @@
 local Event = require 'utils.event'
 local Global = require 'utils.global'
+local Queue = require 'utils.queue'
 local RS = require 'map_gen.shared.redmew_surface'
 
 local Public = {}
@@ -21,13 +22,13 @@ Public.PROD_PENALTY = 1.2 * 1.4^5
 local this = {
   rounds = 0,
   -- Map gen
+  chart_queue = Queue.new(),
   silo_starting_x = 1700,
 
   height = 36,              -- in chunks, height of the ribbon world
   left_boundary = 8,        -- in chunks, distance to water body
   right_boundary = 11,      -- in chunks, distance to wall/biter presence
   wall_width = 5,           -- in tiles
-  wall_vulnerability = true,
   rock_richness = 1,        -- how many rocks/chunk
 
   ore_base_quantity = 11,   -- base ore quantity, everything is scaled up from this
@@ -86,14 +87,14 @@ local this = {
   spawn_shop_upgrades = {},
 }
 
-Global.register_init(
-  this,
-  function() this.surface = RS.get_surface() end,
-  function(tbl) this = tbl end
-)
+Global.register(this, function(tbl) this = tbl end)
 
 function Public.get()
   return this
+end
+
+function Public.surface()
+  return RS.get_surface()
 end
 
 return Public

--- a/utils/queue.lua
+++ b/utils/queue.lua
@@ -74,4 +74,11 @@ function Queue.pairs(queue)
     end
 end
 
+function Queue.clear(queue)
+    for k, _ in pairs(queue) do
+        queue[k] = nil
+    end
+    queue._head, queue._tail = 1, 1
+end
+
 return Queue


### PR DESCRIPTION
# Changes
- [x] 1. `local this = Public.get` moved inside events instead of local in file (otherwise it was nil after `on_load`)
- [x] 2. added a Queue system for initial map reveal
- [x] 3. moved some functions from to the map function itself

Altho for 3. more stuff can be moved to map function, the main in-game UPS issue is from biters pathfinding so I'll maybe come back and refactor this part when I'll add more scenery (rocks, rivers, ...) to terrain gen. 
I've tested both SP and MP on our server and can confirm .2 (+ another 10s from previous surface clear) solved all the restart issues: now the server does not even hiccup a second when restarting :)