### PR TITLE
Updates/crash site

### DIFF
--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -415,7 +415,7 @@ function Public.control(config)
         end
 
         local radius = 5 + (radius_level * 3)
-        local count = (count_level - 2) * 5 + 3
+        local count = (count_level - 2) * 10 + 3
         local strikeCost = count * 4 -- the number of poison-capsules required in the chest as payment
 
         -- parse GPS coordinates from map ping
@@ -508,7 +508,7 @@ function Public.control(config)
         end
 
         local radius = 25 + (radius_level * 5)
-        local count = (count_level-1) * 6
+        local count = (count_level-1) * 12
         local strikeCost = count * 4
 
         -- parse GPS coordinates from map ping

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -416,7 +416,7 @@ function Public.control(config)
 
         local radius = 5 + (radius_level * 3)
         local count = (count_level - 2) * 10 + 3
-        local strikeCost = count * 4 -- the number of poison-capsules required in the chest as payment
+        local strikeCost = count * 2 -- the number of poison-capsules required in the chest as payment
 
         -- parse GPS coordinates from map ping
         for m in string.gmatch(location_string, "(%-?%d*%.?%d+)") do -- Assuming the surface name isn't a valid number.
@@ -509,7 +509,7 @@ function Public.control(config)
 
         local radius = 25 + (radius_level * 5)
         local count = (count_level-1) * 12
-        local strikeCost = count * 4
+        local strikeCost = count * 2
 
         -- parse GPS coordinates from map ping
         for m in string.gmatch(location_string, "(%-?%d*%.?%d+)") do -- Assuming the surface name isn't a valid number.
@@ -602,8 +602,8 @@ function Public.control(config)
             local radius_level = airstrike_data.radius_level -- max radius of the strike area
             local count_level = airstrike_data.count_level -- the number of poison capsules launched at the enemy
             local radius = 5 + (radius_level * 3)
-            local count = (count_level - 1) * 5 + 3
-            local strikeCost = count * 4
+            local count = (count_level - 1) * 10 + 3
+            local strikeCost = count * 2
 
             local name = item.name
             local player_name = event.player.name
@@ -661,8 +661,8 @@ function Public.control(config)
             local radius_level = barrage_data.radius_level -- max radius of the strike area
             local count_level = barrage_data.count_level -- the number of poison capsules launched at the enemy
             local radius = 25 + (radius_level * 5)
-            local count = count_level  * 6
-            local strikeCost = count * 4
+            local count = count_level  * 12
+            local strikeCost = count * 2
 
             local name = item.name
             local player_name = event.player.name

--- a/map_gen/maps/crash_site/events.lua
+++ b/map_gen/maps/crash_site/events.lua
@@ -574,3 +574,10 @@ Event.add(
         set_timeout_in_ticks(1, spawn_player, player)
     end
 )
+
+Event.add(defines.events.on_research_finished, function(event)
+    local research = event.research
+    if research.name == 'uranium-mining' then
+        research.force.technologies['uranium-processing'].researched = true
+    end
+end)


### PR DESCRIPTION
# Changes

- [x] Added U-processing auto unlock after U-mining
- [x] Doubled barrage/airstrike effects to counteract 2.0's increase in enemies health

# Health changes from 1.1 to 2.0:

### Small Worm

Health: 200
Resistances: /

### Medium Worm

Health: 400 > 500
Resistances:
 - laser: +20%

### Big Worm

Health: 750 > 1500
Resistances:
 - laser: +50%

### Behemoth Worm
Health:  750 > 3000
Resistances:
 - laser: +80%
 
### Spawners

Spawners' health increases with evolution. Rough estimate of new health coefficient is `factor = 1 + 9 * (evolution^2.25)`
![health](https://camo.githubusercontent.com/98b65148f35f5aa948133bdda21e7b133265410cb1a7423f682724ea397ec720/68747470733a2f2f63646e2e666163746f72696f2e636f6d2f6173736574732f626c6f672d73796e632f6666662d3432372d737061776e65722d6865616c74682d67726170682e706e67)