### PR TITLE
Loop handlers backwards

### DIFF
--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -22,14 +22,14 @@ local script_on_nth_tick = script.on_nth_tick
 local call_handlers
 if _DEBUG then
     function call_handlers(handlers, event)
-        for i = 1, #handlers do
+        for i = #handlers, 1, -1 do
             local handler = handlers[i]
             handler(event)
         end
     end
 else
     function call_handlers(handlers, event)
-        for i = 1, #handlers do
+        for i = #handlers, 1, -1 do
             local handler = handlers[i]
             local success, error = pcall(handler, event)
             if not success then
@@ -89,7 +89,7 @@ function Public.add(event_name, handler)
         event_handlers[event_name] = {handler}
         script_on_event(event_name, on_event)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script_on_event(event_name, on_event)
         end
@@ -103,7 +103,7 @@ function Public.on_init(handler)
         event_handlers[init_event_name] = {handler}
         script.on_init(on_init)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script.on_init(on_init)
         end
@@ -117,7 +117,7 @@ function Public.on_load(handler)
         event_handlers[load_event_name] = {handler}
         script.on_load(on_load)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script.on_load(on_load)
         end
@@ -131,7 +131,7 @@ function Public.on_configuration_changed(handler)
         event_handlers[configuration_changed_name] = {handler}
         script.on_configuration_changed(configuration_changed)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script.on_configuration_changed(configuration_changed)
         end
@@ -145,7 +145,7 @@ function Public.on_nth_tick(tick, handler)
         on_nth_tick_event_handlers[tick] = {handler}
         script_on_nth_tick(tick, on_nth_tick_event)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script_on_nth_tick(tick, on_nth_tick_event)
         end


### PR DESCRIPTION
# Changes
- [x] event handlers are prepended to the handlers table
- [x] handlers are looped backwards on events

# Issue
Removing functions at runtime is not remove-safe when looping the handlers "straight", while looping them backwards, would allow any handler to remove itself at runtime, without the event_core skipping any functions.

Example: `F1` and `F2` are added at runtime and each of them removes itself.
When the event triggers, `F1` removes itself, then `F2` is effectively skipped because the handler has now moved to next index, which is nil now.

By looping them backwards (and so, registering them backwards to maintain the load order of all modules), `F1` and `F2` can each remove themselves without the event module skipping any handler anymore.

Test code:

```lua
/c
local Event = _G.package.loaded['__level__/utils/event.lua']
storage.ftick = 123 
local f1, f2
f1 = function(event)     game.print("f1")     local Event = _G.package.loaded['__level__/utils/event.lua']     Event.remove_removable_nth_tick_function(storage.ftick, f1) end
f2 = function(event)     game.print("f2")     local Event = _G.package.loaded['__level__/utils/event.lua']     Event.remove_removable_nth_tick_function(storage.ftick, f2) end

Event.add_removable_nth_tick_function(storage.ftick, f1)
Event.add_removable_nth_tick_function(storage.ftick, f2)
```

I'll leave it to you Grilled if you think this is an edge case worth fixing or if it's something we don't care much.