### PR TITLE
Organize danger ores changelog

### DIFF
--- a/map_gen/maps/danger_ores/changelog.lua
+++ b/map_gen/maps/danger_ores/changelog.lua
@@ -1,0 +1,79 @@
+return [[
+  2019-03-27:
+      - [DO] Ore arranged into quadrants to allow for more controlled resource gathering.
+
+  2019-03-30:
+      - [DO] Uranium ore patch threshold increased slightly
+      - [DO] Bug fix: Cars and tanks can now be placed onto ore!
+      - [DO] Starting minimum pollution to expand map set to 650
+          View current pollution via Debug Settings [F4] show-pollution-values,
+          then open map and turn on pollution via the red box.
+      - [DO] Starting water at spawn increased from radius 8 to radius 16 circle.
+
+  2019-04-24:
+      - [DO] Stone ore density reduced by 1/2
+      - [DO] Ore quadrants randomized
+      - [DO] Increased time factor of biter evolution from 5 to 7
+      - [DO] Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
+
+  2020-09-02:
+      - [DO] Destroyed chests dump their content as coal ore.
+
+  2020-12-28:
+      - [DO] Changed win condition. First satellite kills all biters, launch 500 to win the map.
+
+  2021-04-06:
+      - [DO] Rail signals and train stations now allowed on ore.
+
+  2023-06-27:
+      - [DO:LazyOne] Disabled Crafting
+      - [DO:LazyOne] Added Starting Equipment
+
+  2023-10-01:
+      - [Do:K2] Added K2 preset
+
+  2023-10-17:
+      - [Do:Omni] Added Omnimatter presets
+
+  2023-10-21:
+      - [DO:BZ] Added BZ preset
+
+  2023-10-23:
+      - [DO:EI] Added EI presets
+
+  2023-10-24:
+      - [DO:IR3] Added IR3 presets
+      - [DO:PYFE] Added PyFE preset
+
+  2024-02-24:
+      - [Do:Scrap] Added Scrap preset
+
+  2024-04-08:
+      - [DO:Expanse] Forked from DO/terraforming
+      - [DO:Expanse] Added DO/expanse
+      - [DO:Expanse] Lowered tech multiplier 25 > 5
+
+  2024-04-17:
+      - [DO:Expanse] Fixed incorrect request computation
+      - [DO:Expanse] Fixed persistent chests on new chunk unlocks
+      - [DO:Expanse] Added chests for each new expansion border
+      - [DO:Expanse] Reduced pre_multiplier from 0.33 >s 0.20
+
+  2024-08-01:
+      - [DO:Expanse] Fixed allowed entities list with Mk2-3 drills
+      - [DO:Expanse] Fixed typos in description
+
+  2024-11-22:
+      - [DO] Updated scenarios to 2.0
+      - [DO] Added compatibility with AAI Loaders mod
+      - [DO] Added compatibility with Deadlock Stacked Beltboxes and Loaders mod
+      - [DO] Added compatibility with Early Construction mod
+      - [DO] Added compatibility with REdMew Data mod
+      - [DO] Added module to prevent quality miners from being placed on ore
+      - [DO] Added module to replace mining productivity effects with robot cargo size instead
+      - [DO] Removed deadlock's custom scenario forks
+      - [DO] Updated map poll list
+      - [DO] Updated rocket launches requirement to win at 1000 for most presets
+      - [DO] Updated technology multiplier to x25 for most presets
+      - [DO] Updated terraforming for most presets
+]]

--- a/map_gen/maps/danger_ores/presets/danger_ore.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-      View current pollution via Debug Settings [F4] show-pollution-values,
-      then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.biter_drops.enabled = false
 DOC.game.peaceful_mode = false

--- a/map_gen/maps/danger_ores/presets/danger_ore_3way.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_3way.lua
@@ -1,5 +1,4 @@
 local B = require 'map_gen.shared.builders'
-local H = require 'map_gen.maps.danger_ores.modules.helper'
 local DOC = require 'map_gen.maps.danger_ores.configuration'
 local Scenario = require 'map_gen.maps.danger_ores.scenario'
 local ScenarioInfo = require 'features.gui.info'
@@ -10,34 +9,6 @@ ScenarioInfo.add_map_extra_info([[
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
 
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
-
 DOC.scenario_name = 'danger-ore-3way'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_3way'
 DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.config.3way_ores'
@@ -45,7 +16,6 @@ DOC.map_config.main_ores_rotate = nil
 DOC.map_config.spawn_shape = B.rectangle(72)
 DOC.map_config.start_ore_shape = B.rotate(B.rectangle(88), math.rad(135))
 DOC.map_config.water = nil
-DOC.map_gen_settings.settings = H.empty_map_settings()
 
 local t_h_bound, t_v_bound = B.line_x(128), B.line_y(128)
 local t_crop = function(_, y)

--- a/map_gen/maps/danger_ores/presets/danger_ore_bob.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_bob.lua
@@ -8,33 +8,6 @@ ScenarioInfo.set_map_name('Danger Ores - Bobs')
 ScenarioInfo.add_map_extra_info([[
   This map is split in 17 sectors. Each sector has a main resource.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-bob'
 DOC.compatibility.redmew_data.remove_resource_patches = false

--- a/map_gen/maps/danger_ores/presets/danger_ore_bob_angel.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_bob_angel.lua
@@ -8,33 +8,6 @@ ScenarioInfo.set_map_name('Danger Ores - Bobs & Angels')
 ScenarioInfo.add_map_extra_info([[
   This map is split in 6 sectors. Each sector has a main resource.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-          View current pollution via Debug Settings [F4] show-pollution-values,
-          then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-bob-angel'
 DOC.compatibility.redmew_data.remove_resource_patches = false

--- a/map_gen/maps/danger_ores/presets/danger_ore_bz.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_bz.lua
@@ -7,10 +7,6 @@ ScenarioInfo.set_map_name('Danger Ores - Very BZ')
 ScenarioInfo.add_map_extra_info([[
   This map is split in 15 sectors. Each sector has a main resource.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-21:
-      - Added BZ preset
-]])
 
 DOC.scenario_name = 'danger-ore-bz'
 DOC.compatibility.redmew_data.remove_resource_patches = false

--- a/map_gen/maps/danger_ores/presets/danger_ore_chessboard.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_chessboard.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-    - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-chessboard'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_chessboard'

--- a/map_gen/maps/danger_ores/presets/danger_ore_circles.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_circles.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-circles'
 DOC.map_config.circle_thickness = 16 -- Thickness of the rings at weight 1

--- a/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries.lua
@@ -8,10 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in 3 sectors. Each sector has a main resource.
   Resource veins are scattered across the map.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-23:
-      - Added EI preset
-]])
 
 storage.config.redmew_qol.loaders = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_exotic_industries_spiral.lua
@@ -8,10 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in 3 sectors. Each sector has a main resource.
   Resource veins are scattered across the map.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-23:
-      - Added EI preset
-]])
 
 storage.config.redmew_qol.loaders = false
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_expanse.lua
@@ -32,20 +32,6 @@ ScenarioInfo.add_map_extra_info([[
   You can fulfill part of the request & then reroll to change the remaining part (it will always reroll based on its remaining content to be fulfilled).
   Unlocking new land may or may not reward you with another Coin.
 ]])
-ScenarioInfo.set_new_info([[
-  2024-08-01:
-      - Fixed allowed entities list with Mk2-3 drills
-      - Fixed typos in description
-  2024-04-08:
-      - Forked from DO/terraforming
-      - Added DO/expanse
-      - Lowered tech multiplier 25 > 5
-  2024-04-17:
-      - Fixed incorrect request computation
-      - Fixed persistent chests on new chunk unlocks
-      - Added chests for each new expansion border
-      - Reduced pre_multiplier from 0.33 >s 0.20
-]])
 
 Config.market.enabled = false
 Config.player_rewards.enabled = true

--- a/map_gen/maps/danger_ores/presets/danger_ore_for_the_swarm.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_for_the_swarm.lua
@@ -12,33 +12,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in four sectors [item=iron-ore] [item=copper-ore] [item=coal] [item=stone].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 Config.player_create.starting_items = {
   { count =    1, name = 'power-armor' },

--- a/map_gen/maps/danger_ores/presets/danger_ore_gradient.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_gradient.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-gradient'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_gradient'

--- a/map_gen/maps/danger_ores/presets/danger_ore_grid_factory.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_grid_factory.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-grid-factory'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_grid_factory'

--- a/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_hub_spiral.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-hub-spiral'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_hub_spiral'

--- a/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3.lua
@@ -8,10 +8,6 @@ ScenarioInfo.set_map_name('Danger Ores - Industrial Revolution 3')
 ScenarioInfo.add_map_extra_info([[
   This map is split in 6 sectors. Each sector has a main resource. Gas fissures are scattered across the map.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-24:
-      - Added IR3 preset
-]])
 
 Config.redmew_qol.loaders = false
 Config.player_create.starting_items = {

--- a/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
@@ -8,10 +8,6 @@ ScenarioInfo.set_map_name('Danger Ores - Industrial Revolution 3 Grid Factory')
 ScenarioInfo.add_map_extra_info([[
   This map is split in 6 sectors. Each sector has a main resource. Gas fissures are scattered across the map.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-24:
-      - Added IR3 preset
-]])
 
 Config.redmew_qol.loaders = false
 Config.player_create.starting_items = {

--- a/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_krastorio2.lua
@@ -9,21 +9,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in four sectors [item=iron-ore] [item=copper-ore] [item=coal] [item=stone].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-26:
-      - Reduced tech multiplier (10 -> 5)
-      - Increased Uranium ore & Compact raw rare metals spawn radius (128 -> 192 tiles)
-      - Eased terraforming requirements (8 -> 10 chunks, 9 -> 8 pollution increase, 24k -> 16k max pollution, 600 -> 400 min pollution)
-      - Reduced rocket required to win (500 -> 100)
-      - Removed Expensive Warehousing from required mods
-
-  2023-10-11:
-      - Increased Uranium ore & Compact raw rare metals spawn radius to 128 tiles
-      - Reduced Compact raw rare metals yield weight (8 -> 4)
-
-  2023-10-01:
-      - Added K2 preset
-]])
 
 Config.redmew_qol.loaders = false
 Config.player_create.starting_items = {

--- a/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_landfill.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-          View current pollution via Debug Settings [F4] show-pollution-values,
-          then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-landfill'
 DOC.map_config.spawn_tile = 'landfill'

--- a/map_gen/maps/danger_ores/presets/danger_ore_lazy_one.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_lazy_one.lua
@@ -9,38 +9,6 @@ ScenarioInfo.add_map_extra_info([[
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
 
-ScenarioInfo.set_new_info([[
-  2023-06-27:
-      - disabled Crafting
-      - added Starting Equipment
-
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
-
 Config.permissions.presets.no_handcraft = true
 Config.player_create.starting_items = {
   { count = 1,  name = 'steel-furnace' },

--- a/map_gen/maps/danger_ores/presets/danger_ore_normal_science.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_normal_science.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-      View current pollution via Debug Settings [F4] show-pollution-values,
-      then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 Config.hail_hydra.enabled = true
 Config.hail_hydra.online_player_scale_enabled = false

--- a/map_gen/maps/danger_ores/presets/danger_ore_omnimatter.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_omnimatter.lua
@@ -11,11 +11,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is covered in [item=omnite].
   Mine it to make room for your factory.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-17:
-      - Added Omnimatter preset
-]])
-
 
 Config.redmew_qol.loaders = false
 Config.player_create.starting_items = {

--- a/map_gen/maps/danger_ores/presets/danger_ore_omnimatter_cages.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_omnimatter_cages.lua
@@ -11,10 +11,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is covered in [item=omnite] and [item=infinite-omnite].
   Mine it to make room for your factory.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-17:
-      - Added Omnimatter Cages preset
-]])
 
 Config.redmew_qol.loaders = false
 Config.player_create.starting_items = {

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-          View current pollution via Debug Settings [F4] show-pollution-values,
-          then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-one-direction'
 DOC.rocket_launched.win_satellite_count = 250

--- a/map_gen/maps/danger_ores/presets/danger_ore_one_direction_wide.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_one_direction_wide.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-          View current pollution via Debug Settings [F4] show-pollution-values,
-          then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-one-direction-wide'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_one_direction'

--- a/map_gen/maps/danger_ores/presets/danger_ore_patches.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_patches.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
 	This map is covered in [item=coal] with mixed dense patches containing [item=iron-ore] [item=copper-ore] [item=stone].
 	The patches alternate between [item=iron-ore] and [item=copper-ore] as the main resource.
 ]])
-ScenarioInfo.set_new_info([[
-	2019-04-24:
-			- Stone ore density reduced by 1/2
-			- Ore quadrants randomized
-			- Increased time factor of biter evolution from 5 to 7
-			- Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-	2019-03-30:
-			- Uranium ore patch threshold increased slightly
-			- Bug fix: Cars and tanks can now be placed onto ore!
-			- Starting minimum pollution to expand map set to 650
-					View current pollution via Debug Settings [F4] show-pollution-values,
-					then open map and turn on pollution via the red box.
-			- Starting water at spawn increased from radius 8 to radius 16 circle.
-
-	2019-03-27:
-			- Ore arranged into quadrants to allow for more controlled resource gathering.
-
-	2020-09-02:
-			- Destroyed chests dump their content as coal ore.
-
-	2020-12-28:
-			- Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-	2021-04-06:
-			- Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-patches'
 DOC.map_config.main_ore_resource_patches_config = require 'map_gen.maps.danger_ores.config.main_ore_resource_patches'

--- a/map_gen/maps/danger_ores/presets/danger_ore_poor_mans_coal_fields.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_poor_mans_coal_fields.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-          View current pollution via Debug Settings [F4] show-pollution-values,
-          then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-    - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-poor-mans-coal-fields'
 DOC.game.technology_price_multiplier = 6

--- a/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
@@ -9,10 +9,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in 6 sectors.
   Each sector has a main resource.
 ]])
-ScenarioInfo.set_new_info([[
-  2023-10-24:
-      - Added PyFE preset
-]])
 
 DOC.scenario_name = 'danger-ore-pyfe'
 DOC.compatibility.redmew_data.remove_resource_patches = false

--- a/map_gen/maps/danger_ores/presets/danger_ore_scrap.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_scrap.lua
@@ -10,10 +10,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is covered in [entity=scrap].
   Mine it to make room for your factory.
 ]])
-ScenarioInfo.set_new_info([[
-  2024-02-24:
-      - Added Scrap preset
-]])
 
 Config.player_create.starting_items = {
   { count =  2, name = 'burner-mining-drill' },

--- a/map_gen/maps/danger_ores/presets/danger_ore_spiral.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_spiral.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-          View current pollution via Debug Settings [F4] show-pollution-values,
-          then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-spiral'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_spiral'

--- a/map_gen/maps/danger_ores/presets/danger_ore_split.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_split.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in multiple sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-split'
 DOC.map_config.main_ores_rotate = 0

--- a/map_gen/maps/danger_ores/presets/danger_ore_square.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_square.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-          View current pollution via Debug Settings [F4] show-pollution-values,
-          then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 local start_ore_offset = 44
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_terraforming.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_terraforming.lua
@@ -7,33 +7,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 DOC.scenario_name = 'danger-ore-terraforming'
 DOC.terraforming = {

--- a/map_gen/maps/danger_ores/presets/danger_ore_xmas_tree.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_xmas_tree.lua
@@ -8,33 +8,6 @@ ScenarioInfo.add_map_extra_info([[
   This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
-ScenarioInfo.set_new_info([[
-  2019-04-24:
-      - Stone ore density reduced by 1/2
-      - Ore quadrants randomized
-      - Increased time factor of biter evolution from 5 to 7
-      - Added win conditions (+5% evolution every 5 rockets until 100%, +100 rockets until biters are wiped)
-
-  2019-03-30:
-      - Uranium ore patch threshold increased slightly
-      - Bug fix: Cars and tanks can now be placed onto ore!
-      - Starting minimum pollution to expand map set to 650
-        View current pollution via Debug Settings [F4] show-pollution-values,
-        then open map and turn on pollution via the red box.
-      - Starting water at spawn increased from radius 8 to radius 16 circle.
-
-  2019-03-27:
-      - Ore arranged into quadrants to allow for more controlled resource gathering.
-
-  2020-09-02:
-      - Destroyed chests dump their content as coal ore.
-
-  2020-12-28:
-      - Changed win condition. First satellite kills all biters, launch 500 to win the map.
-
-  2021-04-06:
-      - Rail signals and train stations now allowed on ore.
-]])
 
 Config.day_night.enabled = true
 Config.day_night.use_fixed_brightness = true

--- a/map_gen/maps/danger_ores/scenario.lua
+++ b/map_gen/maps/danger_ores/scenario.lua
@@ -18,6 +18,7 @@ ScenarioInfo.set_map_description([[
   A significant amount of pollution must affect a section of the map before it is revealed.
   Pollution does not affect biter evolution.
 ]])
+ScenarioInfo.set_new_info(require 'map_gen.maps.danger_ores.changelog')
 
 Config.apocalypse.enabled = false
 Config.dump_offline_inventories = {


### PR DESCRIPTION
Moves per-scenarios changelog into a shared entry list under `danger_ores/changelog.lua`.
Presets can list custom changes using their own tag `[DO:<preset_name>]` or simply `[DO]` if it involves more/all.
Entries are listed in descending chronological order because the info panel automatically scrolls to the end when opening it, so players will immediately see the latest changes.

![Screenshot from 2024-11-23 05-18-39](https://github.com/user-attachments/assets/cbec2176-e008-4a0e-9c98-6eb4dd18d69c)
