### PR TITLE
Drop players armor and weapons

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -84,7 +84,8 @@ global.config = {
     -- enables dumping of inventories of offline players to a corpse at the player's last location
     dump_offline_inventories = {
         enabled = false,
-        offline_timout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
+        offline_timeout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
+        startup_gear_drop_hours = 24 -- time after which players will keep at least their armor when disconnecting
     },
     -- enables players to create and prioritize tasks
     tasklist = {

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -1,12 +1,18 @@
 -- This feature allows you to turn on anti-hoarding so that X minutes after a player leaves the game
 -- the resources in their inventory are returned to the teams. A corpse will spawn on the player's last
 -- position and remain until they log back in to claim it or someone else mines it.
+-- All players will drop their armors and weapons during the first 24h of the game,
+-- after this time, only regulars and above will keep their armor and just drop the inventory.
 local Event = require 'utils.event'
 local Task = require 'utils.task'
 local Token = require 'utils.token'
 local Global = require 'utils.global'
 local CorpseUtil = require 'features.corpse_util'
 local Config = require 'config'
+local Rank = require 'features.rank_system'
+local Ranks = require 'resources.ranks'
+local MINS_TO_TICKS = 60 * 60
+local HOUR_TO_TICKS = MINS_TO_TICKS * 60
 
 local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local config = Config.dump_offline_inventories
@@ -22,59 +28,54 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
     local player_index = player.index
     offline_player_queue[player_index] = nil
 
-    if not banned and player.connected then
-        return
+    local inventory_types = {
+        defines.inventory.character_main,
+        defines.inventory.character_guns,
+        defines.inventory.character_ammo,
+        defines.inventory.character_vehicle,
+        defines.inventory.character_trash,
+    }
+
+    if game.tick < config.startup_gear_drop_hours * HOUR_TO_TICKS or Rank.less_than(player.name, Ranks.regular) then
+        table.insert(inventory_types, defines.inventory.character_armor)
     end
 
-    local inv_main = player.get_inventory(defines.inventory.character_main)
-    local inv_trash = player.get_inventory(defines.inventory.character_trash)
-
-    local inv_main_contents
-    if inv_main and inv_main.valid then
-        inv_main_contents = inv_main.get_contents()
+    local inv_contents = {}
+    for _, id in pairs(inventory_types)  do
+        local inv = player.get_inventory(id)
+        if inv and inv.valid then
+            for i = 1, #inv do
+                local item_stack = inv[i]
+                if item_stack.valid_for_read then
+                    table.insert(inv_contents, item_stack)
+                end
+            end
+        end
     end
 
-    local inv_trash_contents
-    if inv_trash and inv_trash.valid then
-        inv_trash_contents = inv_trash.get_contents()
-    end
-
-    local inv_corpse_size = 0
-    if inv_main_contents then
-        inv_corpse_size = inv_corpse_size + (#inv_main - inv_main.count_empty_stacks())
-    end
-
-    if inv_trash_contents then
-        inv_corpse_size = inv_corpse_size + (#inv_trash - inv_trash.count_empty_stacks())
-    end
-
-    if inv_corpse_size <= 0 then
+    if #inv_contents == 0 then
         return
     end
 
     local position = player.position
     local corpse = player.surface.create_entity {
-        name = "character-corpse",
+        name = 'character-corpse',
         position = position,
-        inventory_size = inv_corpse_size,
+        inventory_size = #inv_contents,
         player_index = player_index
     }
     corpse.active = false
 
     local inv_corpse = corpse.get_inventory(defines.inventory.character_corpse)
-
-    for item_name, count in pairs(inv_main_contents or {}) do
-        inv_corpse.insert({name = item_name, count = count})
-    end
-    for item_name, count in pairs(inv_trash_contents or {}) do
-        inv_corpse.insert({name = item_name, count = count})
+    for _, item_stack in pairs(inv_contents) do
+        inv_corpse.insert(item_stack)
     end
 
-    if inv_main_contents then
-        inv_main.clear()
-    end
-    if inv_trash_contents then
-        inv_trash.clear()
+    for _, id in pairs(inventory_types)  do
+        local inv = player.get_inventory(id)
+        if inv and inv.valid then
+            inv.clear()
+        end
     end
 
     local text = player.name .. "'s inventory (offline)"
@@ -131,7 +132,7 @@ local function start_timer(event, timeout_minutes)
 
     if player and player.valid and player.character then -- if player leaves before respawning they wont have a character and we don't need to add them to the list.
         local tick = game.tick
-        local timeout = timeout_minutes * 60 * 60
+        local timeout = timeout_minutes * MINS_TO_TICKS
 
         offline_player_queue[player_index] = tick -- tick is used to check that the callback happens after X minutes as multiple callbacks may be active if the player logs off and on multiple times
         set_timeout_in_ticks(timeout, spawn_player_corpse_token,
@@ -144,7 +145,12 @@ Event.add(defines.events.on_pre_player_left_game, function(event)
         return
     end
 
-    start_timer(event, config.offline_timout_mins)
+    if _DEBUG then
+        local player = game.get_player(event.player_index)
+        spawn_player_corpse(player, false, 0)
+    else
+        start_timer(event, config.offline_timeout_mins)
+    end
 end)
 
 Event.add(defines.events.on_player_banned, function(event)

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -36,7 +36,7 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
         defines.inventory.character_trash,
     }
 
-    if game.tick < config.startup_gear_drop_hours * HOUR_TO_TICKS or Rank.less_than(player.name, Ranks.regular) then
+    if banned or game.tick < config.startup_gear_drop_hours * HOUR_TO_TICKS or Rank.less_than(player.name, Ranks.regular) then
         table.insert(inventory_types, defines.inventory.character_armor)
     end
 

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -28,6 +28,10 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
     local player_index = player.index
     offline_player_queue[player_index] = nil
 
+    if not banned and player.connected then
+        return
+    end
+
     local inventory_types = {
         defines.inventory.character_main,
         defines.inventory.character_guns,
@@ -145,12 +149,7 @@ Event.add(defines.events.on_pre_player_left_game, function(event)
         return
     end
 
-    if _DEBUG then
-        local player = game.get_player(event.player_index)
-        spawn_player_corpse(player, false, 0)
-    else
-        start_timer(event, config.offline_timeout_mins)
-    end
+    start_timer(event, config.offline_timeout_mins)
 end)
 
 Event.add(defines.events.on_player_banned, function(event)

--- a/features/dump_offline_inventories.lua
+++ b/features/dump_offline_inventories.lua
@@ -13,6 +13,8 @@ local Rank = require 'features.rank_system'
 local Ranks = require 'resources.ranks'
 local MINS_TO_TICKS = 60 * 60
 local HOUR_TO_TICKS = MINS_TO_TICKS * 60
+local DEFAULT_OFFLINE_TIMEOUT_MINS = 15
+local DEFAULT_STARTUP_GEAR_DROP_HOURS = 24
 
 local set_timeout_in_ticks = Task.set_timeout_in_ticks
 local config = Config.dump_offline_inventories
@@ -40,7 +42,8 @@ local function spawn_player_corpse(player, banned, timeout_minutes)
         defines.inventory.character_trash,
     }
 
-    if banned or game.tick < config.startup_gear_drop_hours * HOUR_TO_TICKS or Rank.less_than(player.name, Ranks.regular) then
+    local startup_gear_drop_hours = config.startup_gear_drop_hours or DEFAULT_STARTUP_GEAR_DROP_HOURS
+    if banned or game.tick < (startup_gear_drop_hours * HOUR_TO_TICKS) or Rank.less_than(player.name, Ranks.regular) then
         table.insert(inventory_types, defines.inventory.character_armor)
     end
 
@@ -149,7 +152,7 @@ Event.add(defines.events.on_pre_player_left_game, function(event)
         return
     end
 
-    start_timer(event, config.offline_timeout_mins)
+    start_timer(event, config.offline_timeout_mins or DEFAULT_OFFLINE_TIMEOUT_MINS)
 end)
 
 Event.add(defines.events.on_player_banned, function(event)

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -51,7 +51,7 @@ RedmewConfig.market.enabled = false
 RedmewConfig.biter_attacks.enabled = false
 RedmewConfig.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
 }
 
 -- leave seeds nil to have them filled in based on the map seed.

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -52,6 +52,7 @@ RedmewConfig.biter_attacks.enabled = false
 RedmewConfig.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 15,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 
 -- leave seeds nil to have them filled in based on the map seed.

--- a/map_gen/maps/danger_ores/presets/danger_bobangels_ores.lua
+++ b/map_gen/maps/danger_ores/presets/danger_bobangels_ores.lua
@@ -109,6 +109,7 @@ Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_bobangels_ores.lua
+++ b/map_gen/maps/danger_ores/presets/danger_bobangels_ores.lua
@@ -108,7 +108,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_bobs_ores.lua
+++ b/map_gen/maps/danger_ores/presets/danger_bobs_ores.lua
@@ -111,7 +111,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_bobs_ores.lua
+++ b/map_gen/maps/danger_ores/presets/danger_bobs_ores.lua
@@ -111,7 +111,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore.lua
@@ -71,7 +71,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore.lua
@@ -72,6 +72,7 @@ Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_3way_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_3way_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_3way_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_3way_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_bz.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_bz.lua
@@ -92,7 +92,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_bz.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_bz.lua
@@ -92,7 +92,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard.lua
@@ -82,7 +82,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform.lua
@@ -82,7 +82,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard_uniform_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_circles.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_circles.lua
@@ -82,7 +82,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_circles.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_circles.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_circles_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_circles_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_circles_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_circles_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_deadlock_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries.lua
@@ -89,7 +89,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries.lua
@@ -89,7 +89,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries_spiral.lua
@@ -90,7 +90,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries_spiral.lua
@@ -90,7 +90,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
@@ -88,7 +88,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
@@ -88,7 +88,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_expensive_grid_factory_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expensive_grid_factory_beltboxes_ore_only.lua
@@ -89,7 +89,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_expensive_grid_factory_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expensive_grid_factory_beltboxes_ore_only.lua
@@ -89,7 +89,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_extra.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_extra.lua
@@ -82,7 +82,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_extra.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_extra.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_for_the_swarm_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_for_the_swarm_beltboxes_ore_only.lua
@@ -93,7 +93,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_for_the_swarm_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_for_the_swarm_beltboxes_ore_only.lua
@@ -93,7 +93,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_gradient.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_gradient.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_gradient.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_gradient.lua
@@ -83,6 +83,7 @@ Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_gradient_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_gradient_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_gradient_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_gradient_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral.lua
@@ -87,7 +87,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral.lua
@@ -88,6 +88,7 @@ Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3.lua
@@ -100,7 +100,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3.lua
@@ -100,7 +100,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
@@ -100,7 +100,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
@@ -100,7 +100,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -112,7 +112,7 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -112,7 +112,8 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
@@ -82,6 +82,7 @@ Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
@@ -81,7 +81,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_landfill_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_landfill_beltboxes_ore_only.lua
@@ -83,7 +83,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_landfill_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_landfill_beltboxes_ore_only.lua
@@ -83,7 +83,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_lazy_one_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_lazy_one_beltboxes_ore_only.lua
@@ -105,7 +105,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_lazy_one_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_lazy_one_beltboxes_ore_only.lua
@@ -105,7 +105,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_normal_science.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_normal_science.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_normal_science.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_normal_science.lua
@@ -83,6 +83,7 @@ Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_omnimatter.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_omnimatter.lua
@@ -82,7 +82,7 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_omnimatter.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_omnimatter.lua
@@ -82,7 +82,8 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_omnimatter_cages.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_omnimatter_cages.lua
@@ -83,7 +83,7 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_omnimatter_cages.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_omnimatter_cages.lua
@@ -83,7 +83,8 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction.lua
@@ -83,7 +83,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction.lua
@@ -83,7 +83,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes.lua
@@ -85,7 +85,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes.lua
@@ -85,7 +85,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes_ore_only.lua
@@ -85,7 +85,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction_beltboxes_ore_only.lua
@@ -85,7 +85,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction_wide_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction_wide_beltboxes_ore_only.lua
@@ -85,7 +85,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction_wide_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction_wide_beltboxes_ore_only.lua
@@ -85,7 +85,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_patches.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_patches.lua
@@ -83,7 +83,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_patches.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_patches.lua
@@ -83,7 +83,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only.lua
@@ -86,7 +86,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only.lua
@@ -86,7 +86,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only_restricted.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only_restricted.lua
@@ -86,7 +86,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only_restricted.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_patches_beltboxes_ore_only_restricted.lua
@@ -86,7 +86,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_poor_mans_coal_fields.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_poor_mans_coal_fields.lua
@@ -89,7 +89,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_poor_mans_coal_fields.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_poor_mans_coal_fields.lua
@@ -89,7 +89,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
@@ -88,7 +88,7 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
@@ -88,7 +88,8 @@ Config.player_create.starting_items = {
 }
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_scrap.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_scrap.lua
@@ -73,7 +73,8 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_scrap.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_scrap.lua
@@ -73,7 +73,7 @@ end
 
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_spiral.lua
@@ -86,7 +86,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_spiral.lua
@@ -87,6 +87,7 @@ Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
     offline_timeout_mins = 30,   -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_spiral_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_spiral_beltboxes_ore_only.lua
@@ -83,7 +83,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_spiral_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_spiral_beltboxes_ore_only.lua
@@ -83,7 +83,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_split.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_split.lua
@@ -82,7 +82,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_split.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_split.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_split_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_split_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_split_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_split_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_square_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_square_beltboxes_ore_only.lua
@@ -89,7 +89,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_square_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_square_beltboxes_ore_only.lua
@@ -89,7 +89,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.permissions.presets.no_blueprints = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_xmas_tree_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_xmas_tree_beltboxes_ore_only.lua
@@ -84,7 +84,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 Config.day_night.enabled = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_xmas_tree_beltboxes_ore_only.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_xmas_tree_beltboxes_ore_only.lua
@@ -84,7 +84,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 Config.day_night.enabled = true

--- a/map_gen/maps/danger_ores/presets/terraforming_danger_ore.lua
+++ b/map_gen/maps/danger_ores/presets/terraforming_danger_ore.lua
@@ -82,7 +82,8 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30, -- time after which a player logs off that their inventory is provided to the team
+    startup_gear_drop_hours = 24, -- time after which players will keep at least their armor when disconnecting
 }
 Config.paint.enabled = false
 

--- a/map_gen/maps/danger_ores/presets/terraforming_danger_ore.lua
+++ b/map_gen/maps/danger_ores/presets/terraforming_danger_ore.lua
@@ -82,7 +82,7 @@ Config.player_rewards.enabled = false
 Config.player_create.starting_items = {}
 Config.dump_offline_inventories = {
     enabled = true,
-    offline_timout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
+    offline_timeout_mins = 30 -- time after which a player logs off that their inventory is provided to the team
 }
 Config.paint.enabled = false
 


### PR DESCRIPTION
# Changes
- [x] fixed typo in configs `offline_timout_mins` --> `offline_timeout_mins`
- [x] added config to drop player's armor and weapons alongside player's inventory when logging off

This issue was raised on Admins chat to retrieve player's armor/weapons when players are banned, and also when players disconnect hoarding a lot of stuff. So the new config has a field `startup_gear_drop_hours = 24` which means:

- ANY player logging off in the first 24h will drop their armor alongside inventory/weapons
- Rank::Regular and above will NOT drop their armor after first 24h of game (but they will still drop inventory (+weapons) as usual.

```lua
if not banned and player.connected then return end
```
I removed this check because it was not clear to me what edge case it was supposed to gate. The new conditions appeared to be always true so it seemed redundant, but happy to revert it.
Also I added a debug option to drop player's stuff in debug mode, but could be too much overhead so it can be removed if we prefer... I've tested it in all the cases (except ban) and it's unlikely I'll need to retest this often

> screenshot of the changes
![Screenshot from 2024-08-21 11-14-33](https://github.com/user-attachments/assets/2c6f012c-4d79-46fd-909a-925296c9ee8a)

