### PR TITLE
Add startup techs to DO

### DIFF
--- a/map_gen/maps/danger_ores/configuration.lua
+++ b/map_gen/maps/danger_ores/configuration.lua
@@ -66,8 +66,10 @@ return {
   },
   technologies = {
     enabled = true,
-    uranium = true,
-    liquefaction = true,
+    unlocks = {
+      ['uranium-mining'] = { 'uranium-processing' },
+      ['oil-gathering'] = { 'oil-processing', 'coal-liquefaction' },
+    },
   },
   game = {
     draw_resource_selection = false,

--- a/map_gen/maps/danger_ores/configuration.lua
+++ b/map_gen/maps/danger_ores/configuration.lua
@@ -64,6 +64,11 @@ return {
     max_pollution = 15000,
     pollution_increment = 4,
   },
+  technologies = {
+    enabled = true,
+    uranium = true,
+    liquefaction = true,
+  },
   game = {
     draw_resource_selection = false,
     technology_price_multiplier = 25,

--- a/map_gen/maps/danger_ores/modules/technologies.lua
+++ b/map_gen/maps/danger_ores/modules/technologies.lua
@@ -1,0 +1,30 @@
+local Event = require 'utils.event'
+
+local trigger_names = {
+  uranium = {
+    'uranium-mining',
+    'uranium-processing',
+  },
+  liquefaction = {
+    'oil-processing',
+  },
+}
+
+return function(config)
+  Event.on_init(function()
+    for _, force in pairs(game.forces) do
+      for key, enabled in pairs(config) do
+
+        local names = enabled and trigger_names[key] or {}
+
+        for _, name in pairs(names) do
+          local tech = force.technologies[name]
+          if tech and tech.prototype.research_trigger then
+            tech.researched = true
+          end
+        end
+
+      end
+    end
+  end)
+end

--- a/map_gen/maps/danger_ores/modules/technologies.lua
+++ b/map_gen/maps/danger_ores/modules/technologies.lua
@@ -1,29 +1,19 @@
 local Event = require 'utils.event'
 
-local trigger_names = {
-  uranium = {
-    'uranium-mining',
-    'uranium-processing',
-  },
-  liquefaction = {
-    'oil-processing',
-  },
-}
-
 return function(config)
-  Event.on_init(function()
-    for _, force in pairs(game.forces) do
-      for key, enabled in pairs(config) do
+  local unlocks = config.unlocks or {}
+  if table_size(unlocks) == 0 then
+    return
+  end
 
-        local names = enabled and trigger_names[key] or {}
+  Event.add(defines.events.on_research_finished, function(event)
+    local research = event.research
+    local techs = research.force.technologies
 
-        for _, name in pairs(names) do
-          local tech = force.technologies[name]
-          if tech and tech.prototype.research_trigger then
-            tech.researched = true
-          end
-        end
-
+    for _, name in pairs(unlocks[research.name] or {}) do
+      local tech = techs[name]
+      if tech and tech.prototype.research_trigger then
+        tech.researched = true
       end
     end
   end)

--- a/map_gen/maps/danger_ores/modules/technologies.lua
+++ b/map_gen/maps/danger_ores/modules/technologies.lua
@@ -12,7 +12,7 @@ return function(config)
 
     for _, name in pairs(unlocks[research.name] or {}) do
       local tech = techs[name]
-      if tech and tech.prototype.research_trigger then
+      if tech then
         tech.researched = true
       end
     end

--- a/map_gen/maps/danger_ores/scenario.lua
+++ b/map_gen/maps/danger_ores/scenario.lua
@@ -46,6 +46,7 @@ local map_builder            = require 'map_gen.maps.danger_ores.modules.map'
 local mining_productivity    = require 'map_gen.maps.danger_ores.modules.mining_productivity'
 local restart_command        = require 'map_gen.maps.danger_ores.modules.restart_command'
 local rocket_launched        = require 'map_gen.maps.danger_ores.modules.rocket_launched_simple'
+local technologies           = require 'map_gen.maps.danger_ores.modules.technologies'
 local terraforming           = require 'map_gen.maps.danger_ores.modules.terraforming'
 
 local Public = {}
@@ -99,6 +100,9 @@ Public.register = function(danger_ores_config)
   end
   if _C.terraforming.enabled then
     terraforming(_C.terraforming)
+  end
+  if _C.technologies.enabled then
+    technologies(_C.technologies)
   end
 
   Event.on_init(function()


### PR DESCRIPTION
Unlocks some techs (uranium, oil) at startup if they require actions to be unlocked, to allow players to still unlock the recipes and prevent any softlock. This also helps with the dats stage that may add early coal liq or stone->uranium

![Screenshot from 2024-11-23 05-51-26](https://github.com/user-attachments/assets/120e6e20-6e45-443c-992c-0d9f3cb2a8c0)
