### PR TITLE
Update April Fools map

### DIFF
--- a/map_gen/maps/april_fools/2024.lua
+++ b/map_gen/maps/april_fools/2024.lua
@@ -3,9 +3,17 @@
   2024 revamped version of "Pinguin" scenario from 2019 with several addons.
 
   Required mods:
-  - Alien Biomes v0.6.8
-  - RedMew Data  v0.2.4
+  - Alien Biomes v0.7.2
+  - RedMew Data  v1.1.0
 ]]
+
+if not script.active_mods['alien-biomes'] or not (script.active_mods['redmew-data'] and settings.startup.redmew_scenario.value == 'april-fools') then
+  error([[
+    Missing dependencies. Please check that the following mods have been correctly installed:
+    - Alien Biomes >= v0.7.2
+    - RedMew Data >= v1.1.0 & scenario setting "April Fools"
+  ]])
+end
 
 local ScenarioInfo = require 'features.gui.info'
 ScenarioInfo.set_map_name('Double Trouble')
@@ -64,6 +72,7 @@ end
 
 local Event = require 'utils.event'
 local ABS = require 'resources.alien_biomes.biomes_settings'
+local ABT = require 'resources.alien_biomes.tile_presets'
 local Biomes = require 'resources.alien_biomes.biomes'
 local mgs = Biomes.preset_to_mgs
 
@@ -80,8 +89,14 @@ local function on_init()
   -- Above ground
   local islands_preset = Biomes.presets.ice
   islands_preset.water = ABS.water.low
-  islands_preset.enemy = ABS.enemy.low
+  islands_preset.enemy = ABS.enemy.high
   local islands_mgs = mgs(islands_preset)
+  islands_mgs.starting_area = 3
+  islands_mgs.autoplace_settings = ABT.cold
+  islands_mgs.autoplace_settings.tile.treat_missing_as_default = true
+  for tile, _ in pairs(ABT.default.tile.settings) do
+    islands_mgs.autoplace_settings.tile.settings[tile] = { frequency = 1, size = 0, richness = 1 }
+  end
   for _, resource in pairs({'iron-ore', 'copper-ore', 'stone', 'coal', 'uranium-ore', 'crude-oil'}) do
     islands_mgs.autoplace_controls[resource] = { frequency = 1, richness = 1, size = 0 }
   end
@@ -91,6 +106,7 @@ local function on_init()
   islands.request_to_generate_chunks(spawn, 5)
   islands.force_generate_chunk_requests()
   islands.ticks_per_day = 72000
+  islands.localised_name = 'Islands'
 
   -- Under ground
   local mines_preset = Biomes.presets.volcano
@@ -98,11 +114,9 @@ local function on_init()
   mines_preset.enemy = ABS.enemy.none
   local mines_mgs = mgs(mines_preset)
   mines_mgs.seed = _DEBUG and 309111855 or nil
-  mines_mgs.autoplace_settings = {
-    tile = {}
-  }
+  mines_mgs.autoplace_settings = ABT.volcano
   for _, tile in pairs({'deepwater', 'deepwater-green', 'water', 'water-green', 'water-mud', 'water-shallow'}) do
-    mines_mgs.autoplace_settings.tile[tile] = { frequency = 1, size = 0, richness = 1 }
+    mines_mgs.autoplace_settings.tile.settings[tile] = { frequency = 1, size = 0, richness = 1 }
   end
   for _, resource in pairs({'iron-ore', 'copper-ore', 'stone', 'coal', 'uranium-ore', 'crude-oil'}) do
     mines_mgs.autoplace_controls[resource] = { frequency = 12.0, size = 0.5, richness = 0.08 }
@@ -117,6 +131,7 @@ local function on_init()
   mines.freeze_daytime = true
   mines.show_clouds = false
   mines.brightness_visual_weights = {1/0.85, 1/0.85, 1/0.85}
+  mines.localised_name = 'Mines'
 
   game.forces.player.set_surface_hidden('nauvis', true)
   game.forces.player.set_spawn_position(spawn, 'islands')

--- a/map_gen/maps/april_fools/2024.lua
+++ b/map_gen/maps/april_fools/2024.lua
@@ -79,13 +79,14 @@ local function on_init()
 
   -- Above ground
   local islands_preset = Biomes.presets.ice
-  islands_preset.water = ABS.water.max
-  islands_preset.enemy = ABS.enemy.high
+  islands_preset.water = ABS.water.low
+  islands_preset.enemy = ABS.enemy.low
   local islands_mgs = mgs(islands_preset)
   for _, resource in pairs({'iron-ore', 'copper-ore', 'stone', 'coal', 'uranium-ore', 'crude-oil'}) do
     islands_mgs.autoplace_controls[resource] = { frequency = 1, richness = 1, size = 0 }
   end
   islands_mgs.autoplace_controls['crude-oil'] = { frequency = 1, richness = 2, size = 1.2 }
+  islands_mgs.property_expression_names.elevation = 'elevation_island'
   local islands = game.create_surface('islands', islands_mgs)
   islands.request_to_generate_chunks(spawn, 5)
   islands.force_generate_chunk_requests()
@@ -94,6 +95,7 @@ local function on_init()
   -- Under ground
   local mines_preset = Biomes.presets.volcano
   mines_preset.water = ABS.water.none
+  mines_preset.enemy = ABS.enemy.none
   local mines_mgs = mgs(mines_preset)
   mines_mgs.seed = _DEBUG and 309111855 or nil
   mines_mgs.autoplace_settings = {
@@ -116,6 +118,7 @@ local function on_init()
   mines.show_clouds = false
   mines.brightness_visual_weights = {1/0.85, 1/0.85, 1/0.85}
 
+  game.forces.player.set_surface_hidden('nauvis', true)
   game.forces.player.set_spawn_position(spawn, 'islands')
   game.forces.player.manual_mining_speed_modifier = _DEBUG and 20 or 1.2
 end

--- a/map_gen/maps/april_fools/2024.lua
+++ b/map_gen/maps/april_fools/2024.lua
@@ -144,7 +144,7 @@ local modules = {
   require 'map_gen.maps.april_fools.modules.auto_build',          -- Randomly selected players will have their cursor items automatically built nearby for a time, before changing targets
   require 'map_gen.maps.april_fools.modules.biter_ores',          -- Biters spawn ores on death, level determines amount
   require 'map_gen.maps.april_fools.modules.crazy_chat_colors',   -- Chance to change player's color every time they send a message in chat
-  require 'map_gen.maps.april_fools.modules.crazy_toolbar',       -- Randomly replaces quickbar slots with new items
+  require 'map_gen.maps.april_fools.modules.crazy_toolbar',       -- Randomly replaces quick-bar slots with new items
   require 'map_gen.maps.april_fools.modules.enemy_turrets',       -- Chance to change turret to enemy force, and give it ammo/fuel/power
   require 'map_gen.maps.april_fools.modules.explosion_scare',     -- Spawns random non-damaging explosions on random players as a jump-scare
   require 'map_gen.maps.april_fools.modules.floor_is_lava',       -- Does minor damage to a player when afk for a few second
@@ -152,12 +152,12 @@ local modules = {
   require 'map_gen.maps.april_fools.modules.marathon_mode',       -- Enables expensive recipes and increases technology multiplier
   require 'map_gen.maps.april_fools.modules.meteOres',            -- Meteors fall from the sky, generating ores, and biters
   require 'map_gen.maps.april_fools.modules.orphan_crafting',     -- Chance to give the player an additional single underground belt or pipe-to-ground
-  require 'map_gen.maps.april_fools.modules.permanent_factory',   -- Chance to make an entity indestructable
+  require 'map_gen.maps.april_fools.modules.permanent_factory',   -- Chance to make an entity indestructible
   require 'map_gen.maps.april_fools.modules.random_ores',         -- Chance to change an ore to a random ore when a mining drill is placed
   require 'map_gen.maps.april_fools.modules.rotate_entities',     -- Chance to randomly rotate an entity when rotated by a player
   require 'map_gen.maps.april_fools.modules.rotate_inserters',    -- Chance to randomly rotate an inserter when built
   require 'map_gen.maps.april_fools.modules.rotten_egg',          -- Randomly selected players will produce pollution for a time, before changing targets
-  require 'map_gen.maps.april_fools.modules.unorganized_recipes', -- Randomly selected players will have their recipe groups and subgroups disabled, unorganizing their crafting menu
+  require 'map_gen.maps.april_fools.modules.unorganized_recipes', -- Randomly selected players will have their recipe groups and subgroups disabled, un-organizing their crafting menu
 }
 
 -- if script.active_mods['redmew-data'] then

--- a/map_gen/maps/april_fools/modules/marathon_mode.lua
+++ b/map_gen/maps/april_fools/modules/marathon_mode.lua
@@ -17,11 +17,6 @@ Global.register(_global, function(tbl) _global = tbl end)
 local function update_price_multiplier()
   local level = math.max(0, _global.level)
 
-  -- Enable expensive recipes after lvl.3
-  game.difficulty_settings.recipe_difficulty = (level > 3) and 1 or 0
-
-  -- Apply expensive tech cost above lvl.0
-  game.difficulty_settings.technology_difficulty = (level > 0) and 1 or 0
   game.difficulty_settings.technology_price_multiplier = (level + 1) * COST_STEP
 end
 

--- a/map_gen/maps/april_fools/scenario/rocket_launched.lua
+++ b/map_gen/maps/april_fools/scenario/rocket_launched.lua
@@ -4,7 +4,7 @@ local ShareGlobals = require 'map_gen.maps.april_fools.scenario.shared_globals'
 
 ShareGlobals.data.map_won = false
 
-local win_satellite_count = 1000
+local win_satellite_count = 100
 
 _G.rocket_launched_win_data = {
   extra_rockets = win_satellite_count
@@ -55,8 +55,24 @@ local function rocket_launched(event)
     return
   end
 
-  local inventory = entity.get_inventory(defines.inventory.rocket_silo_rocket)
-  if not inventory or not inventory.valid then
+  local pod = entity.cargo_pod
+  if not pod or not pod.valid then
+    return
+  end
+
+  local count = 0
+  local qualities = prototypes.quality
+  for k = 1, pod.get_max_inventory_index() do
+    local inventory = pod.get_inventory(k)
+    if inventory then
+      local add = inventory.get_item_count
+      for tier, _ in pairs(qualities) do
+        count = count + add({ name = 'satellite', quality = tier })
+      end
+    end
+  end
+
+  if count == 0 then
     return
   end
 

--- a/map_gen/maps/april_fools/scenario/rocket_waves.lua
+++ b/map_gen/maps/april_fools/scenario/rocket_waves.lua
@@ -144,8 +144,19 @@ local function rocket_launched(event)
     return
   end
 
-  local inventory = entity.get_inventory(defines.inventory.rocket_silo_rocket)
-  if not inventory or not inventory.valid then
+  local count = 0
+  local qualities = prototypes.quality
+  for k = 1, pod.get_max_inventory_index() do
+    local inventory = pod.get_inventory(k)
+    if inventory then
+      local add = inventory.get_item_count
+      for tier, _ in pairs(qualities) do
+        count = count + add({ name = 'satellite', quality = tier })
+      end
+    end
+  end
+
+  if count == 0 then
     return
   end
 
@@ -155,7 +166,7 @@ local function rocket_launched(event)
   end
 
   -- Increase enemy_evolution
-  local current_evolution = game.forces.enemy.get_evolution_factor()
+  local current_evolution = math.max(game.forces.enemy.get_evolution_factor('mines'), game.forces.enemy.get_evolution_factor('islands'))
 
   if (satellite_count % 5) == 0 and win_data.evolution_rocket_maxed == -1 then
     local message = 'Continued launching of satellites has angered the local biter population, evolution increasing...'

--- a/map_gen/maps/april_fools/scenario/rocket_waves.lua
+++ b/map_gen/maps/april_fools/scenario/rocket_waves.lua
@@ -144,6 +144,11 @@ local function rocket_launched(event)
     return
   end
 
+  local pod = entity.cargo_pod
+  if not pod or not pod.valid then
+    return
+  end
+
   local count = 0
   local qualities = prototypes.quality
   for k = 1, pod.get_max_inventory_index() do

--- a/map_gen/maps/april_fools/scenario/template.lua
+++ b/map_gen/maps/april_fools/scenario/template.lua
@@ -174,19 +174,19 @@ end
 
 Template.diggy_rocks = {
   'rock-huge-volcanic',
-  'big-rock-volcanic',
+  'rock-big-volcanic',
   'rock-huge-black',
-  'big-rock-black',
+  'rock-big-black',
   'rock-huge-grey',
-  'big-rock-grey',
+  'rock-big-grey',
   'rock-huge-red',
-  'big-rock-red',
+  'rock-big-red',
   'rock-huge-white',
-  'big-rock-white',
+  'rock-big-white',
   'rock-huge-brown',
-  'big-rock-brown',
+  'rock-big-brown',
   'rock-huge-dustyrose',
-  'big-rock-dustyrose',
+  'rock-big-dustyrose',
 }
 Template.diggy_rocks_map = util.list_to_map(Template.diggy_rocks)
 

--- a/resources/alien_biomes/biomes.lua
+++ b/resources/alien_biomes/biomes.lua
@@ -36,7 +36,7 @@ function Public.preset_to_mgs(preset)
   end
 
   if preset.water then
-    mgs.water = preset.water.water.size
+    mgs.autoplace_controls.water = preset.water.water
     if preset.water.water.frequency and preset.water.water.frequency > 0 then
       mgs.terrain_segmentation = 1 / preset.water.water.frequency
     end

--- a/resources/alien_biomes/biomes_settings.lua
+++ b/resources/alien_biomes/biomes_settings.lua
@@ -53,14 +53,14 @@ return {
     max       = { cliff = { frequency = 6,    richness = 2 } },
   },
   water = {
-    none      = { water = { frequancy = 1,   size = 0 } },
+    none      = { water = { frequency = 1,   size = 0 } },
     low       = { water = { frequency = 0.5, size = 0.3 } },
     med       = { water = { frequency = 1,   size = 1 } },
     high      = { water = { frequency = 1,   size = 4 } },
     max       = { water = { frequency = 0.5, size = 10 } },
   },
   enemy = {
-    none      = { ['enemy-base'] = { frequency = 1e-6, size = -1,  richness = -1 } },
+    none      = { ['enemy-base'] = { frequency = 0,    size = 0,   richness = 0 } },
     very_low  = { ['enemy-base'] = { frequency = 0.1,  size = 0.1, richness = 0.1 } },
     low       = { ['enemy-base'] = { frequency = 0.2,  size = 0.2, richness = 0.2 } },
     med       = { ['enemy-base'] = { frequency = 0.5,  size = 0.5, richness = 0.5 } },

--- a/resources/alien_biomes/tile_presets.lua
+++ b/resources/alien_biomes/tile_presets.lua
@@ -27,13 +27,21 @@ local function make_default_autoplace_settings(tile_table)
       settings = {}
     }
   }
-  for _, tile_name in pairs(Table.concat_tables(tile_table)) do
+  for _, tile_name in pairs(Table.merge(tile_table)) do
     autoplace_settings.tile.settings[tile_name] = {frequency = 1, size = 1, richness = 1}
   end
   return autoplace_settings
 end
 
 return {
+  -- vanilla
+  default = make_default_autoplace_settings{{
+    'grass-1', 'grass-2', 'grass-3', 'grass-4',
+    'dirt-1', 'dirt-2', 'dirt-3', 'dirt-4', 'dirt-5', 'dirt-6', 'dirt-7',
+    'dry-dirt',
+    'sand-1', 'sand-2', 'sand-3',
+    'red-desert-0', 'red-desert-2', 'red-desert-3', 'red-desert-4',
+  }},
   -- Color subsets
   green = make_default_autoplace_settings{
     ab_tiles['vegetation-green-grass'],
@@ -177,16 +185,16 @@ return {
     ab_tiles['mineral-violet-dirt'],
   },
   heat_blue = make_default_autoplace_settings{
-    ab_tiles['volcaninc-blue-heat'],
+    ab_tiles['volcanic-blue-heat'],
   },
   heat_green = make_default_autoplace_settings{
-    ab_tiles['volcaninc-green-heat'],
+    ab_tiles['volcanic-green-heat'],
   },
   heat_orange = make_default_autoplace_settings{
-    ab_tiles['volcaninc-orange-heat'],
+    ab_tiles['volcanic-orange-heat'],
   },
   heat_purple = make_default_autoplace_settings{
-    ab_tiles['volcaninc-purple-heat'],
+    ab_tiles['volcanic-purple-heat'],
   },
 
   -- Full biomes
@@ -194,13 +202,13 @@ return {
     ab_tiles['frozen-snow'],
     ab_tiles['mineral-white-dirt'],
     ab_tiles['mineral-white-sand'],
-    ab_tiles['volcaninc-blue-heat'],
+    ab_tiles['volcanic-blue-heat'],
   },
   hot = make_default_autoplace_settings{
     ab_tiles['mineral-red-dirt'],
     ab_tiles['mineral-red-sand'],
     ab_tiles['vegetation-red-grass'],
-    ab_tiles['volcaninc-orange-heat'],
+    ab_tiles['volcanic-orange-heat'],
   },
   pale = make_default_autoplace_settings{
     ab_tiles['mineral-beige-dirt'],
@@ -243,7 +251,7 @@ return {
     ab_tiles['mineral-red-dirt'],
     ab_tiles['mineral-red-sand'],
     ab_tiles['vegetation-red-grass'],
-    ab_tiles['volcaninc-orange-heat'],
+    ab_tiles['volcanic-orange-heat'],
   },
   mystic_purple = make_default_autoplace_settings{
     ab_tiles['mineral-aubergine-dirt'],


### PR DESCRIPTION
Updates April Fools map to 2.0

# Changes
- [x] Added info message on init if incorrectly loaded without dependencies
- [x] Updated map gen with new Alien Biomes (need to blacklist/whitelist tiles as well due to internal changes. Glad the resource lib I wrote months ago for Ab turned out to be a lot more useful now)
- [x] Fixed crashes when accessing some of old 1.1 API
- [x] Lowered rocket count to win the map from 1'000 to 100 