### PR TITLE
Set hidden tile for landfill tiles

### DIFF
--- a/map_gen/shared/generate.lua
+++ b/map_gen/shared/generate.lua
@@ -30,6 +30,12 @@ local function do_tile_inner(tiles, tile, pos)
     end
 end
 
+local function do_landfill_hidden_tile(tiles, tile, pos)
+    if (tile.tile or tile) == 'landfill' and not tile.hidden_tile then
+        insert(tiles, {tile = 'water-shallow', position = pos})
+    end
+end
+
 local function do_tile(y, x, data, shape)
     local pos = {x, y}
 
@@ -63,6 +69,7 @@ local function do_tile(y, x, data, shape)
     else
         do_tile_inner(data.tiles, tile, pos)
     end
+    do_landfill_hidden_tile(data.hidden_tiles, tile, pos)
 end
 
 local function do_row(row, data, shape)
@@ -109,6 +116,7 @@ local function do_row(row, data, shape)
         else
             do_tile_inner(tiles, tile, pos)
         end
+        do_landfill_hidden_tile(data.hidden_tiles, tile, pos)
     end
 end
 


### PR DESCRIPTION
In Factorio 2.0, landfill tile are now minable/refundable.
For scenarios that use `landfill` tiles in terrain generation now a `shallow-water` tile will be placed beneath landfill as `LuaTile::hidden_tile`, so when mining landfill, water is discovered.
Scenarios that do not want player to find water beneath need pass as hidden tile another valid tile in the shape function.

![Screenshot from 2024-11-23 04-46-47](https://github.com/user-attachments/assets/e182f593-de2e-41bf-ab21-8fa142ce1aea)
