### PR TITLE
Update DO:SA

### DIFF
--- a/map_gen/maps/danger_ores/changelog.lua
+++ b/map_gen/maps/danger_ores/changelog.lua
@@ -109,4 +109,11 @@ return [[
 
   2025-09-02:
       - [DO:Collapse] Added Collapse preset
+
+  2025-09-14:
+      - [DO] Added dominant stone patches to heavy coal presets
+      - [DO:SA] Fixed jellunut and yumako progression softlock
+      - [DO:SA] Removed ore-voiding recipes from recyclers
+      - [DO:K2] Fixed rare metals and yellowcake pictures scaling
+      - [DO:K2] Removed ore-voiding recipes from crushers
 ]]

--- a/map_gen/maps/danger_ores/compatibility/space-age/ores.lua
+++ b/map_gen/maps/danger_ores/compatibility/space-age/ores.lua
@@ -22,6 +22,12 @@ local copper_ratios = {
     { resource = b.resource(b.full_shape, 'stone',      ratio_value), weight = 10 },
 }
 
+local stone_ratios = {
+    { resource = b.resource(b.full_shape, 'iron-ore',   ratio_value), weight = 25 },
+    { resource = b.resource(b.full_shape, 'copper-ore', ratio_value), weight = 15 },
+    { resource = b.resource(b.full_shape, 'stone',      ratio_value), weight = 60 },
+}
+
 local function build_solid_patches(ratios)
     return function(x, y, world)
         local weighted = b.prepare_weighted_array(ratios)
@@ -58,6 +64,7 @@ end
 return {
     { scale = 1 / 24, threshold = 0.50, resource = build_solid_patches(iron_ratios) },
     { scale = 1 / 24, threshold = 0.50, resource = build_solid_patches(copper_ratios) },
+    { scale = 1 / 24, threshold = 0.50, resource = build_solid_patches(stone_ratios) },
     { scale = 1 / 48, threshold = 0.66, resource = b.resource(b.full_shape, 'tungsten-ore', value(100, 1.5)) },
     { scale = 1 / 24, threshold = 0.66, resource = b.resource(b.full_shape, 'calcite',      value(100, 1.5)) },
     { scale = 1 / 48, threshold = 0.66, resource = b.resource(b.full_shape, prototypes.entity['holmium-ore'] and 'holmium-ore' or 'scrap',  value(100, 1.5)) },

--- a/map_gen/maps/danger_ores/compatibility/space-age/tree_names.lua
+++ b/map_gen/maps/danger_ores/compatibility/space-age/tree_names.lua
@@ -29,4 +29,6 @@ return {
     'cuttlepop',
     'fulgurite',
     'fulgurite-small',
+    'yumako-tree',
+    'jellystem',
 }

--- a/map_gen/maps/danger_ores/config/main_ore_resource_patches.lua
+++ b/map_gen/maps/danger_ores/config/main_ore_resource_patches.lua
@@ -20,6 +20,12 @@ local copper_ratios = {
     {resource = b.resource(b.full_shape, 'stone', ratio_value), weight = 10}
 }
 
+local stone_ratios = {
+    { resource = b.resource(b.full_shape, 'iron-ore',   ratio_value), weight = 25 },
+    { resource = b.resource(b.full_shape, 'copper-ore', ratio_value), weight = 15 },
+    { resource = b.resource(b.full_shape, 'stone',      ratio_value), weight = 60 },
+}
+
 local function build_ratio_patches(ratios)
     return function(x, y, world)
         local weighted = b.prepare_weighted_array(ratios)
@@ -42,5 +48,6 @@ end
 
 return {
     {scale = 1 / 24, threshold = 0.5, resource = build_ratio_patches(iron_ratios)},
-    {scale = 1 / 24, threshold = 0.5, resource = build_ratio_patches(copper_ratios)}
+    {scale = 1 / 24, threshold = 0.5, resource = build_ratio_patches(copper_ratios)},
+    {scale = 1 / 24, threshold = 0.5, resource = build_ratio_patches(stone_ratios)},
 }

--- a/map_gen/maps/danger_ores/presets/danger_ore_space_age.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_space_age.lua
@@ -19,6 +19,8 @@ DOC.map_config.trees = require 'map_gen.maps.danger_ores.modules.trees'
 DOC.map_config.tree_names = require 'map_gen.maps.danger_ores.compatibility.space-age.tree_names'
 DOC.map_config.spawner_names = { 'biter-spawner', 'spitter-spawner', 'gleba-spawner-small', 'gleba-spawner' }
 DOC.rocket_launched.enabled = false
+DOC.technologies.unlocks['agriculture'] = { 'jellynut', 'yumako' }
+DOC.technologies.unlocks['electromagnetic-science-pack'] = { 'lithium-processing' }
 DOC.map_gen_settings.settings = H.empty_map_settings{
 	'calcite',
 	'coal',


### PR DESCRIPTION
2025-09-14:
    - [DO] Added dominant stone patches to heavy coal presets
    - [DO:SA] Fixed jellunut and yumako progression softlock
    - [DO:SA] Removed ore-voiding recipes from recyclers
    - [DO:K2] Fixed rare metals and yellowcake pictures scaling
    - [DO:K2] Removed ore-voiding recipes from crushers