### PR TITLE
Fix custom effects on technology effects reset

### DIFF
--- a/map_gen/maps/danger_ores/modules/robot_cargo_capacity.lua
+++ b/map_gen/maps/danger_ores/modules/robot_cargo_capacity.lua
@@ -27,3 +27,12 @@ Event.add(defines.events.on_research_finished, function(event)
     '[color=green][font=var]+'..force.worker_robots_storage_bonus..'[/font][/color]'
   }, '\t\t'))
 end)
+
+Event.add(defines.events.on_technology_effects_reset, function(event)
+  local force = event.force
+  if not (force and force.valid) then
+    return
+  end
+  force.worker_robots_storage_bonus = force.worker_robots_storage_bonus + math.floor(force.mining_drill_productivity_bonus / 0.1)
+  force.mining_drill_productivity_bonus = 0
+end)


### PR DESCRIPTION
Fix that custom effects would be lost `on_technology_effects_reset`, which in 2.0 will happen a lot more frequently (reported here an insight from Boskid):

```cpp
if (input.mapVersion >= MapVersion(1, 2, 10, 27))
    input.shouldResetTechnologyEffects = input.load<CrcValueType>() != TechnologyPrototype::getComputedTechTreeCrc();
  else if (input.prototypeDataChanged)
    input.shouldResetTechnologyEffects = true;
```
> so if you have technology tree changes, technology effects are reset. Its not about prototypes data changed because if technologies remain the same then it wont trigger

I suspect other parts of the code will have this issue, especially if modded (vanilla shouldn't trigger any reset when loading). Hard to predict and debug all other places in the code this will happen, but good to keep in mind that custom actions in reaction to `on_research_finished` may be lost when updating mods