### PR TITLE
Event/event-core refactor

### DIFF
--- a/utils/event.lua
+++ b/utils/event.lua
@@ -99,124 +99,71 @@ local EventCore = require 'utils.event_core'
 local Global = require 'utils.global'
 local Token = require 'utils.token'
 
-local table_remove = table.remove
-local core_add = EventCore.add
-local core_on_init = EventCore.on_init
-local core_on_load = EventCore.on_load
-local core_on_configuration_changed = EventCore.on_configuration_changed
-local core_on_nth_tick = EventCore.on_nth_tick
-local stage_load = _STAGE.load
-local script_on_event = script.on_event
-local script_on_nth_tick = script.on_nth_tick
-local generate_event_name = script.generate_event_name
+Global.register(EventCore.get_handlers(), EventCore.set_handlers)
 
 local Event = {}
 
-local handlers_added = false -- set to true after the removable event handlers have been added.
-
-local event_handlers = EventCore.get_event_handlers()
-local on_nth_tick_event_handlers = EventCore.get_on_nth_tick_event_handlers()
-
-local token_handlers = {}
-local token_nth_tick_handlers = {}
-local function_handlers = {}
-local function_nth_tick_handlers = {}
-
-Global.register(
-    {
-        token_handlers = token_handlers,
-        token_nth_tick_handlers = token_nth_tick_handlers,
-        function_handlers = function_handlers,
-        function_nth_tick_handlers = function_nth_tick_handlers
-    },
-    function(tbl)
-        token_handlers = tbl.token_handlers
-        token_nth_tick_handlers = tbl.token_nth_tick_handlers
-        function_handlers = tbl.function_handlers
-        function_nth_tick_handlers = tbl.function_nth_tick_handlers
-    end
-)
-
-local function remove(tbl, handler)
-    if tbl == nil then
-        return
-    end
-
-    -- the handler we are looking for is more likely to be at the back of the array.
-    for i = #tbl, 1, -1 do
-        if tbl[i] == handler then
-            table_remove(tbl, i)
-            break
-        end
-    end
+Event.on_init = function(handler)
+    EventCore.on_init(handler)
 end
 
---- Register a handler for the event_name event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load.
--- See documentation at top of file for details on using events.
--- @param event_name<number>
--- @param handler<function>
-function Event.add(event_name, handler)
-    if _LIFECYCLE == 8 then
-        error('Calling Event.add after on_init() or on_load() has run is a desync risk.', 2)
-    end
-
-    core_add(event_name, handler)
+Event.on_load = function(handler)
+    EventCore.on_load(handler)
 end
 
---- Register a handler for the script.on_init event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load
--- See documentation at top of file for details on using events.
--- @param handler<function>
-function Event.on_init(handler)
-    if _LIFECYCLE == 8 then
-        error('Calling Event.on_init after on_init() or on_load() has run is a desync risk.', 2)
-    end
-
-    core_on_init(handler)
+Event.on_configuration_changed = function(handler)
+    EventCore.on_configuration_changed(handler)
 end
 
---- Register a handler for the script.on_load event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load
--- See documentation at top of file for details on using events.
--- @param handler<function>
-function Event.on_load(handler)
-    if _LIFECYCLE == 8 then
-        error('Calling Event.on_load after on_init() or on_load() has run is a desync risk.', 2)
-    end
-
-    core_on_load(handler)
+Event.add = function(event_name, handler, options)
+    EventCore.add(event_name, handler, options)
 end
 
---- Register a handler for the script.on_configuration_changed event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load
--- See documentation at top of file for details on using events.
--- @param handler<function>
-function Event.on_configuration_changed(handler)
-    if _LIFECYCLE == 8 then
-        error('Calling Event.on_configuration_changed after on_init() or on_load() has run is a desync risk.', 2)
-    end
-
-    core_on_configuration_changed(handler)
+Event.remove = function(event_name, handler, options)
+    EventCore.remove(event_name, handler, options)
 end
 
---- Register a handler for the nth_tick event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load.
--- See documentation at top of file for details on using events.
--- @param tick<number> The handler will be called every nth tick
--- @param handler<function>
-function Event.on_nth_tick(tick, handler)
-    if _LIFECYCLE == 8 then
-        error('Calling Event.on_nth_tick after on_init() or on_load() has run is a desync risk.', 2)
-    end
+Event.on_nth_tick = function(tick, handler)
+    EventCore.add(tick, handler, { on_nth_tick = true })
+end
 
-    core_on_nth_tick(tick, handler)
+Event.add_removable = function(event_name, token, options)
+    EventCore.add(event_name, token, { get_token = options and options.get_token or Token.get })
+end
+
+Event.remove_removable = function(event_name, token, options)
+    EventCore.remove(event_name, token, { get_token = options and options.get_token or Token.get })
+end
+
+Event.add_removable_on_nth_tick = function(event_name, token, options)
+    EventCore.add(event_name, token, { get_token = options and options.get_token or Token.get, on_nth_tick = true })
+end
+
+Event.remove_removable_on_nth_tick = function(event_name, token, options)
+    EventCore.remove(event_name, token, { get_token = options and options.get_token or Token.get, on_nth_tick = true })
+end
+
+Event.add_function = function(event_name, string_function, options)
+    EventCore.add(event_name, string_function, options)
+end
+
+Event.remove_function = function(event_name, name)
+    EventCore.remove(event_name, name)
+end
+
+Event.add_function_on_nth_tick = function(event_name, string_function, options)
+    options.on_nth_tick = true
+    EventCore.add(event_name, string_function, options)
+end
+
+Event.remove_function_on_nth_tick = function(event_name, name)
+    EventCore.remove(event_name, name, { on_nth_tick = true })
 end
 
 local function handler_factory(event_list)
-    return function(handler)
+    return function(handler, options)
         for _, event_name in pairs(event_list) do
-            Event.add(event_name, handler)
+            EventCore.add(event_name, handler, options)
         end
     end
 end
@@ -248,258 +195,43 @@ Event.on_mined_tile = handler_factory {
     defines.events.on_space_platform_mined_tile,
 }
 
---- Register a token handler that can be safely added and removed at runtime.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  token<number>
-function Event.add_removable(event_name, token)
-    if type(token) ~= 'number' then
-        error('token must be a number', 2)
-    end
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-
-    local tokens = token_handlers[event_name]
-    if not tokens then
-        token_handlers[event_name] = {token}
-    else
-        tokens[#tokens + 1] = token
-    end
-
-    if handlers_added then
-        local handler = Token.get(token)
-        core_add(event_name, handler)
-    end
+Event.generate_event_name = function(name)
+    return EventCore.generate_event_name(name)
 end
 
---- Removes a token handler for the given event_name.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  token<number>
-function Event.remove_removable(event_name, token)
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-    local tokens = token_handlers[event_name]
+local function register_events()
+    local handlers = EventCore.get_handlers()
 
-    if not tokens then
-        return
-    end
-
-    local handler = Token.get(token)
-    local handlers = event_handlers[event_name]
-
-    remove(tokens, token)
-    remove(handlers, handler)
-
-    if #handlers == 0 then
-        script_on_event(event_name, nil)
-    end
-end
-
---- Register a handler that can be safely added and removed at runtime.
--- The handler must not be a closure, as that is a desync risk.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  func<function>
-function Event.add_removable_function(event_name, func)
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-    if type(func) ~= 'function' then
-        error('func must be a function', 2)
-    end
-
-    local funcs = function_handlers[event_name]
-    if not funcs then
-        function_handlers[event_name] = {func}
-    else
-        funcs[#funcs + 1] = func
-    end
-
-    if handlers_added then
-        core_add(event_name, func)
-    end
-end
-
---- Removes a handler for the given event_name.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  func<function>
-function Event.remove_removable_function(event_name, func)
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-    local funcs = function_handlers[event_name]
-
-    if not funcs then
-        return
-    end
-
-    local handlers = event_handlers[event_name]
-
-    remove(funcs, func)
-    remove(handlers, func)
-
-    if #handlers == 0 then
-        script_on_event(event_name, nil)
-    end
-end
-
---- Register a token handler for the nth tick that can be safely added and removed at runtime.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  token<number>
-function Event.add_removable_nth_tick(tick, token)
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-    if type(token) ~= 'number' then
-        error('token must be a number', 2)
-    end
-
-    local tokens = token_nth_tick_handlers[tick]
-    if not tokens then
-        token_nth_tick_handlers[tick] = {token}
-    else
-        tokens[#tokens + 1] = token
-    end
-
-    if handlers_added then
-        local handler = Token.get(token)
-        core_on_nth_tick(tick, handler)
-    end
-end
-
---- Removes a token handler for the nth tick.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  token<number>
-function Event.remove_removable_nth_tick(tick, token)
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-    local tokens = token_nth_tick_handlers[tick]
-
-    if not tokens then
-        return
-    end
-
-    local handler = Token.get(token)
-    local handlers = on_nth_tick_event_handlers[tick]
-
-    remove(tokens, token)
-    remove(handlers, handler)
-
-    if #handlers == 0 then
-        script_on_nth_tick(tick, nil)
-    end
-end
-
---- Register a handler for the nth tick that can be safely added and removed at runtime.
--- The handler must not be a closure, as that is a desync risk.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  func<function>
-function Event.add_removable_nth_tick_function(tick, func)
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-    if type(func) ~= 'function' then
-        error('func must be a function', 2)
-    end
-
-    local funcs = function_nth_tick_handlers[tick]
-    if not funcs then
-        function_nth_tick_handlers[tick] = {func}
-    else
-        funcs[#funcs + 1] = func
-    end
-
-    if handlers_added then
-        core_on_nth_tick(tick, func)
-    end
-end
-
---- Removes a handler for the nth tick.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  func<function>
-function Event.remove_removable_nth_tick_function(tick, func)
-    if _LIFECYCLE == stage_load then
-        error('cannot call during on_load', 2)
-    end
-    local funcs = function_nth_tick_handlers[tick]
-
-    if not funcs then
-        return
-    end
-
-    local handlers = on_nth_tick_event_handlers[tick]
-
-    remove(funcs, func)
-    remove(handlers, func)
-
-    if #handlers == 0 then
-        script_on_nth_tick(tick, nil)
-    end
-end
-
---- Generate a new, unique event ID.
--- @param <string> name of the event/variable that is exposed
-function Event.generate_event_name(name)
-    local event_id = generate_event_name()
-
-    -- If we're in debug, add the event ID into defines.events for the debuggertron's event module
-    if _DEBUG then
-        defines.events[name] = event_id -- luacheck: ignore 122
-    end
-
-    return event_id
-end
-
-local function add_handlers()
-    for event_name, tokens in pairs(token_handlers) do
-        for i = 1, #tokens do
-            local handler = Token.get(tokens[i])
-            core_add(event_name, handler)
+    for event_name, tokens in pairs(handlers.token_handlers) do
+        for _, token in pairs(tokens) do
+            local handler = Token.get(token)
+            EventCore.add(event_name, handler)
         end
     end
 
-    for event_name, funcs in pairs(function_handlers) do
-        for i = 1, #funcs do
-            local handler = funcs[i]
-            core_add(event_name, handler)
+    for tick, tokens in pairs(handlers.token_handlers_on_nth_tick) do
+        for _, token in pairs(tokens) do
+            local handler = Token.get(token)
+            EventCore.add(tick, handler, { on_nth_tick = true })
         end
     end
 
-    for tick, tokens in pairs(token_nth_tick_handlers) do
-        for i = 1, #tokens do
-            local handler = Token.get(tokens[i])
-            core_on_nth_tick(tick, handler)
+    for event_name, string_handlers in pairs(handlers.function_handlers) do
+        for _, string_handler in pairs(string_handlers) do
+            local handler = load('return ' .. string_handler)()
+            EventCore.add(event_name, handler)
         end
     end
 
-    for tick, funcs in pairs(function_nth_tick_handlers) do
-        for i = 1, #funcs do
-            local handler = funcs[i]
-            core_on_nth_tick(tick, handler)
+    for tick, string_handlers in pairs(handlers.function_handlers_on_nth_tick) do
+        for _, string_handler in pairs(string_handlers) do
+            local handler = load('return ' .. string_handler)()
+            EventCore.add(tick, handler, { on_nth_tick = true })
         end
     end
-
-    handlers_added = true
 end
 
-core_on_init(add_handlers)
-core_on_load(add_handlers)
+EventCore.on_init(register_events)
+EventCore.on_load(register_events)
 
 return Event

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -1,165 +1,232 @@
 -- luacheck: globals script
--- This module exists to break the circular dependency between event.lua and storage.lua.
+-- This module exists to break the circular dependency between event.lua and global.lua.
 -- It is not expected that any user code would require this module instead event.lua should be required.
+
+---@alias EventName defines.events | int
+
 local ErrorLogging = require 'utils.error_logging'
 
 local Public = {}
 
-local init_event_name = -1
-local load_event_name = -2
-local configuration_changed_name = -3
-
--- map of event_name to handlers[]
-local event_handlers = {}
--- map of nth_tick to handlers[]
-local on_nth_tick_event_handlers = {}
-
-local pcall = pcall
+local xpcall = xpcall
 local log = log
-local script_on_event = script.on_event
-local script_on_nth_tick = script.on_nth_tick
+local remove_element = require 'utils.table'.remove_element
 
-local call_handlers
-if _DEBUG then
-    function call_handlers(handlers, event)
-        for i = 1, #handlers do
-            local handler = handlers[i]
-            handler(event)
-        end
-    end
-else
-    function call_handlers(handlers, event)
-        for i = 1, #handlers do
-            local handler = handlers[i]
-            local success, error = pcall(handler, event)
-            if not success then
-                log(error)
-                ErrorLogging.generate_error_report(error)
+--- Constants representing special event names
+local events = {
+    on_init = 'on_init',
+    on_load = 'on_load',
+    on_configuration_changed = 'on_configuration_changed',
+}
+
+--- Tables to hold event handlers
+local event_handlers = {}
+local event_handlers_on_nth_tick = {}
+local token_handlers = {}
+local token_handlers_on_nth_tick = {}
+local function_handlers = {}
+local function_handlers_on_nth_tick = {}
+
+--- Call all handlers for a given event
+---@param handlers function[]
+local function call_handlers_factory(handlers)
+    return function(event)
+        if handlers then
+            for i = #handlers, 1, -1 do
+                xpcall(handlers[i], ErrorLogging.generate_error_report, event)
             end
         end
     end
 end
 
-local function on_event(event)
-    local handlers = event_handlers[event.name]
-    call_handlers(handlers, event)
-end
+--- Register a handler for a specific event name
+---@param event_name EventName
+---@param handler function
+---@param handlers_table function[]
+---@param script_event_function function
+local function register_handler(event_name, handler, handlers_table, script_event_function)
+    local handlers = handlers_table[event_name]
 
-local function on_init()
-    _LIFECYCLE = 5 -- on_init
-    local handlers = event_handlers[init_event_name]
-    call_handlers(handlers)
-
-    event_handlers[init_event_name] = nil
-    event_handlers[load_event_name] = nil
-
-    _LIFECYCLE = 8 -- Runtime
-end
-
-local function on_load()
-    _LIFECYCLE = 6 -- on_load
-    local handlers = event_handlers[load_event_name]
-    call_handlers(handlers)
-
-    event_handlers[init_event_name] = nil
-    event_handlers[load_event_name] = nil
-
-    _LIFECYCLE = 8 -- Runtime
-end
-
-local function configuration_changed()
-    _LIFECYCLE = 7 -- config_change
-    local handlers = event_handlers[configuration_changed_name]
-    call_handlers(handlers)
-
-    event_handlers[configuration_changed_name] = nil
-
-    _LIFECYCLE = 8 -- Runtime
-end
-
-local function on_nth_tick_event(event)
-    local handlers = on_nth_tick_event_handlers[event.nth_tick]
-    call_handlers(handlers, event)
-end
-
---- Do not use this function, use Event.add instead as it has safety checks.
-function Public.add(event_name, handler)
-    local handlers = event_handlers[event_name]
     if not handlers then
-        event_handlers[event_name] = {handler}
-        script_on_event(event_name, on_event)
-    else
-        table.insert(handlers, handler)
-        if #handlers == 1 then
-            script_on_event(event_name, on_event)
+        handlers = {}
+        handlers_table[event_name] = handlers
+        if events[event_name] then
+            script_event_function(call_handlers_factory(handlers))
+        else
+            script_event_function(event_name, call_handlers_factory(handlers))
         end
     end
+
+    table.insert(handlers, 1, handler)
 end
 
---- Do not use this function, use Event.on_init instead as it has safety checks.
-function Public.on_init(handler)
-    local handlers = event_handlers[init_event_name]
-    if not handlers then
-        event_handlers[init_event_name] = {handler}
-        script.on_init(on_init)
-    else
-        table.insert(handlers, handler)
-        if #handlers == 1 then
-            script.on_init(on_init)
+--- Remove a handler from a specific event
+---@param event_name EventName
+---@param handler function
+---@param handlers_table function[]
+local function remove_handler(event_name, handler, handlers_table)
+    local handlers = handlers_table[event_name]
+    if handlers then
+        remove_element(handlers, handler)  -- Remove handler from the list
+        if #handlers == 0 then
+            handlers_table[event_name] = nil  -- Remove the event entry if no handlers are left
         end
+        return true
     end
+    return false
 end
 
---- Do not use this function, use Event.on_load instead as it has safety checks.
-function Public.on_load(handler)
-    local handlers = event_handlers[load_event_name]
-    if not handlers then
-        event_handlers[load_event_name] = {handler}
-        script.on_load(on_load)
-    else
-        table.insert(handlers, handler)
-        if #handlers == 1 then
-            script.on_load(on_load)
+--- Add a new event handler to a specified event.
+--- This method allows flexible registration of a function, token, or named string handler.
+--- Use an optional `options` table to customize handler registration, including setting the event to be invoked on nth ticks or specifying a token retrieval function.
+---@param event_name: EventName - The name of the event to register the handler for
+---@param handler: function|number|string - The function, token, or string handler to be called when the event occurs
+---@param options?: table - An optional table containing options for handler registration
+---@param options.on_nth_tick: boolean - If true, the event handler will be invoked on every nth tick
+---@param options.get_token: function - A function that retrieves a token associated with the handler
+---@param options.name: string - The name of the handler for named string handlers
+Public.add = function(event_name, handler, options)
+    options = options or {}
+    local handler_type = type(handler)
+    local on_nth_tick = options.on_nth_tick or false
+    local handlers_table = on_nth_tick and event_handlers_on_nth_tick or event_handlers
+    local script_event_function = on_nth_tick and script.on_nth_tick or script.on_event
+
+    -- Case: Explicit function
+    if handler_type == 'function' then
+        return register_handler(event_name, handler, handlers_table, script_event_function)
+    end
+
+    -- Case: Token function
+    if handler_type == 'number' and options.get_token then
+        local token_handler = options.get_token(handler)
+
+        if not token_handler then
+            return error('Invalid token or handler cannot be nil.')
         end
-    end
-end
 
---- Do not use this function, use Event.on_configuration_changed instead as it has safety checks.
-function Public.on_configuration_changed(handler)
-    local handlers = event_handlers[configuration_changed_name]
-    if not handlers then
-        event_handlers[configuration_changed_name] = {handler}
-        script.on_configuration_changed(configuration_changed)
-    else
-        table.insert(handlers, handler)
-        if #handlers == 1 then
-            script.on_configuration_changed(configuration_changed)
+        local tokens = on_nth_tick and token_handlers_on_nth_tick or token_handlers
+        tokens[event_name] = tokens[event_name] or {}
+        tokens[event_name][handler] = true
+
+        return register_handler(event_name, token_handler, handlers_table, script_event_function)
+    end
+
+    -- Case: Named string function
+    if handler_type == 'string' and options.name then
+        local func_handler, err = load('return ' .. handler)()
+
+        if not func_handler or type(func_handler) ~= 'function' then
+            return error('Invalid string function: ' .. (err or 'nil'))
         end
+
+        local functions = on_nth_tick and function_handlers_on_nth_tick or function_handlers
+        functions[event_name] = functions[event_name] or {}
+        functions[event_name][options.name] = handler
+
+        return register_handler(event_name, func_handler, handlers_table, script_event_function)
     end
+
+    return error('Handler must be a function, token, or valid string function with a name.')
 end
 
---- Do not use this function, use Event.on_nth_tick instead as it has safety checks.
-function Public.on_nth_tick(tick, handler)
-    local handlers = on_nth_tick_event_handlers[tick]
-    if not handlers then
-        on_nth_tick_event_handlers[tick] = {handler}
-        script_on_nth_tick(tick, on_nth_tick_event)
-    else
-        table.insert(handlers, handler)
-        if #handlers == 1 then
-            script_on_nth_tick(tick, on_nth_tick_event)
+--- Remove an existing event handler from a specified event.
+--- This method allows for the removal of a handler that was registered previously using `Event.add`.
+--- The handler can be specified by function reference, token, or by its assigned name.
+--- Use an optional `options` table to customize the removal process, including specifying whether the handler is associated with nth tick events.
+---@param event_name: EventName - The name of the event from which to remove the handler
+---@param handler: function|number|string - The handler to remove, which can be a function reference, token number, or named string handler
+---@param options?: table - An optional table containing options for handler removal
+---@param options.on_nth_tick: boolean - If true, indicates that the handler is associated with nth tick events
+Public.remove = function(event_name, handler, options)
+    options = options or {}
+    local handler_type = type(handler)
+    local on_nth_tick = options.on_nth_tick or false
+    local handlers_table = on_nth_tick and event_handlers_on_nth_tick or event_handlers
+
+    -- Case: Token function
+    if handler_type == 'number' then
+        local token_handler = options.get_token and options.get_token(handler)
+
+        if not token_handler then
+            log('Token not found: ' .. handler)
+            return false
         end
+
+        local tokens = on_nth_tick and token_handlers_on_nth_tick or token_handlers
+        tokens[event_name][handler] = false
+
+        return remove_handler(event_name, token_handler, handlers_table)
     end
+
+    -- Case: Named string handler
+    if handler_type == 'string' then
+        local functions = on_nth_tick and function_handlers_on_nth_tick or function_handlers
+        local string_handler = functions[event_name] and functions[event_name][handler]
+
+        if not string_handler then
+            log('Handler not found: ' .. handler)
+            return false
+        end
+
+        functions[event_name][handler] = nil
+        local func_handler = load('return ' .. string_handler)()
+
+        return remove_handler(event_name, func_handler, handlers_table)
+    end
+
+    -- Assume it's an explicit function
+    return error('Cannot remove registered function: handler must be a token or valid function name.')
 end
 
-function Public.get_event_handlers()
-    return event_handlers
+--- Register an init handler.
+-- This will be called when script initialization occurs.
+-- @param handler The function that will be called on initialization.
+Public.on_init = function(handler)
+    return register_handler(events.on_init, handler, event_handlers, script.on_init)
 end
 
-function Public.get_on_nth_tick_event_handlers()
-    return on_nth_tick_event_handlers
+--- Register a load handler.
+---This will be called when the script is loaded.
+---@param handler The function that will be called on loading.
+Public.on_load = function(handler)
+    return register_handler(events.on_load, handler, event_handlers, script.on_load)
 end
 
-Public.on_event = on_event
+--- Register a configuration change handler.
+---This will be called when the configuration changes.
+---@param handler The function that will be called on configuration change.
+Public.on_configuration_changed = function(handler)
+    return register_handler(events.on_configuration_changed, handler, event_handlers, script.on_configuration_changed)
+end
+
+Public.get_handlers = function()
+    return {
+        token_handlers = token_handlers,
+        token_handlers_on_nth_tick = token_handlers_on_nth_tick,
+        function_handlers = function_handlers,
+        function_handlers_on_nth_tick = function_handlers_on_nth_tick,
+    }
+end
+
+Public.set_handlers = function(tbl)
+    token_handlers = tbl.token_handlers
+    token_handlers_on_nth_tick = tbl.token_handlers_on_nth_tick
+    function_handlers = tbl.function_handlers
+    function_handlers_on_nth_tick = tbl.function_handlers_on_nth_tick
+end
+
+--- Generate a new, unique event ID.
+---@param name string, name of the event/variable that is exposed
+Public.generate_event_name = function(name)
+    local event_id = script.generate_event_name()
+
+    -- If we're in debug, add the event ID into defines.events for the debuggertron's event module
+    if _DEBUG then
+        defines.events[name] = event_id -- luacheck: ignore 122
+    end
+
+    return event_id
+end
 
 return Public


### PR DESCRIPTION
I'm just gonna post this as a mean to share a code ideas, but no real plans to replace our current implementation.

Many checks for the correct `_STAGE` are missing as well as old documentation in `event.lua` not being updated, but I've loaded with some maps and it works just like previous, since `event.lua` acts as a backwards compatibility layer exposing all the old methods.

### Miscellaneous of ideas:
1a. It could be possible to remove `event.lua` and only use `event_core.lua` (maybe renaming it to `event.lua) by having the event module register its tables to the storage table & tokenizing the handlers passed to it itself, removing the dependency of `global.lua` and `token.lua`.

1b. Moving small bits of logic to the event module may make it completely independent but it kinda breaks the single-responsibility principle, which I'm not too happy to do either.

2a. It could be simplified to always call `Event.add(...)' around the code base and it'll automatically take care of registering whatever handler (function, token, string) it has been passed to it, with/without the `on_tick_option`.

2b. On the other hand, keeping `event.lua` layer to add specific methods to call for on_tick/tokens/whatever could be easier to read/use? May be subjective. `event.lua` could still take care of input sanitization and stage checks while `event_core.lua` only handles the technical part of adding/removing