### PR TITLE
PY DO: Fix typo in utility science pack key

### DIFF
--- a/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_pyfe.lua
@@ -60,7 +60,7 @@ tech_scaling({
     ['logistic-science-pack']   = 0.75,
     ['chemical-science-pack']   = 0.50,
     ['production-science-pack'] = 0.25,
-    ['utility-sciemce-pack']    = 0.20,
+    ['utility-science-pack']    = 0.20,
     ['space-science-pack']      = 0.10,
   },
 })


### PR DESCRIPTION
this looks like a bug?