### PR TITLE
Update admin chat command

### DIFF
--- a/features/admin_commands.lua
+++ b/features/admin_commands.lua
@@ -51,7 +51,7 @@ end
 
 --- Sends a message to all online admins
 local function admin_chat(args, player)
-    Utils.print_admins(args.msg, player)
+    Utils.print_admins(args.msg, player, true)
 end
 
 --- Toggles cheat mode for a player
@@ -343,7 +343,8 @@ Command.add(
         arguments = {'msg'},
         required_rank = Ranks.admin,
         capture_excess_arguments = true,
-        allowed_by_server = true
+        allowed_by_server = true,
+        log_command = false
     },
     admin_chat
 )

--- a/utils/command.lua
+++ b/utils/command.lua
@@ -104,6 +104,10 @@ function Command.add(command_name, options, callback)
 
     assert_existing_options(command_name, options)
 
+    if options.log_command ~= nil and options.log_command == false then
+        log_command = false
+    end
+
     if nil == options.allowed_by_player then
         allowed_by_player = true
     end

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -52,7 +52,8 @@ end
 --- Prints a message to all online admins
 -- @param msg <string|table> table if locale is used
 -- @param source <LuaPlayer|string|nil> string must be the name of a player, nil for server.
-function Module.print_admins(msg, source)
+-- @param no_log <boolean|nil> if true, skips logging the message
+function Module.print_admins(msg, source, no_log)
     local source_name
     local chat_color
     if source then
@@ -68,7 +69,9 @@ function Module.print_admins(msg, source)
         chat_color = Color.yellow
     end
     local formatted_msg = {'utils_core.print_admins', prefix, source_name, msg}
-    log(formatted_msg)
+    if not no_log then
+        log(formatted_msg)
+    end
     for _, p in pairs(game.connected_players) do
         if p.admin then
             p.print(formatted_msg, {color = chat_color})


### PR DESCRIPTION
Makes it so `/a` command is no longer logged in the game's log.
Admin chat utils now takes an additional parameter to skip logging admin messages to file