### PR TITLE
Fix map gen settings

### DIFF
--- a/map_gen/shared/redmew_surface.lua
+++ b/map_gen/shared/redmew_surface.lua
@@ -178,9 +178,19 @@ local function create_redmew_surface()
     if config.map_gen_settings then
         -- Add the user's map gen settings as the first entry in the table
         local combined_map_gen = {game.surfaces.nauvis.map_gen_settings}
+        local nauvis_as = combined_map_gen[1].autoplace_settings
         -- Take the map's settings and add them into the table
         for _, v in pairs(data.map_gen_settings_components) do
             insert(combined_map_gen, v)
+            -- Check if any preset is blacklisting other autoplace settings, and void the default one if so
+            local as = v.autoplace_settings
+            if nauvis_as and as then
+                for _, name in pairs({ 'entity', 'tile', 'decorative' }) do
+                    if nauvis_as[name] and as[name] and as[name].treat_missing_as_default == false then
+                        nauvis_as[name].settings = {}
+                    end
+                end
+            end
         end
         surface = game.create_surface(redmew_surface_name, merge(combined_map_gen))
     else


### PR DESCRIPTION
IIRC, in 1.1 the default map gen settings were not specified (other than ore patches), so our system to build `redmew` surface relied on whitelisting new properties to make sand-only, grass-only maps.
In 2.0, all properties are always listed by default, so whitelisting same properties would only overwrite existing ones, but fails at excluding those unwanted (i.e. passing the preset "grass_only" with whitelisted grass tiles would not have any effect as those are already enabled, and so are other unwanted tiles like sand...).

So I've added a check and if any of the map gen presets we're applying is blacklisting others (`treat_missing_as_default = false`) it will proceed to empty that property in the default's nauvis preset, so whitelisting would now work again.

I'm not 100% convinced this is best practice (especially with mods, what if they already added their settings we're not accounting for?). On the other hand, this is how 1.1 worked, and if maps have very special needs needs regarding MGS, they will simply take care themselves and/or pass those additional parameters to the merge table.

So far I've tested it with a handful of our maps, modded and not, and everything seems to work as expected (some decoratives might seem off sometimes, maybe this will need further customization to pass decorative presets along with tile presets, but not a relevant issue imo).

I've tested it with these maps:

```
--return require 'scenario_templates.minimal.map_selection'
--return require 'map_gen.maps.frontier.scenario'
--return require 'map_gen.maps.crash_site.presets.normal'
--return require 'map_gen.maps.crash_site.presets.arrakis'
--return require 'map_gen/maps/april_fools/2024'
--return require 'map_gen/maps/danger_ores/presets/danger_ore_patches'
--return require 'map_gen/maps/danger_ores/presets/danger_ore_landfill'
--return require 'map_gen/maps/danger_ores/presets/danger_ore_gradient'
--return require 'map_gen/maps/diggy/presets/danger_ores'
```

Here's a BEFORE --> AFTER w/ normal crash site (uses grass_only). Before it's just standard Nauvis, and after the changes it's effectively grass-only

![Screenshot from 2025-01-02 12-18-50](https://github.com/user-attachments/assets/997ba824-28b2-4c18-9f56-971a95a7a782)
