### PR TITLE
Add more admin shortcuts

### DIFF
--- a/features/gui/admin_panel/functions.lua
+++ b/features/gui/admin_panel/functions.lua
@@ -87,6 +87,54 @@ function Actions.spank(target_name, source_player)
   game.print(source_player.name .. ' spanked ' .. target_player.name, {color = Color.warning})
 end
 
+---@param player LuaPlayer
+function Actions.toggle_blueprint_permissions(player)
+  local allowed = true
+  local no_blueprints = {
+    defines.input_action.import_blueprint,
+    defines.input_action.import_blueprint_string,
+    defines.input_action.import_blueprints_filtered,
+    defines.input_action.import_permissions_string,
+    defines.input_action.open_blueprint_library_gui,
+    defines.input_action.open_blueprint_record,
+    defines.input_action.upgrade_opened_blueprint_by_record,
+  }
+  local Default = game.permissions.get_group("Default")
+  for _, action in pairs(no_blueprints) do
+    allowed = allowed and Default.allows_action(action)
+  end
+  allowed = not allowed
+  for _, action in pairs(no_blueprints) do
+    Default.set_allows_action(action, allowed)
+  end
+  local on, off = '[color=blue]ON[/color]', '[color=red]OFF[/color]'
+  Game.player_print('Blueprint permissions: ' .. (allowed and on or off), Color.success, player)
+end
+
+---@param player LuaPlayer\
+function Actions.create_oil_field(player)
+  local src = player.physical_position
+  local oil = prototypes.entity['crude-oil']
+  local try = player.physical_surface and player.physical_surface.can_place_entity
+  local create = player.physical_surface and player.physical_surface.create_entity
+  if not create or not oil then
+    return
+  end
+  for y = 0, 2 do
+    for x = 0, 2 do
+      local def = { name = oil, amount = 3e5, position = { x = src.x + x*7 - 7, y = src.y + y*7 - 7 } }
+      if try(def) then create(def) end
+    end
+  end
+  Game.player_print('Caution: slippery oil', Color.success, player)
+end
+
+---@param player LuaPlayer
+function Actions.create_pollution(player)
+  player.surface.pollute(player.position, 1e6)
+  Game.player_print('Your feet smell like pollution', Color.success, player)
+end
+
 -- == SURFACE =================================================================
 
 local Surface = {}

--- a/features/gui/admin_panel/player_manager.lua
+++ b/features/gui/admin_panel/player_manager.lua
@@ -27,6 +27,9 @@ local on_invoke_player = Gui.uid_name()
 local on_goto_player = Gui.uid_name()
 local on_spank_player = Gui.uid_name()
 local on_ban_player = Gui.uid_name()
+local on_create_oil_field = Gui.uid_name()
+local on_toggle_blueprints = Gui.uid_name()
+local on_create_pollution = Gui.uid_name()
 -- local on_teleport = Gui.uid_name()
 -- local on_destroy_selected = Gui.uid_name()
 
@@ -153,7 +156,10 @@ local function draw_gui(player)
   for _, button in pairs({
     { name = on_cheat_mode, caption = 'Cheat mode' },
     { name = on_show_reports, caption = 'Show reports' },
+    { name = on_toggle_blueprints, caption = 'Blueprints ON/OFF' },
     { name = on_create_pool, caption = 'Create pool' },
+    { name = on_create_oil_field, caption = 'Create oil field' },
+    { name = on_create_pollution, caption = 'Spawn pollution' },
     { name = on_revive_ghosts, caption = 'Revive ghosts' },
     { name = on_save_game, caption = 'Save game' },
     { name = on_delete_blueprints, caption = 'Destroy ghost entities' },
@@ -253,8 +259,20 @@ Gui.on_click(on_show_reports, function(event)
   Actions.show_reports(nil, event.player)
 end)
 
+Gui.on_click(on_toggle_blueprints, function(event)
+  Actions.toggle_blueprint_permissions(event.player)
+end)
+
 Gui.on_click(on_create_pool, function(event)
   Actions.create_pool(nil, event.player)
+end)
+
+Gui.on_click(on_create_oil_field, function(event)
+  Actions.create_oil_field(event.player)
+end)
+
+Gui.on_click(on_create_pollution, function(event)
+  Actions.create_pollution(event.player)
 end)
 
 Gui.on_click(on_revive_ghosts, function(event)


### PR DESCRIPTION
# Changes
Added 3 more buttons in admin panel:

- **Blueprints ON/OFF**: toggles blueprint permissions on/off for the default permission group
- **Create oil field**: will try to spawn a 3x3 oil field around player's character, if possible
- **Spawn pollution**: will add a ton of pollution at the player's position (or from the map view)

![Screenshot from 2024-11-22 11-38-28](https://github.com/user-attachments/assets/0038b1c2-f222-4675-b8f1-24ca8881a4cc)
