### PR TITLE
Add DO:Permanence map

### DIFF
--- a/map_gen/maps/danger_ores/modules/allowed_entities.lua
+++ b/map_gen/maps/danger_ores/modules/allowed_entities.lua
@@ -191,6 +191,16 @@ end
 
 local Public = {}
 
+---@param entity LuaEntity
+---@return bool
+Public.is_allowed = function(entity)
+  local e = get_entity_info(entity)
+  if not banned_entities[e.name] and (allowed_entities[e.name] or types[e.type]) then
+    return true
+  end
+  return false
+end
+
 ---@param config
 ---@field types? table<string, bool>
 ---@field allowed_entities? table<string, bool>

--- a/map_gen/maps/danger_ores/modules/map_poll.lua
+++ b/map_gen/maps/danger_ores/modules/map_poll.lua
@@ -53,6 +53,7 @@ local maps = {
     { name = 'danger-ore-one-direction', display_name = 'One Direction (right ribbon world)', mod_pack = mod_packs.normal },
     { name = 'danger-ore-one-direction-wide', display_name = 'One Direction Wide (wide right ribbon world)', mod_pack = mod_packs.normal },
     { name = 'danger-ore-patches', display_name = 'Patches (ore islands in coal)', mod_pack = mod_packs.normal },
+    { name = 'danger-ore-permanence', display_name = 'Permanence (rebuilding penalty)', mod_pack = mod_packs.normal },
     --{ name = 'danger-ore-poor-mans-coal-fields', display_name = 'Poor Man\'s Coal Fields (Alex Gaming\'s map)', mod_pack = mod_packs.normal },
     { name = 'danger-ore-pyfe', display_name = 'Pyanodon Short (PyFe)', mod_pack = mod_packs.py_short },
     { name = 'danger-ore-scrap', display_name = 'Scrapworld (no ores, all scraps)', mod_pack = mod_packs.scrap },

--- a/map_gen/maps/danger_ores/modules/permanence.lua
+++ b/map_gen/maps/danger_ores/modules/permanence.lua
@@ -72,4 +72,11 @@ return function(config)
 
   Event.add(defines.events.on_player_mined_entity, on_mined)
   Event.add(defines.events.on_robot_mined_entity, on_mined)
+  Event.add(defines.events.on_entity_died, function(event)
+    local force = event.entity and event.entity.force
+    if force.name ~= 'player' then
+      return
+    end
+    on_mined(event)
+  end)
 end

--- a/map_gen/maps/danger_ores/modules/permanence.lua
+++ b/map_gen/maps/danger_ores/modules/permanence.lua
@@ -1,0 +1,75 @@
+-- This module spawns ore in place of mined entities
+-- By default, only entities not-allowed on resources spawn ore when mined away/upgraded
+--
+-- Params:
+-- multiplier? double, defines the ore_dropped/entity_health ratio
+-- resources? table<string>, array of resources to spawn
+-- handler? function, handler for the event. Gets passed a valid LuaEntity, must return True (take action) / False (pass)
+
+local Event = require 'utils.event'
+local AllowedEntities = require 'map_gen.maps.danger_ores.modules.allowed_entities'
+local max = math.max
+local floor = math.floor
+local random = math.random
+
+local default_resources = {
+  'iron-ore', 'iron-ore', 'iron-ore', 'iron-ore', 'iron-ore', 'iron-ore',
+  'copper-ore', 'copper-ore', 'copper-ore', 'copper-ore',
+  'coal', 'coal', 'coal', 'coal',
+  'stone',
+}
+local function default_handler(entity)
+  if entity.type == 'simple-entity' or entity.type == 'tree' then
+    return false
+  end
+  if entity.name == 'entity-ghost' or entity.name == 'tile-ghost' then
+    return false
+  end
+  return not AllowedEntities.is_allowed(entity)
+end
+
+---@param config
+---@field multiplier? double `defines the ore dropped/entity_health ratio`
+---@field resources? table<string> `array of resources to spawn`
+---@field handler? function `handler for the event. Gets passed a valid LuaEntity, must return True (take action) / False (pass)`
+return function(config)
+  config = config or {}
+  local multiplier = config.multiplier or 1
+  local resource_pool = config.resources or default_resources
+  local handler = config.handler or default_handler
+
+  local function on_mined(event)
+    local entity = event.entity
+    if not (entity and entity.valid) then
+      return
+    end
+
+    if not handler(entity) then
+      return
+    end
+
+    local area = entity.bounding_box
+    local left_top, right_bottom = area.left_top, area.right_bottom
+    local x1, y1 = floor(left_top.x), floor(left_top.y)
+    local x2, y2 = floor(right_bottom.x), floor(right_bottom.y)
+    local size_x = x2 - x1 + 1
+    local size_y = y2 - y1 + 1
+    local base = size_x * size_y
+
+    local health = entity.prototype.get_max_health(entity.quality)
+    local amount = max(1, floor(multiplier * health / base))
+    local can_place_entity = entity.surface.can_place_entity
+    local create_entity = entity.surface.create_entity
+
+    local def = { name = resource_pool[random(#resource_pool)], amount = amount }
+    for x = x1, x2 do
+      for y = y1, y2 do
+        def.position = { x, y }
+        if can_place_entity(def) then create_entity(def) end
+      end
+    end
+  end
+
+  Event.add(defines.events.on_player_mined_entity, on_mined)
+  Event.add(defines.events.on_robot_mined_entity, on_mined)
+end

--- a/map_gen/maps/danger_ores/presets/danger_ore_grid_factory.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_grid_factory.lua
@@ -4,7 +4,7 @@ local ScenarioInfo = require 'features.gui.info'
 
 ScenarioInfo.set_map_name('Danger Ores - Grid Factory')
 ScenarioInfo.add_map_extra_info([[
-  This map is split in three sectors [item=iron-ore] [item=copper-ore] [item=coal].
+  This map is divided in quadrants of [item=iron-ore] [item=copper-ore] [item=coal].
   Each sector has a main resource and the other resources at a lower ratio.
 ]])
 

--- a/map_gen/maps/danger_ores/presets/danger_ore_permanence.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_permanence.lua
@@ -1,0 +1,27 @@
+local DOC = require 'map_gen.maps.danger_ores.configuration'
+local Scenario = require 'map_gen.maps.danger_ores.scenario'
+local ScenarioInfo = require 'features.gui.info'
+
+ScenarioInfo.set_map_name('Danger Ores - Permanence')
+ScenarioInfo.add_map_extra_info([[
+  This map is divided in quadrants of [item=iron-ore] [item=copper-ore] [item=coal].
+  Each sector has a main resource and the other resources at a lower ratio.
+
+  Mined entities will create ore drops beneath them, encouraging players to strategize their factory layouts.
+
+  Only specific machines, such as assembling machines, furnaces, roboports, chemical plants... can generate ore drops,
+  while entities already allowed on ore like miners, belts, and power poles will not.
+
+  Additionally, upgrading your base will also spawn resources, so plan and upgrade carefully!
+  Transform your gameplay and embrace the permanence of your factory's footprint!
+]])
+
+DOC.scenario_name = 'danger-ore-grid-permanence'
+DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_grid_factory'
+DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.config.vanilla_ores_landfill'
+DOC.map_config.spawn_tile = 'red-refined-concrete'
+
+local permanence = require 'map_gen.maps.danger_ores.modules.permanence'
+permanence({ multiplier = 1 })
+
+return Scenario.register(DOC)

--- a/scenario_templates/danger-ore-permanence/map_selection.lua
+++ b/scenario_templates/danger-ore-permanence/map_selection.lua
@@ -1,0 +1,1 @@
+return require 'map_gen.maps.danger_ores.presets.danger_ore_permanence'


### PR DESCRIPTION
Permanence is a module that makes it so when mining an entity (if it's not one of the entities whitelisted to be built on ore like miners, poles, belts, rails...) it will spawn ore beneath it.

This evil map makes planning the base in advance much more important, as even upgrading machines will cause ore to spawn beneath old machine mined!

Map description:

```
  Mined entities will create ore drops beneath them, encouraging players to strategize their factory layouts.

  Only specific machines, such as assembling machines, furnaces, roboports, chemical plants... can generate ore drops,
  while entities already allowed on ore like miners, belts, and power poles will not.

  Additionally, upgrading your base will also spawn resources, so plan and upgrade carefully!
  Transform your gameplay and embrace the permanence of your factory's footprint!
```

`danger_ores/modules/permanence.lua` has additional info on parameters it accepts to customize it.
By default, iron > copper > coal > stone are spawned (only 1 type of ore per entity)m and total amount of ore spawned = entity's health.

Here's an example of the ore footprint left behind when mining assemblers or upgrading inserters
> ![permanence](https://github.com/user-attachments/assets/8fc08bba-740b-4436-8ff2-5d927226ccb5)
