### PR TITLE
Update weapons rebalance

### DIFF
--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -16,35 +16,35 @@ crash_site_spy_funds=Training these spy fish ain't cheap! You need more coins!
 crash_site_spy_success=__1__ used the /spy command and spent __2__ coins to train a fish to spy on the enemy [gps=__3__,__4__,redmew]
 crash_site_airstrike_invalid=Invalid co-ordinates.
 crash_site_airstrike=Launch an airstrike against the enemy with poison capsules.
-crash_site_airstrike_count=Upgrade the airstrike damage to  to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike followed by a gps position\n\nDamage upgrades increase the number of poison capsules launched by airstrike.\n\nCurrent level: __2__\nCurrent shell count: __3__\nCurrent cost: __4__
-crash_site_airstrike_radius=Upgrade the airstrike radius to level __1__\n\nTo use airstrike place poison capsules in the spawn chest then type /strike followed by a gps position\n\nCurrent level: __2__\nCurrent radius: __3__
-crash_site_airstrike_radius_name_label=Airstrike Radius __1__
-crash_site_airstrike_count_name_label=Airstrike Damage __1__
+crash_site_airstrike_count=Upgrade the airstrike damage to  to level [font=var]__1__[/font]\n\nTo use airstrike place poison capsules in the spawn chest then type /strike followed by a gps position\n\nDamage upgrades increase the number of poison capsules launched by airstrike.\n\n[color=255,230,192][font=default-bold]Current level:[/font][/color] [font=var]__2__[/font]\n[color=255,230,192][font=default-bold]Current shell count:[/font][/color] [font=var]__3__[/font]\n[color=255,230,192][font=default-bold]Current cost:[/font][/color] [font=var]__4__[/font]
+crash_site_airstrike_radius=Upgrade the airstrike radius to level [font=var]__1__[/font]\n\nTo use airstrike place poison capsules in the spawn chest then type /strike followed by a gps position\n\n[color=255,230,192][font=default-bold]Current level:[/font][/color] [font=var]__2__[/font]\n[color=255,230,192][font=default-bold]Current radius:[/font][/color] [font=var]__3__[/font]
+crash_site_airstrike_radius_name_label=[color=255,230,192][font=default-large-bold]Airstrike Radius __1__\n[/font][/color]
+crash_site_airstrike_count_name_label=[color=255,230,192][font=default-large-bold]Airstrike Damage __1__\n[/font][/color]
 crash_site_airstrike_not_researched=You have not researched airstrike yet. Visit the market at the spawn [gps=-3,-3,redmew]
 crash_site_airstrike_insufficient_currency_error=To send an air strike, load __1__ more poison capsules into the payment chest [gps=2.5,-7.5,redmew]
 crash_site_airstrike_friendly_fire_error=You don't want to do that, no enemies found in the target area.
 crash_site_airstrike_damage_upgrade_success=__1__ has upgraded Airstrike Damage to level __2__
 crash_site_airstrike_radius_upgrade_success=__1__ has updgraded Airstrike Radius to level __2__
-crash_site_airstrike_planner_label=Poison strike targetting remote.
+crash_site_airstrike_planner_label=[color=255,230,192][font=default-large-bold]Poison strike targetting remote\n[/font][/color]
 crash_site_airstrike_planner_description=Use this deconstruction planner to easily launch a poison strike with a click. Put it in your hotbar for easy access.
 crash_site_airstrike_no_enemies=No enemies found at [gps=__1__,__2__,__3__]. What a waste of poison capsules!
-crash_site_barrage_planner_label=Barrage targetting remote.
+crash_site_barrage_planner_label=[color=255,230,192][font=default-large-bold]Barrage targetting remote\n[/font][/color]
 crash_site_barrage_planner_description=Use this deconstruction planner to easily launch an artillery barrage with a click. Put it in your hotbar for easy access.
 crash_site_barrage_invalid=Invalid co-ordinates.
 crash_site_barrage=Launch a barrage of heat seeking rockets against the enemy.
-crash_site_barrage_count=Upgrade the barrage damage to  to level __1__\n\nTo use barrage place explosive rockets in the spawn chest then type /barrage followed by a gps position\n\nDamage upgrades increase the number of rockets launched.\n\nCurrent level: __2__\nCurrent rocket count: __3__\nCurrent cost: __4__ rockets
-crash_site_barrage_radius=Upgrade the barrage radius to level __1__\n\nTo use barrage place explosive rockets in the spawn chest then type /barrage followed by a gps position\n\nCurrent level: __2__\nCurrent radius: __3__
-crash_site_barrage_radius_name_label=Rocket Barrage Radius __1__
-crash_site_barrage_count_name_label=Rocket Barrage Damage __1__
+crash_site_barrage_count=Upgrade the barrage damage to  to level [font=var]__1__[/font]\n\nTo use barrage place explosive rockets in the spawn chest then type /barrage followed by a gps position\n\nDamage upgrades increase the number of rockets launched.\n\n[color=255,230,192][font=default-bold]Current level:[/font][/color] [font=var]__2__[/font]\n[color=255,230,192][font=default-bold]Current rocket count:[/font][/color] [font=var]__3__[/font]\n[color=255,230,192][font=default-bold]Current cost:[/font][/color] [font=var]__4__[/font] rockets
+crash_site_barrage_radius=Upgrade the barrage radius to level [font=var]__1__[/font]\n\nTo use barrage place explosive rockets in the spawn chest then type /barrage followed by a gps position\n\n[color=255,230,192][font=default-bold]Current level:[/font][/color] [font=var]__2__[/font]\n[color=255,230,192][font=default-bold]Current radius:[/font][/color] [font=var]__3__[/font]
+crash_site_barrage_radius_name_label=[color=255,230,192][font=default-large-bold]Rocket Barrage Radius __1__\n[/font][/color]
+crash_site_barrage_count_name_label=[color=255,230,192][font=default-large-bold]Rocket Barrage Damage __1__\n[/font][/color]
 crash_site_barrage_not_researched=You have not researched Barrage yet. Visit the market at the spawn [gps=-3,-3,redmew]
 crash_site_barrage_insufficient_currency_error=To send a rocket barrage, load __1__ more explosive rockets into the payment chest [gps=-4.5,-7.5,redmew]
 crash_site_barrage_no_nests=No nests found at these coordinates ([gps=__1__,__2__,__3__]), what a waste of rockets!
 crash_site_barrage_damage_upgrade_success=__1__ has upgraded Rocket Barrage Damage to level __2__
 crash_site_barrage_radius_upgrade_success=__1__ has updgraded Rocket Barrage Radius to level __2__
-crash_site_rocket_tanks_name_label=Rocket Tanks Fire Interval __1__
+crash_site_rocket_tanks_name_label=[color=255,230,192][font=default-large-bold]Rocket Tanks Fire Interval __1__\n[/font][/color]
 crash_site_rocket_tank_upgrade_success=__1__ has upgraded Rocket Tank interval to level __2__
-crash_site_rocket_tanks_description= Upgrade the rocket tank firing interval to reduce the time between rockets.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.
-crash_site_spider_army_decon_label= Spidertron Army Grouping Planner
+crash_site_rocket_tanks_description=Upgrade the rocket tank firing interval to reduce the time between rockets.\n\nPlace rockets in the tank inventory to have them automatically target enemy worms and nests.
+crash_site_spider_army_decon_label=[color=255,230,192][font=default-large-bold]Spidertron Army Grouping Planner\n[/font][/color]
 crash_site_spider_army_decon_description=Use this deconstruction planner to quickly group spidertrons into an army. First, group select an area containing your spidertrons. Second, single left click a target spidertron for your group to follow.
 max_level=(MAX LEVEL)
 dataset_copy=Copies a dataset

--- a/map_gen/maps/crash_site/commands.lua
+++ b/map_gen/maps/crash_site/commands.lua
@@ -402,6 +402,12 @@ function Public.control(config)
         }
     end
 
+    local function strike_formula(count_level)
+        local count = (count_level - 2) * 10 + 3
+        local cost = count * 2 -- the number of poison-capsules required in the chest as payment
+        return count, cost
+    end
+
     local function strike(args, player)
         local s = player.surface
         local location_string = args.location
@@ -415,8 +421,7 @@ function Public.control(config)
         end
 
         local radius = 5 + (radius_level * 3)
-        local count = (count_level - 2) * 10 + 3
-        local strikeCost = count * 2 -- the number of poison-capsules required in the chest as payment
+        local count, strikeCost = strike_formula(count_level)
 
         -- parse GPS coordinates from map ping
         for m in string.gmatch(location_string, "(%-?%d*%.?%d+)") do -- Assuming the surface name isn't a valid number.
@@ -486,13 +491,19 @@ function Public.control(config)
 
     local spawn_rocket_callback = Token.register(function(data)
         data.s.create_entity {
-            name = "explosive-rocket",
+            name = "artillery-projectile", --"explosive-rocket",
             position = {0, 0},
             target = {data.xpos, data.ypos},
             speed = 10,
             max_range = 100000
         }
     end)
+
+    local function barrage_formula(count_level)
+        local count = (count_level-1)
+        local cost = count * 24
+        return count, cost
+    end
 
     local function barrage(args, player)
         local s = player.surface
@@ -508,8 +519,7 @@ function Public.control(config)
         end
 
         local radius = 25 + (radius_level * 5)
-        local count = (count_level-1) * 12
-        local strikeCost = count * 2
+        local count, strikeCost = barrage_formula(count_level)
 
         -- parse GPS coordinates from map ping
         for m in string.gmatch(location_string, "(%-?%d*%.?%d+)") do -- Assuming the surface name isn't a valid number.
@@ -540,7 +550,7 @@ function Public.control(config)
             local inv = dropbox.get_inventory(defines.inventory.chest)
             local capCount = inv.get_item_count("explosive-rocket")
 
-            if capCount < count then
+            if capCount < strikeCost then
                 player.print({
                     'command_description.crash_site_barrage_insufficient_currency_error',
                     strikeCost - capCount
@@ -601,14 +611,12 @@ function Public.control(config)
         if item.type == 'airstrike' then
             local radius_level = airstrike_data.radius_level -- max radius of the strike area
             local count_level = airstrike_data.count_level -- the number of poison capsules launched at the enemy
-            local radius = 5 + (radius_level * 3)
-            local count = (count_level - 1) * 10 + 3
-            local strikeCost = count * 2
 
             local name = item.name
             local player_name = event.player.name
             if name == 'airstrike_damage' then
                 airstrike_data.count_level = airstrike_data.count_level + 1
+                local count, strikeCost = strike_formula(airstrike_data.count_level)
 
                 Toast.toast_all_players(15, {
                     'command_description.crash_site_airstrike_damage_upgrade_success',
@@ -629,6 +637,8 @@ function Public.control(config)
                 Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.
             elseif name == 'airstrike_radius' then
                 airstrike_data.radius_level = airstrike_data.radius_level + 1
+                local radius = 5 + (airstrike_data.radius_level * 3)
+
                 Toast.toast_all_players(15, {
                     'command_description.crash_site_airstrike_radius_upgrade_success',
                     player_name,
@@ -660,14 +670,12 @@ function Public.control(config)
         if item.type == 'barrage' then
             local radius_level = barrage_data.radius_level -- max radius of the strike area
             local count_level = barrage_data.count_level -- the number of poison capsules launched at the enemy
-            local radius = 25 + (radius_level * 5)
-            local count = count_level  * 12
-            local strikeCost = count * 2
 
             local name = item.name
             local player_name = event.player.name
             if name == 'barrage_damage' then
                 barrage_data.count_level = barrage_data.count_level + 1
+                local count, strikeCost = barrage_formula(barrage_data.count_level)
 
                 Toast.toast_all_players(15, {
                     'command_description.crash_site_barrage_damage_upgrade_success',
@@ -688,6 +696,8 @@ function Public.control(config)
                 Retailer.set_item(market_id, item) -- this updates the retailer with the new item values.
             elseif name == 'barrage_radius' then
                 barrage_data.radius_level = barrage_data.radius_level + 1
+                local radius = 25 + (barrage_data.radius_level * 5)
+
                 Toast.toast_all_players(15, {
                     'command_description.crash_site_barrage_radius_upgrade_success',
                     player_name,
@@ -715,6 +725,7 @@ function Public.control(config)
                 cursor_stack.entity_filters = {'big-rock'}
             end
         end
+
         if item.type == 'spidertron' and item.name=='spidertron_planner' then
                 local player = event.player
                 player.clear_cursor()

--- a/map_gen/maps/crash_site/weapon_balance.lua
+++ b/map_gen/maps/crash_site/weapon_balance.lua
@@ -3,39 +3,39 @@ local Event = require 'utils.event'
 local RS = require 'map_gen.shared.redmew_surface'
 
 local player_ammo_starting_modifiers = {
-    ['artillery-shell'] = -0.75,
-    ['biological'] = -0.5,
-    ['bullet'] = -0.25,
-    ['cannon-shell'] = -0.75,
-    ['capsule'] = -0.5,
-    ['electric'] = -0.5,
-    ['flamethrower'] = -0.75,
-    ['grenade'] = -0.5,
-    ['landmine'] = -0.33,
-    ['laser'] = -0.75,
-    ['melee'] = 1,
-    ['rocket'] = -0.5,
-    ['shotgun-shell'] = -0.20
+    --['artillery-shell'] = -0.75,
+    --['biological'] = -0.5,
+    --['bullet'] = -0.25,
+    --['cannon-shell'] = -0.75,
+    --['capsule'] = -0.5,
+    --['electric'] = -0.5,
+    --['flamethrower'] = -0.75,
+    --['grenade'] = -0.5,
+    --['landmine'] = -0.33,
+    --['laser'] = -0.75,
+    --['melee'] = 1,
+    --['rocket'] = -0.5,
+    --['shotgun-shell'] = -0.20
 }
 
 local player_ammo_research_modifiers = {
-    ['artillery-shell'] = -0.75,
-    ['biological'] = -0.5,
-    ['bullet'] = -0.20,
-    ['cannon-shell'] = -0.75,
-    ['capsule'] = -0.5,
-    ['electric'] = -0.6,
-    ['flamethrower'] = -0.75,
-    ['grenade'] = -0.5,
-    ['landmine'] = -0.5,
-    ['laser'] = -0.75,
-    ['melee'] = -0.5,
-    ['rocket'] = -0.5,
-    ['shotgun-shell'] = -0.20
+    --['artillery-shell'] = -0.75,
+    --['biological'] = -0.5,
+    --['bullet'] = -0.20,
+    --['cannon-shell'] = -0.75,
+    --['capsule'] = -0.5,
+    --['electric'] = -0.6,
+    --['flamethrower'] = -0.75,
+    --['grenade'] = -0.5,
+    --['landmine'] = -0.5,
+    --['laser'] = -0.75,
+    --['melee'] = -0.5,
+    --['rocket'] = -0.5,
+    --['shotgun-shell'] = -0.20
 }
 
 local player_turrets_research_modifiers = {
-    ['gun-turret'] = -0.5,
+    --['gun-turret'] = -0.5,
     --['laser-turret'] = -0.75,
     ['flamethrower-turret'] = -0.75
 }


### PR DESCRIPTION
Followup pr of #1468, as the health buffs of 2.0 have a huge impact on the combat balance. In a nutshell, 2.0 is basically rebalancing combat as the scenario itself does, but it's implemented by increasing enemies health, vs scenario nerfing the player's weapons. Thus resulting in double the nerf for player.

# Changes
- removed initial ammo nerfs from player force to re-asses the game combat balance (only left flamethrower nerf)
- replaced created entities of "explosive-rockets" with "artillery-projectile" in `/barrage` command as rockets spawned with the command do not benefit from force bonuses and 36+ rockets were needed to kill a spawner Vs 1-2 arty shells. Adjusted the cost of the command to maintain same cost-effect ratio, just with less entities spawned
- re-formatted some of the Market texts just to make it easier to read


![Screenshot from 2024-12-09 12-33-44](https://github.com/user-attachments/assets/5493510f-d9d1-4bb9-ad48-3de625021cd7)
