### PR TITLE
Add minimal scenario

### DIFF
--- a/scenario_templates/minimal/map_selction.lua
+++ b/scenario_templates/minimal/map_selction.lua
@@ -1,0 +1,7 @@
+local config = require 'config'
+config.redmew_surface.enabled = false
+config.market.enabled = false
+config.reactor_meltdown.enabled = false
+config.player_create.starting_items = {}
+config.player_rewards.enabled = false
+config.apocalypse.enabled = false


### PR DESCRIPTION
I wanted a scenario we can use that has the non-essential features turned off. I think this would be an better scenario to use for SA compared to develop. There is also the possibly that after we merge this for 1.1, we change it again in your PR for SA.

If there are any other features you think we should turn off I'm open to suggestions. landfill_remover, autofill and turret_active_delay could be controversial. I'm also not sure what to use for `player_create.starting_items` but I figured in a multiplayer map it doesn't make much difference.