### PR TITLE
Update water settings in map gen settings

### DIFF
--- a/features/antigrief.lua
+++ b/features/antigrief.lua
@@ -6,7 +6,30 @@ storage.original_last_users_by_ent_pos = {}
 
 Event.on_init(
     function()
-        storage.ag_surface = game.create_surface('antigrief', {autoplace_controls = {coal = {frequency = 'normal', richness = 'normal', size = 'none'}, ['copper-ore'] = {frequency = 'normal', richness = 'normal', size = 'none'}, ['crude-oil'] = {frequency = 'normal', richness = 'normal', size = 'none'}, desert = {frequency = 'normal', richness = 'normal', size = 'none'}, dirt = {frequency = 'normal', richness = 'normal', size = 'none'}, ['enemy-base'] = {frequency = 'normal', richness = 'normal', size = 'none'}, grass = {frequency = 'normal', richness = 'normal', size = 'none'}, ['iron-ore'] = {frequency = 'normal', richness = 'normal', size = 'none'}, sand = {frequency = 'normal', richness = 'normal', size = 'none'}, stone = {frequency = 'normal', richness = 'normal', size = 'none'}, trees = {frequency = 'normal', richness = 'normal', size = 'none'}, ['uranium-ore'] = {frequency = 'normal', richness = 'normal', size = 'none'}}, cliff_settings = {cliff_elevation_0 = 1024, cliff_elevation_interval = 10, name = 'cliff'}, height = 2000000, peaceful_mode = false, seed = 3461559752, starting_area = 'very-low', starting_points = {{x = 0, y = 0}}, terrain_segmentation = 'normal', water = 'normal', width = 2000000})
+        storage.ag_surface = game.create_surface('antigrief', {
+            autoplace_controls = {
+                coal = {frequency = 'normal', richness = 'normal', size = 'none'},
+                ['copper-ore'] = {frequency = 'normal', richness = 'normal', size = 'none'},
+                ['crude-oil'] = {frequency = 'normal', richness = 'normal', size = 'none'},
+                desert = {frequency = 'normal', richness = 'normal', size = 'none'},
+                dirt = {frequency = 'normal', richness = 'normal', size = 'none'},
+                ['enemy-base'] = {frequency = 'normal', richness = 'normal', size = 'none'},
+                grass = {frequency = 'normal', richness = 'normal', size = 'none'},
+                ['iron-ore'] = {frequency = 'normal', richness = 'normal', size = 'none'},
+                sand = {frequency = 'normal', richness = 'normal', size = 'none'},
+                stone = {frequency = 'normal', richness = 'normal', size = 'none'},
+                trees = {frequency = 'normal', richness = 'normal', size = 'none'},
+                ['uranium-ore'] = {frequency = 'normal', richness = 'normal', size = 'none'},
+                water = {frequency = 'normal', richness = 'normal', size = 'normal'},
+            },
+            cliff_settings = {cliff_elevation_0 = 1024, cliff_elevation_interval = 10, name = 'cliff'},
+            height = 2000000,
+            peaceful_mode = false,
+            seed = 3461559752,
+            starting_area = 'very-low',
+            starting_points = {{x = 0, y = 0}},
+            width = 2000000
+        })
         storage.ag_surface.always_day = true
     end
 )

--- a/map_gen/maps/HilbertSandTrap.lua
+++ b/map_gen/maps/HilbertSandTrap.lua
@@ -88,8 +88,13 @@ local tree_settings = {
 -- This seems to be a decent balance between small pools of water and not blocking entire sections
 -- of the maze near spawn by lakes
 local water_settings = {
-    terrain_segmentation = 'high',
-    water = 'low'
+    autoplace_controls = {
+        water = {
+            frequency = 'low', -- 'high' terrain segmentation
+            richness = 'normal',
+            size = 'low'
+        },
+    }
 }
 --Set map settings
 RS.set_map_gen_settings(

--- a/map_gen/maps/crash_site/cutscene_surface_settings.lua
+++ b/map_gen/maps/crash_site/cutscene_surface_settings.lua
@@ -50,6 +50,11 @@ return {
             frequency = 1,
             richness = 1,
             size = 0
+        },
+        water = {
+            frequency = 1,
+            richness = 1,
+            size = 1,
         }
     },
     cliff_settings = {
@@ -64,6 +69,4 @@ return {
     starting_points = {
         {x = 0, y = 0}
     },
-    terrain_segmentation = 1,
-    water = 1
 }

--- a/map_gen/maps/crash_site/presets/desert.lua
+++ b/map_gen/maps/crash_site/presets/desert.lua
@@ -6,7 +6,7 @@ local config = {
     map_gen_settings = {
         MGSP.sand_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/desert.lua
+++ b/map_gen/maps/crash_site/presets/desert.lua
@@ -6,10 +6,7 @@ local config = {
     map_gen_settings = {
         MGSP.sand_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/logistic_network_embargo.lua
+++ b/map_gen/maps/crash_site/presets/logistic_network_embargo.lua
@@ -7,7 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/logistic_network_embargo.lua
+++ b/map_gen/maps/crash_site/presets/logistic_network_embargo.lua
@@ -7,10 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/no_bots.lua
+++ b/map_gen/maps/crash_site/presets/no_bots.lua
@@ -7,7 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/no_bots.lua
+++ b/map_gen/maps/crash_site/presets/no_bots.lua
@@ -7,10 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/normal.lua
+++ b/map_gen/maps/crash_site/presets/normal.lua
@@ -6,10 +6,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/only_construction_bots.lua
+++ b/map_gen/maps/crash_site/presets/only_construction_bots.lua
@@ -7,7 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/only_construction_bots.lua
+++ b/map_gen/maps/crash_site/presets/only_construction_bots.lua
@@ -7,10 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/only_personal_bots.lua
+++ b/map_gen/maps/crash_site/presets/only_personal_bots.lua
@@ -7,7 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/only_personal_bots.lua
+++ b/map_gen/maps/crash_site/presets/only_personal_bots.lua
@@ -7,10 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/raining_bullets.lua
+++ b/map_gen/maps/crash_site/presets/raining_bullets.lua
@@ -7,7 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/raining_bullets.lua
+++ b/map_gen/maps/crash_site/presets/raining_bullets.lua
@@ -7,10 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/spiderless.lua
+++ b/map_gen/maps/crash_site/presets/spiderless.lua
@@ -7,7 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/spiderless.lua
+++ b/map_gen/maps/crash_site/presets/spiderless.lua
@@ -7,10 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/steam_all_the_way.lua
+++ b/map_gen/maps/crash_site/presets/steam_all_the_way.lua
@@ -7,7 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        MGSP.water_segmented,
+        MGSP.water_very_low,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/presets/steam_all_the_way.lua
+++ b/map_gen/maps/crash_site/presets/steam_all_the_way.lua
@@ -7,10 +7,7 @@ local config = {
     map_gen_settings = {
         MGSP.grass_only,
         MGSP.enable_water,
-        {
-            terrain_segmentation = 6,
-            water = 0.25
-        },
+        MGSP.water_segmented,
         MGSP.starting_area_very_low,
         MGSP.ore_oil_none,
         MGSP.enemy_none,

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -26,7 +26,7 @@ local cutscene_force_name = 'cutscene'
 local default_map_gen_settings = {
     MGSP.grass_only,
     MGSP.enable_water,
-    MGSP.water_segmented,
+    MGSP.water_very_low,
     MGSP.starting_area_very_low,
     MGSP.ore_oil_none,
     MGSP.enemy_none,

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -26,10 +26,7 @@ local cutscene_force_name = 'cutscene'
 local default_map_gen_settings = {
     MGSP.grass_only,
     MGSP.enable_water,
-    {
-        terrain_segmentation = 6,
-        water = 0.25
-    },
+    MGSP.water_segmented,
     MGSP.starting_area_very_low,
     MGSP.ore_oil_none,
     MGSP.enemy_none,

--- a/map_gen/maps/danger_ores/modules/helper.lua
+++ b/map_gen/maps/danger_ores/modules/helper.lua
@@ -31,7 +31,7 @@ function Public.empty_map_settings(resource_list)
         MGSP.enemy_none,
         MGSP.cliff_none,
         MGSP.tree_none,
-        { terrain_segmentation = 'normal', water = 'normal' },
+        MGSP.water_normal,
         Public.ore_oil_none(resource_list)
     }
 end

--- a/map_gen/maps/frontier/modules/terrain.lua
+++ b/map_gen/maps/frontier/modules/terrain.lua
@@ -80,7 +80,6 @@ RS.set_map_gen_settings({
       ['control-setting:moisture:frequency:multiplier'] = '3.000000',
     },
     starting_area = 3,
-    terrain_segmentation = 1,
   },
   MGSP.water_none,
 })

--- a/map_gen/maps/hilbert_water_trap.lua
+++ b/map_gen/maps/hilbert_water_trap.lua
@@ -94,8 +94,13 @@ local tree_settings = {
 -- This seems to be a decent balance between small pools of water and not blocking entire sections
 -- of the maze near spawn by lakes
 local water_settings = {
-    terrain_segmentation = 'high',
-    water = 'low'
+    autoplace_controls = {
+        water = {
+            frequency = 'low', -- 'high' terrain segmentation
+            richness = 'normal',
+            size = 'low'
+        },
+    }
 }
 --Set map settings
 RS.set_map_gen_settings(

--- a/map_gen/maps/quadrants/settings.lua
+++ b/map_gen/maps/quadrants/settings.lua
@@ -63,12 +63,13 @@ local settings = {
                     frequency = 0.5,
                     richness = 0.25,
                     size = 0.5
+                },
+                water = {
+                    frequency = 2,
+                    richness = 1,
+                    size = 0.5
                 }
             }
-        },
-        water = {
-            terrain_segmentation = 0.5,
-            water = 0.5
         },
         enemy = {
             autoplace_controls = {

--- a/map_gen/maps/toxic_science_jungle.lua
+++ b/map_gen/maps/toxic_science_jungle.lua
@@ -45,10 +45,12 @@ local map_gen_settings = {
         },
         ['crude-oil'] = {
             richness = 'very-good'
+        },
+        water = {
+            frequency = 'very-low', -- 'very-high' terrain segmentation
+            size = 'very-big',
         }
     },
-    terrain_segmentation = 'very-high',
-    water = 'very-big'
 }
 RS.set_map_gen_settings({map_gen_settings})
 RS.set_map_settings({enemy_expansion = {enabled = true}})

--- a/resources/alien_biomes/biomes.lua
+++ b/resources/alien_biomes/biomes.lua
@@ -36,10 +36,7 @@ function Public.preset_to_mgs(preset)
   end
 
   if preset.water then
-    mgs.water = preset.water.water.size
-    if preset.water.water.frequency and preset.water.water.frequency > 0 then
-      mgs.terrain_segmentation = 1 / preset.water.water.frequency
-    end
+    mgs.autoplace_controls.water = preset.water.water
   end
 
   if preset.trees then

--- a/resources/alien_biomes/biomes_settings.lua
+++ b/resources/alien_biomes/biomes_settings.lua
@@ -53,11 +53,11 @@ return {
     max       = { cliff = { frequency = 6,    richness = 2 } },
   },
   water = {
-    none      = { water = { frequancy = 1,   size = 0 } },
-    low       = { water = { frequency = 0.5, size = 0.3 } },
-    med       = { water = { frequency = 1,   size = 1 } },
-    high      = { water = { frequency = 1,   size = 4 } },
-    max       = { water = { frequency = 0.5, size = 10 } },
+    none      = { water = { frequency = 1,   richness = 1, size = 0 } },
+    low       = { water = { frequency = 0.5, richness = 1, size = 0.3 } },
+    med       = { water = { frequency = 1,   richness = 1, size = 1 } },
+    high      = { water = { frequency = 1,   richness = 1, size = 4 } },
+    max       = { water = { frequency = 0.5, richness = 1, size = 10 } },
   },
   enemy = {
     none      = { ['enemy-base'] = { frequency = 1e-6, size = -1,  richness = -1 } },

--- a/resources/map_gen_settings.lua
+++ b/resources/map_gen_settings.lua
@@ -7,7 +7,11 @@
     This will output a file with a table that you can add to this resources file or into your specific map.
     In either case, make sure to set seed to nil unless you want your map to be *exactly* the same each time.
     The expectation is that all changes that deviate from default generation are noted.
-    Water size and frequency is not denoted as such. Instead water size = water and water frequency = terrain_segmentation
+
+    Water:
+        frequency: (water scale), defines "Terrain segmentation" := 1 / water.frequency
+        richness: 0/1, defines the presence of water on map
+        size: (water coverage), defines the amount of water on map
 ]]
 return {
     -- the default table is included as a reference but also to give the option of overwriting all user settings
@@ -38,6 +42,21 @@ return {
                 richness = 1,
                 size = 1
             },
+            nauvis_cliff = {
+                frequency = 1,
+                richness = 1,
+                size = 1
+            },
+            rocks = {
+                frequency = 1,
+                richness = 1,
+                size = 1
+            },
+            starting_area_moisture = {
+                frequency = 1,
+                richness = 1,
+                size = 1
+            },
             stone = {
                 frequency = 1,
                 richness = 1,
@@ -52,16 +71,24 @@ return {
                 frequency = 1,
                 richness = 1,
                 size = 1
-            }
+            },
+            water = {
+                frequency = 1,
+                richness = 1,
+                size = 1
+            },
         },
         autoplace_settings = {},
         cliff_settings = {
             cliff_elevation_0 = 10,
             cliff_elevation_interval = 40,
+            cliff_smoothing = 0,
+            control = 'nauvis_cliff',
             name = 'cliff',
             richness = 1
         },
         height = 2000000,
+        no_enemies_mode = false,
         peaceful_mode = false,
         property_expression_names = {},
         seed = nil,
@@ -72,8 +99,6 @@ return {
                 y = 0
             }
         },
-        terrain_segmentation = 1,
-        water = 1,
         width = 2000000
     },
     -- no enemies
@@ -198,8 +223,32 @@ return {
     },
     -- very low water
     water_very_low = {
-        terrain_segmentation = 0.5,
-        water = 0.5
+        autoplace_controls = {
+            water = {
+                frequency = 1/6,
+                richness = 1,
+                size = 1/6
+            },
+        }
+    },
+    -- segmented water (terrain_segmentation = 6, water = 0.25)
+    water_segmented = {
+        autoplace_controls = {
+            water = {
+                frequency = 1/6,
+                richness = 1,
+                size = 0.25,
+            }
+        }
+    },
+    water_normal = {
+        autoplace_controls = {
+            water = {
+                frequency = 1,
+                richness = 1,
+                size = 1,
+            }
+        }
     },
     -- no cliffs
     cliff_none = {
@@ -211,9 +260,14 @@ return {
     },
     -- normal cliffs
     cliff_normal = {
-        name = 'cliff',
-        cliff_elevation_0 = 10,
-        cliff_elevation_interval = 10
+        cliff_settings = {
+            cliff_elevation_0 = 10,
+            cliff_elevation_interval = 40,
+            cliff_smoothing = 0,
+            control = 'nauvis_cliff',
+            name = 'cliff',
+            richness = 1
+        },
     },
     -- cliffs to high frequency, big size
     cliff_high = {

--- a/resources/map_gen_settings.lua
+++ b/resources/map_gen_settings.lua
@@ -227,18 +227,8 @@ return {
             water = {
                 frequency = 1/6,
                 richness = 1,
-                size = 1/6
+                size = 0.25
             },
-        }
-    },
-    -- segmented water (terrain_segmentation = 6, water = 0.25)
-    water_segmented = {
-        autoplace_controls = {
-            water = {
-                frequency = 1/6,
-                richness = 1,
-                size = 0.25,
-            }
         }
     },
     water_normal = {

--- a/resources/map_gen_size.lua
+++ b/resources/map_gen_size.lua
@@ -1,0 +1,22 @@
+-- source: https://lua-api.factorio.com/latest/concepts/MapGenSize.html
+
+local sqrt2 = math.sqrt(2)
+
+return {
+  none = 0,
+  very_low = 1 / 2,
+  very_small = 1 / 2,
+  very_poor = 1 / 2,
+  low = 1 / sqrt2,
+  small = 1 / sqrt2,
+  poor = 1 / sqrt2,
+  normal = 1,
+  medium = 1,
+  regular = 1,
+  high = sqrt2,
+  big = sqrt2,
+  good = sqrt2,
+  very_high = 2,
+  very_big = 2,
+  very_good = 2,
+}


### PR DESCRIPTION
# Changes

- [x] Updated `resources/map_gen_settings` presets to 2.0
- [x] Updated scenarios with new water format
- [x] Added `map_gen_size` in resources for future reference

Basically `MapGenSettings::water` and `MapGenSettings::terrain_segmentation` have been moved inside `MapGenSettings::autoplace_controls->water` in 2.0, with default params `frequency/richness/size` just like ores instead of being stand alone in root mgs.