### PR TITLE
Add DO:Coal Maze

### DIFF
--- a/map_gen/maps/danger_ores/changelog.lua
+++ b/map_gen/maps/danger_ores/changelog.lua
@@ -87,5 +87,8 @@ return [[
 
   2025-01-13:
       - [DO] Added quality settings to rocket launched goals
-      - [DO_Permanence] Increased manual mining speed to +900%
+      - [DO:Permanence] Increased manual mining speed to +900%
+
+  2025-01-14:
+      - [DO:CoalMaze] Added Coal Maze preset
 ]]

--- a/map_gen/maps/danger_ores/configuration.lua
+++ b/map_gen/maps/danger_ores/configuration.lua
@@ -52,6 +52,12 @@ return {
     enabled = true,
     settings = H.empty_map_settings(),
   },
+  maze = {
+    enabled = false,
+    size = 50,          -- in chunks
+    wall_thickness = 1, -- in chunks
+    cell_size = 3,      -- must be an odd number
+  },
   prevent_quality_mining = {
     enabled = true,
   },

--- a/map_gen/maps/danger_ores/modules/map_poll.lua
+++ b/map_gen/maps/danger_ores/modules/map_poll.lua
@@ -35,6 +35,7 @@ local maps = {
     --{ name = 'danger-ore-bz', display_name = 'Very BZ (default)', mod_pack = mod_packs.danger_ore_bz },
     { name = 'danger-ore-chessboard', display_name = 'Chessboard (random squares)', mod_pack = mod_packs.danger_ore_normal },
     { name = 'danger-ore-circles', display_name = 'Circles (ore rings)', mod_pack = mod_packs.danger_ore_normal },
+    { name = 'danger-ore-coal-maze', display_name = 'Coal Maze (maze)', mod_pack = mod_packs.danger_ore_normal },
     --{ name = 'danger-ore-exotic-industries', display_name = 'Exotic Industries (default)', mod_pack = mod_packs.danger_ore_ei },
     --{ name = 'danger-ore-exotic-industries-spiral', display_name = 'Exotic Industries Spiral (without void)', mod_pack = mod_packs.danger_ore_ei },
     --{ name = 'danger-ore-expanse', display_name = 'Expanse (feed Hungry Chests to expand)', mod_pack = mod_packs.danger_ore_normal },

--- a/map_gen/maps/danger_ores/modules/maze.lua
+++ b/map_gen/maps/danger_ores/modules/maze.lua
@@ -1,0 +1,219 @@
+local Event = require 'utils.event'
+local Generate = require 'map_gen.shared.generate'
+local Global = require 'utils.global'
+local RS = require 'map_gen.shared.redmew_surface'
+local math = require 'utils.math'
+local table = require 'utils.table'
+
+local insert = table.insert
+local shuffle = table.shuffle_table
+local math_max = math.max
+local math_floor = math.floor
+local math_random = math.random
+
+return function(config)
+  local MAZE_SIZE = config.size
+  local WALL_THICKNESS = config.wall_thickness
+  local CELL_SIZE = config.cell_size
+  local WALL_DELTA = math_floor((CELL_SIZE - WALL_THICKNESS) / 2)
+  local DIRECTIONS = {
+    { x =  0, y = -2 }, -- north
+    { x =  2, y =  0 }, -- east
+    { x = -2, y =  0 }, -- west
+    { x =  0, y =  2 }, -- south
+  }
+
+  local pixels = {}
+  local cells = {}
+  local maze_walls = {}
+  local primitives = {
+    max = 0,
+    walk_seed_w = 0,
+    walk_seed_h = 0,
+  }
+
+  Global.register({
+      maze_walls = maze_walls,
+      primitives = primitives,
+    },
+    function(tbl)
+      maze_walls = tbl.maze_walls
+      primitives = tbl.primitives
+    end
+  )
+
+  local function add_tile(x, y, width, height, add_cell)
+    if add_cell then
+      if cells[x] == nil then
+        cells[x] = {}
+      end
+      cells[x][y] = 1
+    end
+    for x_pos = x, x + width - 1 do
+      for y_pos = y, y + height - 1 do
+        if pixels[x_pos] == nil then
+          pixels[x_pos] = {}
+        end
+        pixels[x_pos][y_pos] = 1
+      end
+    end
+  end
+
+  local function render()
+    local y_max = 0
+    for x, _ in pairs(pixels) do
+      for y, _ in pairs(pixels[x]) do
+        if y * 32 > primitives.max and y % 2 == 0 then
+          y_max = math_max(y_max, y)
+        end
+      end
+    end
+    primitives.max = y_max * 32
+
+    for x = 1, y_max do
+      for y = 1, WALL_DELTA do
+        if not pixels[x] then
+          pixels[x] = {}
+        end
+        pixels[x][y] = 1
+      end
+    end
+    for x = 1, WALL_DELTA do
+      for y = 1, y_max do
+        if not pixels[x] then
+          pixels[x] = {}
+        end
+        pixels[x][y] = 1
+      end
+    end
+
+    for x = 1, y_max do
+      for y = 1, y_max do
+        if not (pixels[x] and pixels[x][y]) then
+          maze_walls[x * 32 .. '/' .. y * 32] = true
+        end
+      end
+    end
+  end
+
+  -- builds a width-by-height grid
+  local function initialize_grid(w, h)
+    local a = {}
+    for i = 1, h do
+      insert(a, {})
+      for j = 1, w do
+        insert(a[i], true)
+      end
+    end
+    return a
+  end
+
+  -- average of a and b
+  local function avg(a, b)
+    return (a + b) / 2
+  end
+
+  local function make_maze(w, h)
+    local map = initialize_grid(w * 2 + 1, h * 2 + 1)
+
+    local walk
+    walk = function(x, y)
+      map[y][x] = false
+
+      local d = { 1, 2, 3, 4 }
+      shuffle(d)
+      for i, dir_num in pairs(d) do
+        local xx = x + DIRECTIONS[dir_num].x
+        local yy = y + DIRECTIONS[dir_num].y
+        if map[yy] and map[yy][xx] then
+          map[avg(y, yy)][avg(x, xx)] = false
+          walk(xx, yy)
+        end
+      end
+    end
+    walk(primitives.walk_seed_w, primitives.walk_seed_h)
+
+    for i = 1, h * 2 + 1 do
+      for j = 1, w * 2 + 1 do
+        if map[i][j] then
+          add_tile(i * CELL_SIZE, j * CELL_SIZE, CELL_SIZE, CELL_SIZE, true)
+        end
+      end
+    end
+  end
+
+  local function is_map(x, y)
+    return cells[x] and cells[x][y] == 1
+  end
+
+  local function is_wall(x, y)
+    return not is_map(x, y)
+  end
+
+  local function reduce_walls()
+    for x, _ in pairs(cells) do
+      for y, _ in pairs(cells[x]) do
+        -- Left
+        if is_wall(x - CELL_SIZE, y) then
+          add_tile(x - WALL_DELTA, y, WALL_DELTA, CELL_SIZE, false)
+        end
+        -- Right
+        if is_wall(x + CELL_SIZE, y) then
+          add_tile(x + CELL_SIZE, y, WALL_DELTA, CELL_SIZE, false)
+        end
+        -- Above
+        if is_wall(x, y - CELL_SIZE) then
+          add_tile(x - WALL_DELTA, y - WALL_DELTA, CELL_SIZE + 2 * WALL_DELTA, WALL_DELTA, false)
+        end
+        -- Below
+        if is_wall(x, y + CELL_SIZE) then
+          add_tile(x - WALL_DELTA, y + CELL_SIZE, CELL_SIZE + 2 * WALL_DELTA, WALL_DELTA, false)
+        end
+      end
+    end
+  end
+
+  local function remove_chunk(surface, area)
+    local tiles = {}
+    for x = area.left_top.x, area.right_bottom.x - 1 do
+      for y = area.left_top.y, area.right_bottom.y - 1 do
+        insert(tiles, { name = 'out-of-map', position = { x = x, y = y } })
+      end
+    end
+    surface.set_tiles(tiles)
+  end
+
+  local set_wall_tiles = function(surface, area)
+    if not config.enabled then
+      return
+    end
+
+    local pos = area.left_top
+    if maze_walls[pos.x + primitives.max / 2 .. '/' .. pos.y + primitives.max / 2] then
+      remove_chunk(surface, area)
+      return true
+    end
+    return
+  end
+
+  Event.on_init(function()
+    if not config.enabled then
+      return
+    end
+
+    primitives.walk_seed_w = math_random(1, MAZE_SIZE) * 2
+    primitives.walk_seed_h = math_random(1, MAZE_SIZE) * 2
+    make_maze(MAZE_SIZE, MAZE_SIZE)
+    reduce_walls()
+    render()
+  end)
+
+  Event.add(Generate.events.on_chunk_generated, function(event)
+    local surface, area = event.surface, event.area
+    if surface ~= RS.get_surface() then
+      return
+    end
+    -- Make maze walls
+    set_wall_tiles(surface, area)
+  end)
+end

--- a/map_gen/maps/danger_ores/presets/danger_ore_coal_maze.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_coal_maze.lua
@@ -1,0 +1,20 @@
+
+local DOC = require 'map_gen.maps.danger_ores.configuration'
+local Scenario = require 'map_gen.maps.danger_ores.scenario'
+local ScenarioInfo = require 'features.gui.info'
+
+ScenarioInfo.set_map_name('Danger Ores - Coal Maze')
+ScenarioInfo.add_map_extra_info([[
+	This maze is covered in [item=coal] with mixed dense patches containing [item=iron-ore] [item=copper-ore] [item=stone].
+	The patches alternate between [item=iron-ore] and [item=copper-ore] as the main resource.
+]])
+
+DOC.scenario_name = 'danger-ore-coal-maze'
+DOC.map_config.main_ore_resource_patches_config = require 'map_gen.maps.danger_ores.config.main_ore_resource_patches'
+DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_patches'
+DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.config.coal'
+DOC.map_config.main_ores_rotate = nil
+DOC.maze.enabled = true
+DOC.terraforming.enabled = false
+
+return Scenario.register(DOC)

--- a/map_gen/maps/danger_ores/presets/danger_ore_coal_maze.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_coal_maze.lua
@@ -1,4 +1,4 @@
-
+local B = require 'map_gen.shared.builders'
 local DOC = require 'map_gen.maps.danger_ores.configuration'
 local Scenario = require 'map_gen.maps.danger_ores.scenario'
 local ScenarioInfo = require 'features.gui.info'
@@ -10,6 +10,9 @@ ScenarioInfo.add_map_extra_info([[
 ]])
 
 DOC.scenario_name = 'danger-ore-coal-maze'
+DOC.map_config.spawn_shape = B.translate(B.rectangle(64), 2, 2)
+DOC.map_config.start_ore_shape = B.translate(B.rectangle(68), 2, 2)
+DOC.map_config.no_resource_patch_shape = B.translate(B.rectangle(80), 2, 2)
 DOC.map_config.main_ore_resource_patches_config = require 'map_gen.maps.danger_ores.config.main_ore_resource_patches'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_patches'
 DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.config.coal'

--- a/map_gen/maps/danger_ores/scenario.lua
+++ b/map_gen/maps/danger_ores/scenario.lua
@@ -45,6 +45,7 @@ local concrete_on_landfill   = require 'map_gen.maps.danger_ores.modules.concret
 local container_dump         = require 'map_gen.maps.danger_ores.modules.container_dump'.register
 local map_builder            = require 'map_gen.maps.danger_ores.modules.map'
 local mining_productivity    = require 'map_gen.maps.danger_ores.modules.mining_productivity'.register
+local maze                   = require 'map_gen.maps.danger_ores.modules.maze'
 local restart_command        = require 'map_gen.maps.danger_ores.modules.restart_command'
 local rocket_launched        = require 'map_gen.maps.danger_ores.modules.rocket_launched_simple'
 local technologies           = require 'map_gen.maps.danger_ores.modules.technologies'
@@ -89,6 +90,9 @@ Public.register = function(danger_ores_config)
   end
   if _C.map_gen_settings.enabled then
     RS.set_map_gen_settings(_C.map_gen_settings.settings or {})
+  end
+  if _C.maze.enabled then
+    maze(_C.maze)
   end
   if _C.prevent_quality_mining.enabled then
     require 'map_gen.maps.danger_ores.modules.prevent_quality_mining'

--- a/scenario_templates/danger-ore-coal-maze/map_selection.lua
+++ b/scenario_templates/danger-ore-coal-maze/map_selection.lua
@@ -1,0 +1,1 @@
+return require 'map_gen.maps.danger_ores.presets.danger_ore_coal_maze'


### PR DESCRIPTION
Adds a new Danger Ores preset: Coal Maze
Uses 2 presets we already have: maze gen (50x50, 3 wide) and coal + patches (DO).
Terraforming module has been disabled for this map.

Hopefully many trains will be used here!
Couple of screenshots:

> Close up
![Screenshot from 2025-01-14 21-18-18](https://github.com/user-attachments/assets/95562a89-3937-4a51-b8cd-da086a2f6469)

> Whole view
![Screenshot from 2025-01-14 21-23-12](https://github.com/user-attachments/assets/ed74e2a6-4219-49ff-b882-cf2857c245fa)

Biters seem dense but it's just the default enemy curve we have on every DO map. We'll see I guess. SHouldnt be a problem in peaceful mode tho