### PR TITLE
Fix crash with nil item stack

### DIFF
--- a/map_gen/shared/entity_placement_restriction.lua
+++ b/map_gen/shared/entity_placement_restriction.lua
@@ -213,8 +213,15 @@ local on_built_token =
         end
 
         local index = event.player_index
+        local stack = event.consumed_items.get_contents()[1]
+        if not stack then
+            if index then
+                return
+            else
+                stack = {}
+            end
+        end
 
-        local stack = event.consumed_items.get_contents()[1] -- TODO: proper handle of consumed_items as LuaInventory
         raise_event(
             Public.events.on_pre_restricted_entity_destroyed,
             {


### PR DESCRIPTION
While debugging the [`entity_placement_restrictions`](<https://github.com/Refactorio/RedMew/blob/develop/map_gen/shared/entity_placement_restriction.lua>) & making the new module for DO I found a bug in the old one: when placing ores from editor mode, the scenario crashes due to:

```lua
-- L217
local stack = event.consumed_items.get_contents()[1] -- TODO: proper handle of consumed_items as LuaInventory
raise_event(on_pre_restricted_entity_destroyed, { stack = stack, ... })
...
-- L243
if player and player.valid and primitives.refund and not ghost and stack.valid then
    player.insert(stack)
end
raise_event(on_restricted_entity_destroyed, {...})
```
```
Crash: attempt to access `stack` (a nil value) on L243
```

Proposed solution is:
- if item stack is present, proceed
- if item stack is nil, decide:
  - if index is defined, we're likely in editor mode, so allow the action and early return
  - if index is not defined, then make an empty object and proceed with checks and events, as it's likely another part of script performing the action (not in use currently, but supported via custom events)

```lua
local index = event.player_index
local stack = event.consumed_items.get_contents()[1]
 if not stack then
    if index then
        return
    else
        stack = {}
    end
end
```