### PR TITLE
Add DO Collapse preset

### DIFF
--- a/map_gen/maps/danger_ores/changelog.lua
+++ b/map_gen/maps/danger_ores/changelog.lua
@@ -106,4 +106,7 @@ return [[
       - [DO] Removed ore breakdown, only total amount is displayed instead
       - [DO] Removed custom surface from base scenario
       - [DO:SpaceAge] Added DO/SpaceAge
+
+  2025-09-02:
+      - [DO:Collapse] Added Collapse preset
 ]]

--- a/map_gen/maps/danger_ores/modules/map_poll.lua
+++ b/map_gen/maps/danger_ores/modules/map_poll.lua
@@ -27,6 +27,7 @@ local mod_packs = {
     danger_ore_py_short   = 'danger_ore_py_short',
     danger_ore_scrap      = 'danger_ore_scrap',
     danger_ore_space_age  = 'danger_ore_space_age',
+    danger_ore_collapse   = 'danger_ore_collapse',
 }
 
 local maps = {
@@ -37,6 +38,7 @@ local maps = {
     { name = 'danger-ore-chessboard', display_name = 'Chessboard (random squares)', mod_pack = mod_packs.danger_ore_normal },
     { name = 'danger-ore-circles', display_name = 'Circles (ore rings)', mod_pack = mod_packs.danger_ore_normal },
     { name = 'danger-ore-coal-maze', display_name = 'Coal Maze (maze)', mod_pack = mod_packs.danger_ore_normal },
+    { name = 'danger-ore-collapse', display_name = 'Collapse (increasing hardness)', mod_pack = mod_packs.danger_ore_collapse },
     --{ name = 'danger-ore-exotic-industries', display_name = 'Exotic Industries (default)', mod_pack = mod_packs.danger_ore_ei },
     --{ name = 'danger-ore-exotic-industries-spiral', display_name = 'Exotic Industries Spiral (without void)', mod_pack = mod_packs.danger_ore_ei },
     --{ name = 'danger-ore-expanse', display_name = 'Expanse (feed Hungry Chests to expand)', mod_pack = mod_packs.danger_ore_normal },

--- a/map_gen/maps/danger_ores/presets/danger_ore_collapse.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_collapse.lua
@@ -1,0 +1,21 @@
+
+local DOC = require 'map_gen.maps.danger_ores.configuration'
+local Scenario = require 'map_gen.maps.danger_ores.scenario'
+local ScenarioInfo = require 'features.gui.info'
+
+ScenarioInfo.set_map_name('Danger Ores - Collapse')
+ScenarioInfo.add_map_extra_info([[
+	This map is covered in [item=coal] with mixed dense patches containing [item=iron-ore] [item=copper-ore] [item=stone].
+	The patches alternate between [item=iron-ore] and [item=copper-ore] as the main resource.
+
+	Every time a resource production goal is reached, a Collapse event is initiated and all the ore on the map will collapse
+	on itself and generate new ore increasingly harder to mine.
+]])
+
+DOC.scenario_name = 'danger-ore-collapse'
+DOC.map_config.main_ore_resource_patches_config = require 'map_gen.maps.danger_ores.config.main_ore_resource_patches'
+DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_patches'
+DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.config.coal'
+DOC.map_config.main_ores_rotate = nil
+
+return Scenario.register(DOC)

--- a/scenario_templates/danger-ore-collapse/map_selection.lua
+++ b/scenario_templates/danger-ore-collapse/map_selection.lua
@@ -1,0 +1,1 @@
+return require 'map_gen.maps.danger_ores.presets.danger_ore_collapse'


### PR DESCRIPTION
Adds a new DO preset: DO Collapse.

> Ore hardness increases along with the Factory's production.

Everything is basically handled by the mod [Ore Evolution](https://mods.factorio.com/mod/ore-evolution).

Customizable via settings, by default, 9 levels of:
- Ore hardness: 2,4,8,16,32,64,128,256,512
- Ore to mine: 5e6,15e6,45e6,135e6,270e6,350e6,425e6,500e6,1e9
- Ore tiles updated/second: 10 (for low UPS impact), ~2s per chunk

Small UI with info displayed to all:

<img width="374" height="374" alt="oe_1" src="https://github.com/user-attachments/assets/15644133-64f4-435d-9b3b-cdaefdcc663d" />
