### PR TITLE
Gui tags

### DIFF
--- a/features/cutscene/cutscene_controller.lua
+++ b/features/cutscene/cutscene_controller.lua
@@ -248,21 +248,21 @@ function Public.register_running_cutscene(player_index, identifier, final_transi
     local flow = Gui.add_top_element(player, { type = 'flow', name = flow_name })
     running_cutscene.btn = flow
 
-    local btn = flow.add {type = 'sprite-button', caption = 'Skip cutscene', style = Styles.default_top_element.name, tags = { [Gui.tag] = skip_btn_name } }
+    local btn = flow.add {type = 'sprite-button', caption = 'Skip cutscene', style = Styles.default_top_element.name, tags = { [Gui.event_tag] = skip_btn_name } }
     btn.style.minimal_height = 36
     btn.style.maximal_height = 36
     btn.style.minimal_width = 150
     btn.style.font = 'default-large-bold'
     btn.style.font_color = {r = 255, g = 215, b = 0}
 
-    local back_btn = flow.add {type = 'sprite-button', caption = 'Go back', style = Styles.default_top_element.name, tags = { [Gui.tag] = backward_btn_name } }
+    local back_btn = flow.add {type = 'sprite-button', caption = 'Go back', style = Styles.default_top_element.name, tags = { [Gui.event_tag] = backward_btn_name } }
     back_btn.style.minimal_height = 36
     back_btn.style.maximal_height = 36
     back_btn.style.minimal_width = 100
     back_btn.style.font = 'default-large-bold'
     back_btn.style.font_color = {r = 255, g = 215, b = 0}
 
-    local forward_btn = flow.add {type = 'sprite-button', caption = 'Go forward', style = Styles.default_top_element.name, tags = { [Gui.tag] = forward_btn_name } }
+    local forward_btn = flow.add {type = 'sprite-button', caption = 'Go forward', style = Styles.default_top_element.name, tags = { [Gui.event_tag] = forward_btn_name } }
     forward_btn.style.minimal_height = 36
     forward_btn.style.maximal_height = 36
     forward_btn.style.minimal_width = 100
@@ -275,7 +275,7 @@ function Public.register_running_cutscene(player_index, identifier, final_transi
             type = 'checkbox',
             caption = 'Auto play cutscene',
             state = Settings.get(player_index, auto_play_cutscene_setting_name),
-            tags = { [Gui.tag] = auto_play_cutscene_checkbox_name },
+            tags = { [Gui.event_tag] = auto_play_cutscene_checkbox_name },
         }
 
         auto_play_cutscene_checkbox.style.top_margin = 8

--- a/features/cutscene/cutscene_controller.lua
+++ b/features/cutscene/cutscene_controller.lua
@@ -15,7 +15,6 @@ local skip_btn_name = Gui.uid_name()
 local backward_btn_name = Gui.uid_name()
 local forward_btn_name = Gui.uid_name()
 local auto_play_cutscene_checkbox_name = Gui.uid_name()
-local flow_name = Gui.uid_name()
 
 local Public = {}
 local handler
@@ -245,24 +244,24 @@ function Public.register_running_cutscene(player_index, identifier, final_transi
         final_transition_time = final_transition_time
     }
 
-    local flow = Gui.add_top_element(player, { type = 'flow', name = flow_name })
+    local flow = Gui.add_top_element(player, { type = 'flow' })
     running_cutscene.btn = flow
 
-    local btn = flow.add {type = 'sprite-button', name = skip_btn_name, caption = 'Skip cutscene', style = Styles.default_top_element.name }
+    local btn = flow.add {type = 'sprite-button', caption = 'Skip cutscene', style = Styles.default_top_element.name, tags = { [Gui.tag] = skip_btn_name } }
     btn.style.minimal_height = 36
     btn.style.maximal_height = 36
     btn.style.minimal_width = 150
     btn.style.font = 'default-large-bold'
     btn.style.font_color = {r = 255, g = 215, b = 0}
 
-    local back_btn = flow.add {type = 'sprite-button', name = backward_btn_name, caption = 'Go back', style = Styles.default_top_element.name }
+    local back_btn = flow.add {type = 'sprite-button', caption = 'Go back', style = Styles.default_top_element.name, tags = { [Gui.tag] = backward_btn_name } }
     back_btn.style.minimal_height = 36
     back_btn.style.maximal_height = 36
     back_btn.style.minimal_width = 100
     back_btn.style.font = 'default-large-bold'
     back_btn.style.font_color = {r = 255, g = 215, b = 0}
 
-    local forward_btn = flow.add {type = 'sprite-button', name = forward_btn_name, caption = 'Go forward', style = Styles.default_top_element.name }
+    local forward_btn = flow.add {type = 'sprite-button', caption = 'Go forward', style = Styles.default_top_element.name, tags = { [Gui.tag] = forward_btn_name } }
     forward_btn.style.minimal_height = 36
     forward_btn.style.maximal_height = 36
     forward_btn.style.minimal_width = 100
@@ -273,9 +272,9 @@ function Public.register_running_cutscene(player_index, identifier, final_transi
         local auto_play_cutscene_checkbox = flow.add
         {
             type = 'checkbox',
-            name = auto_play_cutscene_checkbox_name,
             caption = 'Auto play cutscene',
-            state = Settings.get(player_index, auto_play_cutscene_setting_name)
+            state = Settings.get(player_index, auto_play_cutscene_setting_name),
+            tags = { [Gui.tag] = auto_play_cutscene_checkbox_name },
         }
 
         auto_play_cutscene_checkbox.style.top_margin = 8

--- a/features/cutscene/cutscene_controller.lua
+++ b/features/cutscene/cutscene_controller.lua
@@ -15,6 +15,7 @@ local skip_btn_name = Gui.uid_name()
 local backward_btn_name = Gui.uid_name()
 local forward_btn_name = Gui.uid_name()
 local auto_play_cutscene_checkbox_name = Gui.uid_name()
+local flow_name = Gui.uid_name()
 
 local Public = {}
 local handler
@@ -244,7 +245,7 @@ function Public.register_running_cutscene(player_index, identifier, final_transi
         final_transition_time = final_transition_time
     }
 
-    local flow = Gui.add_top_element(player, { type = 'flow' })
+    local flow = Gui.add_top_element(player, { type = 'flow', name = flow_name })
     running_cutscene.btn = flow
 
     local btn = flow.add {type = 'sprite-button', caption = 'Skip cutscene', style = Styles.default_top_element.name, tags = { [Gui.tag] = skip_btn_name } }

--- a/features/gui/admin_panel/core.lua
+++ b/features/gui/admin_panel/core.lua
@@ -55,7 +55,7 @@ function Public.get_main_frame(player)
     name = main_frame_name,
     direction = 'vertical',
     style = 'frame',
-    tags = { [Gui.tag] = main_frame_name },
+    tags = { [Gui.event_tag] = main_frame_name },
   }
   frame.auto_center = true
   player.opened = frame
@@ -87,7 +87,7 @@ function Public.get_main_frame(player)
       clicked_sprite = 'utility/close_black',
       style = 'close_button',
       tooltip = {'gui.close-instruction'},
-      tags = { [Gui.tag] = close_button_name },
+      tags = { [Gui.event_tag] = close_button_name },
     }
   end
 
@@ -138,7 +138,7 @@ function Public.update_top_button(player)
     name = main_button_name,
     sprite = 'item/power-armor-mk2',
     tooltip = {'admin_panel.info_tooltip'},
-    tags = { [Gui.tag] = main_button_name },
+    tags = { [Gui.event_tag] = main_button_name },
   })
   button.visible = player.admin
 end

--- a/features/gui/admin_panel/core.lua
+++ b/features/gui/admin_panel/core.lua
@@ -55,6 +55,7 @@ function Public.get_main_frame(player)
     name = main_frame_name,
     direction = 'vertical',
     style = 'frame',
+    tags = { [Gui.tag] = main_frame_name },
   }
   frame.auto_center = true
   player.opened = frame
@@ -82,11 +83,11 @@ function Public.get_main_frame(player)
 
     flow.add {
       type = 'sprite-button',
-      name = close_button_name,
       sprite = 'utility/close',
       clicked_sprite = 'utility/close_black',
       style = 'close_button',
-      tooltip = {'gui.close-instruction'}
+      tooltip = {'gui.close-instruction'},
+      tags = { [Gui.tag] = close_button_name },
     }
   end
 
@@ -137,6 +138,7 @@ function Public.update_top_button(player)
     name = main_button_name,
     sprite = 'item/power-armor-mk2',
     tooltip = {'admin_panel.info_tooltip'},
+    tags = { [Gui.tag] = main_button_name },
   })
   button.visible = player.admin
 end
@@ -183,20 +185,8 @@ Event.add(defines.events.on_player_joined_game, function(event)
   end
 end)
 
-Event.add(defines.events.on_gui_closed, function(event)
-  local element = event.element
-  if not (element and element.valid) then
-    return
-  end
-
-  local player = game.get_player(event.player_index)
-  if not (player and player.valid) then
-    return
-  end
-
-  if element.name == main_frame_name then
-    Public.toggle_main_button(player)
-  end
+Gui.on_custom_close(main_frame_name, function(event)
+  Public.toggle_main_button(event.player)
 end)
 
 Gui.allow_player_to_toggle_top_element_visibility(main_button_name)

--- a/features/gui/admin_panel/lua_console.lua
+++ b/features/gui/admin_panel/lua_console.lua
@@ -19,8 +19,8 @@ pages[#pages +1] = {
   type = 'sprite-button',
   sprite = 'utility/scripting_editor_icon',
   tooltip = '[font=default-bold]Lua console[/font]',
-  name = main_button_name,
   auto_toggle = true,
+  tags = { [Gui.tag] = main_button_name },
 }
 
 local function draw_gui(player)
@@ -54,9 +54,9 @@ local function draw_gui(player)
 
   local button_flow = canvas.add { type = 'flow', direction = 'horizontal' }
   Gui.add_pusher(button_flow)
-  button_flow.add { type = 'button', name = clear_button_name, style = 'red_back_button', caption = 'Clear' }
-  local dry_run = button_flow.add { type = 'button', name = dry_run_button_name, style = 'forward_button', caption = 'Dry run' }
-  local confirm = button_flow.add { type = 'button', name = confirm_button_name, style = 'confirm_double_arrow_button', caption = 'Confirm', tooltip = 'Run input code' }
+  button_flow.add { type = 'button', style = 'red_back_button', caption = 'Clear', tags = { [Gui.tag] = clear_button_name } }
+  local dry_run = button_flow.add { type = 'button', tags = { [Gui.tag] = dry_run_button_name }, style = 'forward_button', caption = 'Dry run' }
+  local confirm = button_flow.add { type = 'button', tags = { [Gui.tag] = confirm_button_name }, style = 'confirm_double_arrow_button', caption = 'Confirm', tooltip = 'Run input code' }
   Gui.set_style(confirm, { left_margin = -9 })
 
   Gui.set_data(dry_run, { input = input, output = output })

--- a/features/gui/admin_panel/lua_console.lua
+++ b/features/gui/admin_panel/lua_console.lua
@@ -20,7 +20,7 @@ pages[#pages +1] = {
   sprite = 'utility/scripting_editor_icon',
   tooltip = '[font=default-bold]Lua console[/font]',
   auto_toggle = true,
-  tags = { [Gui.tag] = main_button_name },
+  tags = { [Gui.event_tag] = main_button_name },
 }
 
 local function draw_gui(player)
@@ -54,9 +54,9 @@ local function draw_gui(player)
 
   local button_flow = canvas.add { type = 'flow', direction = 'horizontal' }
   Gui.add_pusher(button_flow)
-  button_flow.add { type = 'button', style = 'red_back_button', caption = 'Clear', tags = { [Gui.tag] = clear_button_name } }
-  local dry_run = button_flow.add { type = 'button', tags = { [Gui.tag] = dry_run_button_name }, style = 'forward_button', caption = 'Dry run' }
-  local confirm = button_flow.add { type = 'button', tags = { [Gui.tag] = confirm_button_name }, style = 'confirm_double_arrow_button', caption = 'Confirm', tooltip = 'Run input code' }
+  button_flow.add { type = 'button', style = 'red_back_button', caption = 'Clear', tags = { [Gui.event_tag] = clear_button_name } }
+  local dry_run = button_flow.add { type = 'button', tags = { [Gui.event_tag] = dry_run_button_name }, style = 'forward_button', caption = 'Dry run' }
+  local confirm = button_flow.add { type = 'button', tags = { [Gui.event_tag] = confirm_button_name }, style = 'confirm_double_arrow_button', caption = 'Confirm', tooltip = 'Run input code' }
   Gui.set_style(confirm, { left_margin = -9 })
 
   Gui.set_data(dry_run, { input = input, output = output })

--- a/features/gui/admin_panel/map_manager.lua
+++ b/features/gui/admin_panel/map_manager.lua
@@ -27,7 +27,7 @@ pages[#pages +1] = {
   sprite = 'utility/surface_editor_icon',
   tooltip = '[font=default-bold]Map manager[/font]',
   auto_toggle = true,
-  tags = { [Gui.tag] = main_button_name },
+  tags = { [Gui.event_tag] = main_button_name },
 }
 
 local function make_button(parent, params)
@@ -50,7 +50,7 @@ local function make_slider(parent, params)
   Gui.set_style(button, { width = 150 })
   params.slider.value = math.clamp(params.value, params.slider.minimum_value, params.slider.maximum_value)
   local slider = flow.add(params.slider)
-  slider.tags = { [Gui.tag] = slider_tag_name }
+  slider.tags = { [Gui.event_tag] = slider_tag_name }
   slider.tooltip = string.format(params.format, slider.slider_value)
   Gui.set_style(slider, { width = 250 })
   local label = flow.add { type = 'label', caption = string.format(params.format, params.value), tooltip = params.tooltip or 'Current value' }
@@ -79,7 +79,7 @@ local function draw_gui(player)
   make_slider(row_1, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_performance_speed },
+      tags = { [Gui.event_tag] = on_performance_speed },
       caption = 'Performance speed',
       tooltip = {'command_description.performance_scale_set'},
     },
@@ -95,7 +95,7 @@ local function draw_gui(player)
   make_slider(row_1, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_slow_down },
+      tags = { [Gui.event_tag] = on_slow_down },
       caption = 'Slow down'
     },
     slider = {
@@ -110,7 +110,7 @@ local function draw_gui(player)
   make_slider(row_1, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_speed_up },
+      tags = { [Gui.event_tag] = on_speed_up },
       caption = 'Speed up'
     },
     slider = {
@@ -127,7 +127,7 @@ local function draw_gui(player)
   make_slider(row_2, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_pollution_ageing },
+      tags = { [Gui.event_tag] = on_pollution_ageing },
       caption = 'Ageing'
     },
     slider = {
@@ -143,7 +143,7 @@ local function draw_gui(player)
   make_slider(row_2, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_pollution_diffusion },
+      tags = { [Gui.event_tag] = on_pollution_diffusion },
       caption = 'Diffusion ratio'
     },
     slider = {
@@ -159,7 +159,7 @@ local function draw_gui(player)
   make_slider(row_2, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_pollution_attack_modifier },
+      tags = { [Gui.event_tag] = on_pollution_attack_modifier },
       caption = 'Atk. modifier'
     },
     slider = {
@@ -177,7 +177,7 @@ local function draw_gui(player)
   make_slider(row_3, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_evolution_value },
+      tags = { [Gui.event_tag] = on_evolution_value },
       caption = 'Enemy evolution'
     },
     slider = {
@@ -193,7 +193,7 @@ local function draw_gui(player)
   make_slider(row_3, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_evolution_destroy_factor },
+      tags = { [Gui.event_tag] = on_evolution_destroy_factor },
       caption = 'Destroy factor'
     },
     slider = {
@@ -210,7 +210,7 @@ local function draw_gui(player)
   make_slider(row_3, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_evolution_time_factor },
+      tags = { [Gui.event_tag] = on_evolution_time_factor },
       caption = 'Time factor'
     },
     slider = {
@@ -228,7 +228,7 @@ local function draw_gui(player)
   make_slider(row_4, {
     button = {
       type = 'button',
-      tags = { [Gui.tag] = on_map_chart },
+      tags = { [Gui.event_tag] = on_map_chart },
       caption = 'Chart map'
     },
     slider = {
@@ -242,9 +242,9 @@ local function draw_gui(player)
   })
   local table_4 = row_4.add { type = 'table', column_count = 3 }
   for _, button in pairs({
-    { tags = { [Gui.tag] = on_map_hide }, caption = 'Hide all' },
-    { tags = { [Gui.tag] = on_map_reveal }, caption = 'Reveal all' },
-    { tags = { [Gui.tag] = on_map_rechart }, caption = 'Re-chart all' },
+    { tags = { [Gui.event_tag] = on_map_hide }, caption = 'Hide all' },
+    { tags = { [Gui.event_tag] = on_map_reveal }, caption = 'Reveal all' },
+    { tags = { [Gui.event_tag] = on_map_rechart }, caption = 'Re-chart all' },
   }) do make_button(table_4, button) end
 end
 

--- a/features/gui/admin_panel/map_manager.lua
+++ b/features/gui/admin_panel/map_manager.lua
@@ -1,5 +1,4 @@
 local AdminPanel = require 'features.gui.admin_panel.core'
-local Event = require 'utils.event'
 local Gui = require 'utils.gui'
 local math = require 'utils.math'
 local Surface = require 'features.gui.admin_panel.functions'.surface
@@ -27,15 +26,15 @@ pages[#pages +1] = {
   type = 'sprite-button',
   sprite = 'utility/surface_editor_icon',
   tooltip = '[font=default-bold]Map manager[/font]',
-  name = main_button_name,
   auto_toggle = true,
+  tags = { [Gui.tag] = main_button_name },
 }
 
 local function make_button(parent, params)
   local button = parent.add {
     type = 'button',
     caption = params.caption,
-    name = params.name,
+    tags = params.tags,
     tooltip = params.tooltip,
   }
   Gui.set_style(button, {
@@ -51,7 +50,7 @@ local function make_slider(parent, params)
   Gui.set_style(button, { width = 150 })
   params.slider.value = math.clamp(params.value, params.slider.minimum_value, params.slider.maximum_value)
   local slider = flow.add(params.slider)
-  slider.tags = { name = slider_tag_name }
+  slider.tags = { [Gui.tag] = slider_tag_name }
   slider.tooltip = string.format(params.format, slider.slider_value)
   Gui.set_style(slider, { width = 250 })
   local label = flow.add { type = 'label', caption = string.format(params.format, params.value), tooltip = params.tooltip or 'Current value' }
@@ -80,7 +79,7 @@ local function draw_gui(player)
   make_slider(row_1, {
     button = {
       type = 'button',
-      name = on_performance_speed,
+      tags = { [Gui.tag] = on_performance_speed },
       caption = 'Performance speed',
       tooltip = {'command_description.performance_scale_set'},
     },
@@ -96,7 +95,7 @@ local function draw_gui(player)
   make_slider(row_1, {
     button = {
       type = 'button',
-      name = on_slow_down,
+      tags = { [Gui.tag] = on_slow_down },
       caption = 'Slow down'
     },
     slider = {
@@ -111,7 +110,7 @@ local function draw_gui(player)
   make_slider(row_1, {
     button = {
       type = 'button',
-      name = on_speed_up,
+      tags = { [Gui.tag] = on_speed_up },
       caption = 'Speed up'
     },
     slider = {
@@ -128,7 +127,7 @@ local function draw_gui(player)
   make_slider(row_2, {
     button = {
       type = 'button',
-      name = on_pollution_ageing,
+      tags = { [Gui.tag] = on_pollution_ageing },
       caption = 'Ageing'
     },
     slider = {
@@ -144,7 +143,7 @@ local function draw_gui(player)
   make_slider(row_2, {
     button = {
       type = 'button',
-      name = on_pollution_diffusion,
+      tags = { [Gui.tag] = on_pollution_diffusion },
       caption = 'Diffusion ratio'
     },
     slider = {
@@ -160,7 +159,7 @@ local function draw_gui(player)
   make_slider(row_2, {
     button = {
       type = 'button',
-      name = on_pollution_attack_modifier,
+      tags = { [Gui.tag] = on_pollution_attack_modifier },
       caption = 'Atk. modifier'
     },
     slider = {
@@ -178,7 +177,7 @@ local function draw_gui(player)
   make_slider(row_3, {
     button = {
       type = 'button',
-      name = on_evolution_value,
+      tags = { [Gui.tag] = on_evolution_value },
       caption = 'Enemy evolution'
     },
     slider = {
@@ -194,7 +193,7 @@ local function draw_gui(player)
   make_slider(row_3, {
     button = {
       type = 'button',
-      name = on_evolution_destroy_factor,
+      tags = { [Gui.tag] = on_evolution_destroy_factor },
       caption = 'Destroy factor'
     },
     slider = {
@@ -211,7 +210,7 @@ local function draw_gui(player)
   make_slider(row_3, {
     button = {
       type = 'button',
-      name = on_evolution_time_factor,
+      tags = { [Gui.tag] = on_evolution_time_factor },
       caption = 'Time factor'
     },
     slider = {
@@ -229,7 +228,7 @@ local function draw_gui(player)
   make_slider(row_4, {
     button = {
       type = 'button',
-      name = on_map_chart,
+      tags = { [Gui.tag] = on_map_chart },
       caption = 'Chart map'
     },
     slider = {
@@ -243,9 +242,9 @@ local function draw_gui(player)
   })
   local table_4 = row_4.add { type = 'table', column_count = 3 }
   for _, button in pairs({
-    { name = on_map_hide, caption = 'Hide all' },
-    { name = on_map_reveal, caption = 'Reveal all' },
-    { name = on_map_rechart, caption = 'Re-chart all' },
+    { tags = { [Gui.tag] = on_map_hide }, caption = 'Hide all' },
+    { tags = { [Gui.tag] = on_map_reveal }, caption = 'Reveal all' },
+    { tags = { [Gui.tag] = on_map_rechart }, caption = 'Re-chart all' },
   }) do make_button(table_4, button) end
 end
 
@@ -261,18 +260,8 @@ Gui.on_click(main_button_name, function(event)
   end
 end)
 
-Event.add(defines.events.on_gui_value_changed, function(event)
-  local element = event.element
-  if not (element and element.valid) then
-    return
-  end
-
-  local tag = element.tags and element.tags.name
-  if not tag or tag ~= slider_tag_name then
-    return
-  end
-
-  local data = Gui.get_data(element)
+Gui.on_value_changed(slider_tag_name, function(event)
+  local data = Gui.get_data(event.element)
   data.slider.tooltip = string.format(data.format, data.slider.slider_value)
 end)
 

--- a/features/gui/admin_panel/player_manager.lua
+++ b/features/gui/admin_panel/player_manager.lua
@@ -50,7 +50,7 @@ pages[#pages +1] = {
   sprite = 'entity/character',
   tooltip = '[font=default-bold]Player manager[/font]',
   auto_toggle = true,
-  tags = { [Gui.tag] = main_button_name },
+  tags = { [Gui.event_tag] = main_button_name },
 }
 
 local ban_items = {}
@@ -135,10 +135,10 @@ local function make_player_dropdown(parent)
   Gui.set_style(selection_flow, { vertical_align = 'center' })
 
   selection_flow.add { type = 'label', caption = '[font=default-small][color=255,230,192]ONLINE[/color][/font]' }
-  selection_flow.add { type = 'switch', switch_state = this.selection_switch[player_index], allow_none_state = true, tags = { [Gui.tag] = selection_switch_name } }
+  selection_flow.add { type = 'switch', switch_state = this.selection_switch[player_index], allow_none_state = true, tags = { [Gui.event_tag] = selection_switch_name } }
   selection_flow.add { type = 'label', caption = '[font=default-small][color=255,230,192]OFFLINE[/color][/font]' }
 
-  local dropdown = selection_flow.add { type = 'drop-down', selected_index = selection_data.index, items = player_list, tags = { [Gui.tag] = selection_dropdown_name } }
+  local dropdown = selection_flow.add { type = 'drop-down', selected_index = selection_data.index, items = player_list, tags = { [Gui.event_tag] = selection_dropdown_name } }
   Gui.set_style(dropdown, { horizontally_stretchable = true })
   return selection_flow
 end
@@ -154,34 +154,34 @@ local function draw_gui(player)
   local row_1 = canvas.add { type = 'frame', style = 'bordered_frame', direction = 'vertical', caption = 'General actions' }
   local table_1 = row_1.add { type = 'table', column_count = 3 }
   for _, button in pairs({
-    { tags = { [Gui.tag] = on_cheat_mode }, caption = 'Cheat mode' },
-    { tags = { [Gui.tag] = on_show_reports }, caption = 'Show reports' },
-    { tags = { [Gui.tag] = on_toggle_blueprints }, caption = 'Blueprints ON/OFF' },
-    { tags = { [Gui.tag] = on_create_pool }, caption = 'Create pool' },
-    { tags = { [Gui.tag] = on_create_oil_field }, caption = 'Create oil field' },
-    { tags = { [Gui.tag] = on_create_pollution }, caption = 'Spawn pollution' },
-    { tags = { [Gui.tag] = on_revive_ghosts }, caption = 'Revive ghosts' },
-    { tags = { [Gui.tag] = on_save_game }, caption = 'Save game' },
-    { tags = { [Gui.tag] = on_delete_blueprints }, caption = 'Destroy ghost entities' },
-    { tags = { [Gui.tag] = on_destroy_speakers }, caption = 'Destroy speakers' },
-    { tags = { [Gui.tag] = on_remove_biters }, caption = 'Remove biters' },
-    { tags = { [Gui.tag] = on_remove_enemies }, caption = 'Remove all enemies' },
-    -- { tags = { [Gui.tag] = on_teleport }, caption = 'Teleport' },
-    -- { tags = { [Gui.tag] = on_destroy_selected }, caption = 'Destroy selected' }
+    { tags = { [Gui.event_tag] = on_cheat_mode }, caption = 'Cheat mode' },
+    { tags = { [Gui.event_tag] = on_show_reports }, caption = 'Show reports' },
+    { tags = { [Gui.event_tag] = on_toggle_blueprints }, caption = 'Blueprints ON/OFF' },
+    { tags = { [Gui.event_tag] = on_create_pool }, caption = 'Create pool' },
+    { tags = { [Gui.event_tag] = on_create_oil_field }, caption = 'Create oil field' },
+    { tags = { [Gui.event_tag] = on_create_pollution }, caption = 'Spawn pollution' },
+    { tags = { [Gui.event_tag] = on_revive_ghosts }, caption = 'Revive ghosts' },
+    { tags = { [Gui.event_tag] = on_save_game }, caption = 'Save game' },
+    { tags = { [Gui.event_tag] = on_delete_blueprints }, caption = 'Destroy ghost entities' },
+    { tags = { [Gui.event_tag] = on_destroy_speakers }, caption = 'Destroy speakers' },
+    { tags = { [Gui.event_tag] = on_remove_biters }, caption = 'Remove biters' },
+    { tags = { [Gui.event_tag] = on_remove_enemies }, caption = 'Remove all enemies' },
+    -- { tags = { [Gui.event_tag] = on_teleport }, caption = 'Teleport' },
+    -- { tags = { [Gui.event_tag] = on_destroy_selected }, caption = 'Destroy selected' }
   }) do make_button(table_1, button) end
 
   local row_2 = canvas.add { type = 'frame', style = 'bordered_frame', direction = 'vertical', caption = 'Players management' }
   local table_2 = row_2.add { type = 'table', column_count = 3 }
   for _, button in pairs({
-    { tags = { [Gui.tag] = on_add_regular }, caption = 'Add regular' },
-    { tags = { [Gui.tag] = on_add_probation }, caption = 'Add probation' },
-    { tags = { [Gui.tag] = on_jail_player }, caption = 'Jail player' },
-    { tags = { [Gui.tag] = on_remove_regular }, caption = 'Remove regular' },
-    { tags = { [Gui.tag] = on_remove_probation }, caption = 'Remove probation' },
-    { tags = { [Gui.tag] = on_unjail_player }, caption = 'Unjail player' },
-    { tags = { [Gui.tag] = on_invoke_player }, caption = 'Invoke player' },
-    { tags = { [Gui.tag] = on_goto_player }, caption = 'Goto player' },
-    { tags = { [Gui.tag] = on_spank_player }, caption = 'Spank player' },
+    { tags = { [Gui.event_tag] = on_add_regular }, caption = 'Add regular' },
+    { tags = { [Gui.event_tag] = on_add_probation }, caption = 'Add probation' },
+    { tags = { [Gui.event_tag] = on_jail_player }, caption = 'Jail player' },
+    { tags = { [Gui.event_tag] = on_remove_regular }, caption = 'Remove regular' },
+    { tags = { [Gui.event_tag] = on_remove_probation }, caption = 'Remove probation' },
+    { tags = { [Gui.event_tag] = on_unjail_player }, caption = 'Unjail player' },
+    { tags = { [Gui.event_tag] = on_invoke_player }, caption = 'Invoke player' },
+    { tags = { [Gui.event_tag] = on_goto_player }, caption = 'Goto player' },
+    { tags = { [Gui.event_tag] = on_spank_player }, caption = 'Spank player' },
   }) do make_button(table_2, button) end
   make_player_dropdown(row_2)
 
@@ -190,7 +190,7 @@ local function draw_gui(player)
   for _, item in pairs(ban_items) do
     make_checkbox(table_3, {
       caption = item.caption,
-      tags = { [Gui.tag] = item.tag },
+      tags = { [Gui.event_tag] = item.tag },
       state = Table.contains(this.player_ban_items[player.index], item.caption),
     })
   end
@@ -202,7 +202,7 @@ local function draw_gui(player)
 
   local flow_3 = row_3.add { type = 'flow', direction = 'horizontal' }
   Gui.add_pusher(flow_3)
-  local ban_button = flow_3.add { type = 'button', tags = { [Gui.tag] = on_ban_player }, style = 'confirm_button', caption = 'Ban player' }
+  local ban_button = flow_3.add { type = 'button', tags = { [Gui.event_tag] = on_ban_player }, style = 'confirm_button', caption = 'Ban player' }
   Gui.set_data(ban_button, { textbox = textbox })
 end
 

--- a/features/gui/admin_panel/player_manager.lua
+++ b/features/gui/admin_panel/player_manager.lua
@@ -49,8 +49,8 @@ pages[#pages +1] = {
   type = 'sprite-button',
   sprite = 'entity/character',
   tooltip = '[font=default-bold]Player manager[/font]',
-  name = main_button_name,
   auto_toggle = true,
+  tags = { [Gui.tag] = main_button_name },
 }
 
 local ban_items = {}
@@ -63,7 +63,7 @@ for _, text in pairs({
   'resource hoarding',
   'tanking server UPS',
   'toxic behavior',
-}) do table.insert(ban_items, { name = Gui.uid_name(), caption = text }) end
+}) do table.insert(ban_items, { tags = { [Gui.tag] = Gui.uid_name() }, caption = text }) end
 
 local function get_selected_player(player)
   return this.player_selection[player.index].name or '__NIL__'
@@ -99,7 +99,7 @@ local function make_button(parent, params)
   local button = parent.add {
     type = 'button',
     caption = params.caption,
-    name = params.name,
+    tags = params.tags,
     tooltip = params.tooltip,
   }
   Gui.set_style(button, {
@@ -112,7 +112,7 @@ local function make_checkbox(parent, params)
   local checkbox = parent.add {
     type = 'checkbox',
     caption = params.caption,
-    name = params.name,
+    tags = params.tags,
     tooltip = params.tooltip,
     state = params.state or false,
   }
@@ -135,10 +135,10 @@ local function make_player_dropdown(parent)
   Gui.set_style(selection_flow, { vertical_align = 'center' })
 
   selection_flow.add { type = 'label', caption = '[font=default-small][color=255,230,192]ONLINE[/color][/font]' }
-  selection_flow.add { type = 'switch', name = selection_switch_name, switch_state = this.selection_switch[player_index], allow_none_state = true }
+  selection_flow.add { type = 'switch', switch_state = this.selection_switch[player_index], allow_none_state = true, tags = { [Gui.tag] = selection_switch_name } }
   selection_flow.add { type = 'label', caption = '[font=default-small][color=255,230,192]OFFLINE[/color][/font]' }
 
-  local dropdown = selection_flow.add { type = 'drop-down', name = selection_dropdown_name, selected_index = selection_data.index, items = player_list }
+  local dropdown = selection_flow.add { type = 'drop-down', selected_index = selection_data.index, items = player_list, tags = { [Gui.tag] = selection_dropdown_name } }
   Gui.set_style(dropdown, { horizontally_stretchable = true })
   return selection_flow
 end
@@ -154,34 +154,34 @@ local function draw_gui(player)
   local row_1 = canvas.add { type = 'frame', style = 'bordered_frame', direction = 'vertical', caption = 'General actions' }
   local table_1 = row_1.add { type = 'table', column_count = 3 }
   for _, button in pairs({
-    { name = on_cheat_mode, caption = 'Cheat mode' },
-    { name = on_show_reports, caption = 'Show reports' },
-    { name = on_toggle_blueprints, caption = 'Blueprints ON/OFF' },
-    { name = on_create_pool, caption = 'Create pool' },
-    { name = on_create_oil_field, caption = 'Create oil field' },
-    { name = on_create_pollution, caption = 'Spawn pollution' },
-    { name = on_revive_ghosts, caption = 'Revive ghosts' },
-    { name = on_save_game, caption = 'Save game' },
-    { name = on_delete_blueprints, caption = 'Destroy ghost entities' },
-    { name = on_destroy_speakers, caption = 'Destroy speakers' },
-    { name = on_remove_biters, caption = 'Remove biters' },
-    { name = on_remove_enemies, caption = 'Remove all enemies' },
-    -- { name = on_teleport, caption = 'Teleport' },
-    -- { name = on_destroy_selected, caption = 'Destroy selected' }
+    { tags = { [Gui.tag] = on_cheat_mode }, caption = 'Cheat mode' },
+    { tags = { [Gui.tag] = on_show_reports }, caption = 'Show reports' },
+    { tags = { [Gui.tag] = on_toggle_blueprints }, caption = 'Blueprints ON/OFF' },
+    { tags = { [Gui.tag] = on_create_pool }, caption = 'Create pool' },
+    { tags = { [Gui.tag] = on_create_oil_field }, caption = 'Create oil field' },
+    { tags = { [Gui.tag] = on_create_pollution }, caption = 'Spawn pollution' },
+    { tags = { [Gui.tag] = on_revive_ghosts }, caption = 'Revive ghosts' },
+    { tags = { [Gui.tag] = on_save_game }, caption = 'Save game' },
+    { tags = { [Gui.tag] = on_delete_blueprints }, caption = 'Destroy ghost entities' },
+    { tags = { [Gui.tag] = on_destroy_speakers }, caption = 'Destroy speakers' },
+    { tags = { [Gui.tag] = on_remove_biters }, caption = 'Remove biters' },
+    { tags = { [Gui.tag] = on_remove_enemies }, caption = 'Remove all enemies' },
+    -- { tags = { [Gui.tag] = on_teleport }, caption = 'Teleport' },
+    -- { tags = { [Gui.tag] = on_destroy_selected }, caption = 'Destroy selected' }
   }) do make_button(table_1, button) end
 
   local row_2 = canvas.add { type = 'frame', style = 'bordered_frame', direction = 'vertical', caption = 'Players management' }
   local table_2 = row_2.add { type = 'table', column_count = 3 }
   for _, button in pairs({
-    { name = on_add_regular, caption = 'Add regular' },
-    { name = on_add_probation, caption = 'Add probation' },
-    { name = on_jail_player, caption = 'Jail player' },
-    { name = on_remove_regular, caption = 'Remove regular' },
-    { name = on_remove_probation, caption = 'Remove probation' },
-    { name = on_unjail_player, caption = 'Unjail player' },
-    { name = on_invoke_player, caption = 'Invoke player' },
-    { name = on_goto_player, caption = 'Goto player' },
-    { name = on_spank_player, caption = 'Spank player' },
+    { tags = { [Gui.tag] = on_add_regular }, caption = 'Add regular' },
+    { tags = { [Gui.tag] = on_add_probation }, caption = 'Add probation' },
+    { tags = { [Gui.tag] = on_jail_player }, caption = 'Jail player' },
+    { tags = { [Gui.tag] = on_remove_regular }, caption = 'Remove regular' },
+    { tags = { [Gui.tag] = on_remove_probation }, caption = 'Remove probation' },
+    { tags = { [Gui.tag] = on_unjail_player }, caption = 'Unjail player' },
+    { tags = { [Gui.tag] = on_invoke_player }, caption = 'Invoke player' },
+    { tags = { [Gui.tag] = on_goto_player }, caption = 'Goto player' },
+    { tags = { [Gui.tag] = on_spank_player }, caption = 'Spank player' },
   }) do make_button(table_2, button) end
   make_player_dropdown(row_2)
 
@@ -190,7 +190,7 @@ local function draw_gui(player)
   for _, item in pairs(ban_items) do
     make_checkbox(table_3, {
       caption = item.caption,
-      name = item.name,
+      tags = item.tags,
       state = Table.contains(this.player_ban_items[player.index], item.caption),
     })
   end
@@ -202,7 +202,7 @@ local function draw_gui(player)
 
   local flow_3 = row_3.add { type = 'flow', direction = 'horizontal' }
   Gui.add_pusher(flow_3)
-  local ban_button = flow_3.add { type = 'button', name = on_ban_player, style = 'confirm_button', caption = 'Ban player' }
+  local ban_button = flow_3.add { type = 'button', tags = { [Gui.tag] = on_ban_player }, style = 'confirm_button', caption = 'Ban player' }
   Gui.set_data(ban_button, { textbox = textbox })
 end
 

--- a/features/gui/admin_panel/player_manager.lua
+++ b/features/gui/admin_panel/player_manager.lua
@@ -63,7 +63,7 @@ for _, text in pairs({
   'resource hoarding',
   'tanking server UPS',
   'toxic behavior',
-}) do table.insert(ban_items, { tags = { [Gui.tag] = Gui.uid_name() }, caption = text }) end
+}) do table.insert(ban_items, { tag = Gui.uid_name(), caption = text }) end
 
 local function get_selected_player(player)
   return this.player_selection[player.index].name or '__NIL__'
@@ -190,7 +190,7 @@ local function draw_gui(player)
   for _, item in pairs(ban_items) do
     make_checkbox(table_3, {
       caption = item.caption,
-      tags = item.tags,
+      tags = { [Gui.tag] = item.tag },
       state = Table.contains(this.player_ban_items[player.index], item.caption),
     })
   end
@@ -233,7 +233,7 @@ Gui.on_selection_state_changed(selection_dropdown_name, function(event)
 end)
 
 for _, ban_item in pairs(ban_items) do
-  Gui.on_checked_state_changed(ban_item.name, function(event)
+  Gui.on_checked_state_changed(ban_item.tag, function(event)
     local player = event.player
     local element = event.element
     if element.state then

--- a/features/gui/autofill.lua
+++ b/features/gui/autofill.lua
@@ -28,6 +28,7 @@ local function player_created(event)
         sprite = 'item/piercing-rounds-magazine',
         tooltip = {'autofill.main_button_tooltip'},
         auto_toggle = true,
+        tags = { [Gui.tag] = main_button_name },
     })
 end
 
@@ -55,9 +56,9 @@ local function toggle_main_frame(event)
         local enabled_checkbox =
             frame.add {
             type = 'checkbox',
-            name = enabled_checkbox_name,
             caption = {'autofill.enable'},
-            state = Autofill.get_enabled(player_index)
+            state = Autofill.get_enabled(player_index),
+            tags = { [Gui.tag] = enabled_checkbox_name },
         }
 
         local ammo_count_flow = frame.add {type = 'flow', direction = 'horizontal'}
@@ -65,8 +66,8 @@ local function toggle_main_frame(event)
         local ammo_count_textfield =
             ammo_count_flow.add {
             type = 'textfield',
-            name = ammo_count_name,
-            text = tostring(Autofill.get_ammo_count(player_index))
+            text = tostring(Autofill.get_ammo_count(player_index)),
+            tags = { [Gui.tag] = ammo_count_name },
         }
 
         local enabled_ammos_flow = frame.add {type = 'flow', direction = 'horizontal'}
@@ -74,11 +75,11 @@ local function toggle_main_frame(event)
 
         for name, enabled in pairs(Autofill.get_player_ammos(player_index)) do
             local button =
-                enabled_ammos_flow.add({type = 'flow'}).add(
+                enabled_ammos_flow.add(
                 {
                     type = 'sprite-button',
-                    name = enabled_ammo_button,
-                    sprite = 'item/' .. name
+                    sprite = 'item/' .. name,
+                    tags = { [Gui.tag] = enabled_ammo_button },
                 }
             )
             update_ammo_button(button, name, enabled)

--- a/features/gui/autofill.lua
+++ b/features/gui/autofill.lua
@@ -28,7 +28,7 @@ local function player_created(event)
         sprite = 'item/piercing-rounds-magazine',
         tooltip = {'autofill.main_button_tooltip'},
         auto_toggle = true,
-        tags = { [Gui.tag] = main_button_name },
+        tags = { [Gui.event_tag] = main_button_name },
     })
 end
 
@@ -58,7 +58,7 @@ local function toggle_main_frame(event)
             type = 'checkbox',
             caption = {'autofill.enable'},
             state = Autofill.get_enabled(player_index),
-            tags = { [Gui.tag] = enabled_checkbox_name },
+            tags = { [Gui.event_tag] = enabled_checkbox_name },
         }
 
         local ammo_count_flow = frame.add {type = 'flow', direction = 'horizontal'}
@@ -67,7 +67,7 @@ local function toggle_main_frame(event)
             ammo_count_flow.add {
             type = 'textfield',
             text = tostring(Autofill.get_ammo_count(player_index)),
-            tags = { [Gui.tag] = ammo_count_name },
+            tags = { [Gui.event_tag] = ammo_count_name },
         }
 
         local enabled_ammos_flow = frame.add {type = 'flow', direction = 'horizontal'}
@@ -79,7 +79,7 @@ local function toggle_main_frame(event)
                 {
                     type = 'sprite-button',
                     sprite = 'item/' .. name,
-                    tags = { [Gui.tag] = enabled_ammo_button },
+                    tags = { [Gui.event_tag] = enabled_ammo_button },
                 }
             )
             update_ammo_button(button, name, enabled)

--- a/features/gui/calculator/technology.lua
+++ b/features/gui/calculator/technology.lua
@@ -173,7 +173,7 @@ local function get_main_frame(player)
         name = main_frame_name,
         direction = 'vertical',
         style = 'frame',
-        tags = { [Gui.tag] = main_frame_name },
+        tags = { [Gui.event_tag] = main_frame_name },
     }
     Gui.set_style(frame, {
         horizontally_stretchable = true,
@@ -212,7 +212,7 @@ local function shortcut_button(parent, info)
             type = 'sprite-button',
             style = 'transparent_slot',
             sprite = 'technology/' .. info.name,
-            tags = { [Gui.tag] = shortcut_button_name, name = info.name },
+            tags = { [Gui.event_tag] = shortcut_button_name, name = info.name },
             tooltip = {'', '[color=0.5,0.8,0.94][font=var]Click[/font][/color] to go to this technology\'s breakdown'}
         }
     Gui.set_style(b, { size = 32 })
@@ -256,7 +256,7 @@ local function draw(player)
             clicked_sprite = 'utility/backward_arrow_black',
             style = 'close_button',
             tooltip = 'Back',
-            tags = { [Gui.tag] = history_back_button_name },
+            tags = { [Gui.event_tag] = history_back_button_name },
         }
         backward.enabled = h:peek_previous() ~= nil
 
@@ -266,7 +266,7 @@ local function draw(player)
             clicked_sprite = 'utility/forward_arrow_black',
             style = 'close_button',
             tooltip = 'Forward',
-            tags = { [Gui.tag] = history_forward_button_name },
+            tags = { [Gui.event_tag] = history_forward_button_name },
         }
         forward.enabled = h:peek_next() ~= nil
 
@@ -276,7 +276,7 @@ local function draw(player)
             clicked_sprite = 'utility/close_black',
             style = 'close_button',
             tooltip = { 'gui.close-instruction' },
-            tags = { [Gui.tag] = close_button_name },
+            tags = { [Gui.event_tag] = close_button_name },
         }
         Gui.set_data(close_button, { frame = frame })
     end
@@ -296,7 +296,7 @@ local function draw(player)
                 style = 'slot_button_in_shallow_frame',
                 elem_type = 'technology',
                 technology = technology_name,
-                tags = { [Gui.tag] = select_button_name },
+                tags = { [Gui.event_tag] = select_button_name },
             }
             data.select_button = select_button
             Gui.set_data(select_button, data)
@@ -347,7 +347,7 @@ local function draw(player)
                 style = 'bold_label',
                 caption = toggled[player.index] and on_technologies or off_technologies,
                 tooltip = 'Hide/Show technologies list',
-                tags = { [Gui.tag] = toggle_list_button_name},
+                tags = { [Gui.event_tag] = toggle_list_button_name},
             }
             data.label = label
             Gui.set_data(label, data)

--- a/features/gui/calculator/technology.lua
+++ b/features/gui/calculator/technology.lua
@@ -173,6 +173,7 @@ local function get_main_frame(player)
         name = main_frame_name,
         direction = 'vertical',
         style = 'frame',
+        tags = { [Gui.tag] = main_frame_name },
     }
     Gui.set_style(frame, {
         horizontally_stretchable = true,
@@ -251,31 +252,31 @@ local function draw(player)
 
         local backward = history_flow.add {
             type = 'sprite-button',
-            name = history_back_button_name,
             sprite = 'utility/backward_arrow',
             clicked_sprite = 'utility/backward_arrow_black',
             style = 'close_button',
             tooltip = 'Back',
+            tags = { [Gui.tag] = history_back_button_name },
         }
         backward.enabled = h:peek_previous() ~= nil
 
         local forward = history_flow.add {
             type = 'sprite-button',
-            name = history_forward_button_name,
             sprite = 'utility/forward_arrow',
             clicked_sprite = 'utility/forward_arrow_black',
             style = 'close_button',
             tooltip = 'Forward',
+            tags = { [Gui.tag] = history_forward_button_name },
         }
         forward.enabled = h:peek_next() ~= nil
 
         local close_button = flow.add {
             type = 'sprite-button',
-            name = close_button_name,
             sprite = 'utility/close',
             clicked_sprite = 'utility/close_black',
             style = 'close_button',
             tooltip = { 'gui.close-instruction' },
+            tags = { [Gui.tag] = close_button_name },
         }
         Gui.set_data(close_button, { frame = frame })
     end
@@ -292,10 +293,10 @@ local function draw(player)
 
             local select_button = flow.add {
                 type = 'choose-elem-button',
-                name = select_button_name,
                 style = 'slot_button_in_shallow_frame',
                 elem_type = 'technology',
                 technology = technology_name,
+                tags = { [Gui.tag] = select_button_name },
             }
             data.select_button = select_button
             Gui.set_data(select_button, data)
@@ -345,8 +346,8 @@ local function draw(player)
                 type = 'label',
                 style = 'bold_label',
                 caption = toggled[player.index] and on_technologies or off_technologies,
-                name = toggle_list_button_name,
                 tooltip = 'Hide/Show technologies list',
+                tags = { [Gui.tag] = toggle_list_button_name},
             }
             data.label = label
             Gui.set_data(label, data)

--- a/features/gui/debug/_g_view.lua
+++ b/features/gui/debug/_g_view.lua
@@ -57,27 +57,25 @@ local ignore = {
 }
 
 local header_name = Gui.uid_name()
-local left_panel_name = Gui.uid_name()
-local right_panel_name = Gui.uid_name()
 
 Public.name = '_G'
 
 function Public.show(container)
     local main_flow = container.add {type = 'flow', direction = 'horizontal'}
 
-    local left_panel = main_flow.add {type = 'scroll-pane', name = left_panel_name}
+    local left_panel = main_flow.add {type = 'scroll-pane'}
     local left_panel_style = left_panel.style
     left_panel_style.width = 300
 
     for key, value in pairs(_G) do
         if not ignore[key] then
             local header =
-                left_panel.add({type = 'flow'}).add {type = 'label', name = header_name, caption = tostring(key)}
+                left_panel.add({type = 'flow'}).add {type = 'label', caption = tostring(key), tags = { [Gui.tag] = header_name }}
             Gui.set_data(header, value)
         end
     end
 
-    local right_panel = main_flow.add {type = 'text-box', name = right_panel_name}
+    local right_panel = main_flow.add {type = 'text-box'}
     right_panel.read_only = true
     right_panel.selectable = true
 

--- a/features/gui/debug/_g_view.lua
+++ b/features/gui/debug/_g_view.lua
@@ -70,7 +70,7 @@ function Public.show(container)
     for key, value in pairs(_G) do
         if not ignore[key] then
             local header =
-                left_panel.add({type = 'flow'}).add {type = 'label', caption = tostring(key), tags = { [Gui.tag] = header_name }}
+                left_panel.add({type = 'flow'}).add {type = 'label', caption = tostring(key), tags = { [Gui.event_tag] = header_name }}
             Gui.set_data(header, value)
         end
     end

--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -101,7 +101,7 @@ local function redraw_event_table(gui_table, filter)
                 type = 'checkbox',
                 state = enabled[index] or false,
                 caption = event_name,
-                tags = { [Gui.tag] = checkbox_name },
+                tags = { [Gui.event_tag] = checkbox_name },
             }
         end
     end
@@ -114,8 +114,8 @@ function Public.show(container)
 
     local filter_flow = main_frame_flow.add({type = 'flow', direction = 'horizontal'})
     filter_flow.add({type = 'label', caption = 'filter'})
-    local filter_textfield = filter_flow.add({type = 'textfield', text = filter, tags = { [Gui.tag] = filter_name }})
-    local clear_button = filter_flow.add({type = 'button', caption = 'clear', tags = { [Gui.tag] = clear_filter_name }})
+    local filter_textfield = filter_flow.add({type = 'textfield', text = filter, tags = { [Gui.event_tag] = filter_name }})
+    local clear_button = filter_flow.add({type = 'button', caption = 'clear', tags = { [Gui.event_tag] = clear_filter_name }})
 
     local scroll_pane = main_frame_flow.add({type = 'scroll-pane'})
     local gui_table = scroll_pane.add({type = 'table', column_count = 3, draw_horizontal_lines = true})

--- a/features/gui/debug/event_view.lua
+++ b/features/gui/debug/event_view.lua
@@ -97,11 +97,11 @@ local function redraw_event_table(gui_table, filter)
     for _, event_name in pairs(grid_builder) do
         if filter == '' or event_name:find(filter) then
             local index = events[event_name]
-            gui_table.add({type = 'flow'}).add {
-                name = checkbox_name,
+            gui_table.add {
                 type = 'checkbox',
                 state = enabled[index] or false,
-                caption = event_name
+                caption = event_name,
+                tags = { [Gui.tag] = checkbox_name },
             }
         end
     end
@@ -114,8 +114,8 @@ function Public.show(container)
 
     local filter_flow = main_frame_flow.add({type = 'flow', direction = 'horizontal'})
     filter_flow.add({type = 'label', caption = 'filter'})
-    local filter_textfield = filter_flow.add({type = 'textfield', name = filter_name, text = filter})
-    local clear_button = filter_flow.add({type = 'button', name = clear_filter_name, caption = 'clear'})
+    local filter_textfield = filter_flow.add({type = 'textfield', text = filter, tags = { [Gui.tag] = filter_name }})
+    local clear_button = filter_flow.add({type = 'button', caption = 'clear', tags = { [Gui.tag] = clear_filter_name }})
 
     local scroll_pane = main_frame_flow.add({type = 'scroll-pane'})
     local gui_table = scroll_pane.add({type = 'table', column_count = 3, draw_horizontal_lines = true})

--- a/features/gui/debug/global_view.lua
+++ b/features/gui/debug/global_view.lua
@@ -26,7 +26,7 @@ function Public.show(container)
     for key, _ in pairs(storage) do
         if not ignore[key] then
             local header =
-                left_panel.add({type = 'flow'}).add {type = 'label', caption = tostring(key), tags = { [Gui.tag] = header_name }}
+                left_panel.add({type = 'flow'}).add {type = 'label', caption = tostring(key), tags = { [Gui.event_tag] = header_name }}
             Gui.set_data(header, key)
         end
     end
@@ -35,14 +35,14 @@ function Public.show(container)
 
     local right_top_flow = right_flow.add {type = 'flow', direction = 'horizontal'}
 
-    local input_text_box = right_top_flow.add {type = 'text-box', tags = { [Gui.tag] = input_text_box_name }}
+    local input_text_box = right_top_flow.add {type = 'text-box', tags = { [Gui.event_tag] = input_text_box_name }}
     local input_text_box_style = input_text_box.style
     input_text_box_style.horizontally_stretchable = true
     input_text_box_style.height = 32
     input_text_box_style.maximal_width = 1000
 
     local refresh_button =
-        right_top_flow.add {type = 'sprite-button', sprite = 'utility/reset', tooltip = 'refresh', tags = { [Gui.tag] = refresh_name }}
+        right_top_flow.add {type = 'sprite-button', sprite = 'utility/reset', tooltip = 'refresh', tags = { [Gui.event_tag] = refresh_name }}
     local refresh_button_style = refresh_button.style
     refresh_button_style.width = 32
     refresh_button_style.height = 32

--- a/features/gui/debug/global_view.lua
+++ b/features/gui/debug/global_view.lua
@@ -11,8 +11,6 @@ local Public = {}
 local ignore = {tokens = true}
 
 local header_name = Gui.uid_name()
-local left_panel_name = Gui.uid_name()
-local right_panel_name = Gui.uid_name()
 local input_text_box_name = Gui.uid_name()
 local refresh_name = Gui.uid_name()
 
@@ -21,14 +19,14 @@ Public.name = 'storage'
 function Public.show(container)
     local main_flow = container.add {type = 'flow', direction = 'horizontal'}
 
-    local left_panel = main_flow.add {type = 'scroll-pane', name = left_panel_name}
+    local left_panel = main_flow.add {type = 'scroll-pane'}
     local left_panel_style = left_panel.style
     left_panel_style.width = 300
 
     for key, _ in pairs(storage) do
         if not ignore[key] then
             local header =
-                left_panel.add({type = 'flow'}).add {type = 'label', name = header_name, caption = tostring(key)}
+                left_panel.add({type = 'flow'}).add {type = 'label', caption = tostring(key), tags = { [Gui.tag] = header_name }}
             Gui.set_data(header, key)
         end
     end
@@ -37,19 +35,19 @@ function Public.show(container)
 
     local right_top_flow = right_flow.add {type = 'flow', direction = 'horizontal'}
 
-    local input_text_box = right_top_flow.add {type = 'text-box', name = input_text_box_name}
+    local input_text_box = right_top_flow.add {type = 'text-box', tags = { [Gui.tag] = input_text_box_name }}
     local input_text_box_style = input_text_box.style
     input_text_box_style.horizontally_stretchable = true
     input_text_box_style.height = 32
     input_text_box_style.maximal_width = 1000
 
     local refresh_button =
-        right_top_flow.add {type = 'sprite-button', name = refresh_name, sprite = 'utility/reset', tooltip = 'refresh'}
+        right_top_flow.add {type = 'sprite-button', sprite = 'utility/reset', tooltip = 'refresh', tags = { [Gui.tag] = refresh_name }}
     local refresh_button_style = refresh_button.style
     refresh_button_style.width = 32
     refresh_button_style.height = 32
 
-    local right_panel = right_flow.add {type = 'text-box', name = right_panel_name}
+    local right_panel = right_flow.add {type = 'text-box'}
     right_panel.read_only = true
     right_panel.selectable = true
 

--- a/features/gui/debug/gui_data_view.lua
+++ b/features/gui/debug/gui_data_view.lua
@@ -10,11 +10,8 @@ local Public = {}
 
 local player_header_name = Gui.uid_name()
 local element_header_name = Gui.uid_name()
-local player_panel_name = Gui.uid_name()
-local element_panel_name = Gui.uid_name()
 local input_text_box_name = Gui.uid_name()
 local refresh_name = Gui.uid_name()
-local data_panel_name = Gui.uid_name()
 
 Public.name = 'Gui Data'
 
@@ -30,11 +27,10 @@ local function draw_player_headers(player_panel, selected_index)
             player_name = player.name
         end
 
-        local header =
-            player_panel.add({type = 'flow'}).add {
+        local header = player_panel.add {
             type = 'label',
-            name = player_header_name,
-            caption = concat({player_index, ' - ', player_name})
+            caption = concat({player_index, ' - ', player_name}),
+            tags = { [Gui.tag] = player_header_name },
         }
         Gui.set_data(header, {values = values, player_index = player_index})
 
@@ -49,7 +45,7 @@ end
 function Public.show(container)
     local main_flow = container.add {type = 'flow', direction = 'horizontal'}
 
-    local player_panel = main_flow.add {type = 'scroll-pane', name = player_panel_name}
+    local player_panel = main_flow.add {type = 'scroll-pane'}
     local player_panel_style = player_panel.style
     player_panel_style.width = 200
 
@@ -57,14 +53,14 @@ function Public.show(container)
 
     local right_flow = main_flow.add {type = 'flow', direction = 'vertical'}
 
-    local element_panel = right_flow.add {type = 'scroll-pane', name = element_panel_name}
+    local element_panel = right_flow.add {type = 'scroll-pane'}
     local element_panel_style = element_panel.style
     element_panel_style.horizontally_stretchable = true
     element_panel_style.height = 200
 
     local right_middle_flow = right_flow.add {type = 'flow', direction = 'horizontal'}
 
-    local input_text_box = right_middle_flow.add {type = 'text-box', name = input_text_box_name}
+    local input_text_box = right_middle_flow.add {type = 'text-box'}
     local input_text_box_style = input_text_box.style
     input_text_box_style.horizontally_stretchable = true
     input_text_box_style.height = 32
@@ -73,15 +69,15 @@ function Public.show(container)
     local refresh_button =
         right_middle_flow.add {
         type = 'sprite-button',
-        name = refresh_name,
         sprite = 'utility/reset',
-        tooltip = 'refresh'
+        tooltip = 'refresh',
+        tags = { [Gui.tag] = refresh_name },
     }
     local refresh_button_style = refresh_button.style
     refresh_button_style.width = 32
     refresh_button_style.height = 32
 
-    local data_panel = right_flow.add {type = 'text-box', name = data_panel_name}
+    local data_panel = right_flow.add {type = 'text-box'}
     data_panel.read_only = true
     data_panel.selectable = true
 
@@ -134,11 +130,10 @@ local function draw_element_headers(element_panel, values, selected_index)
             goto continue
         end
 
-        local middle_header =
-            element_panel.add({type = 'flow'}).add {
+        local middle_header = element_panel.add {
             type = 'label',
-            name = element_header_name,
-            caption = concat({ei, ' - ', ele_name})
+            caption = concat({ei, ' - ', ele_name}),
+            tags = { [Gui.tag] = element_header_name },
         }
 
         Gui.set_data(middle_header, {stored_data = stored_data, element_index = ei})

--- a/features/gui/debug/gui_data_view.lua
+++ b/features/gui/debug/gui_data_view.lua
@@ -30,7 +30,7 @@ local function draw_player_headers(player_panel, selected_index)
         local header = player_panel.add {
             type = 'label',
             caption = concat({player_index, ' - ', player_name}),
-            tags = { [Gui.tag] = player_header_name },
+            tags = { [Gui.event_tag] = player_header_name },
         }
         Gui.set_data(header, {values = values, player_index = player_index})
 
@@ -71,7 +71,7 @@ function Public.show(container)
         type = 'sprite-button',
         sprite = 'utility/reset',
         tooltip = 'refresh',
-        tags = { [Gui.tag] = refresh_name },
+        tags = { [Gui.event_tag] = refresh_name },
     }
     local refresh_button_style = refresh_button.style
     refresh_button_style.width = 32
@@ -133,7 +133,7 @@ local function draw_element_headers(element_panel, values, selected_index)
         local middle_header = element_panel.add {
             type = 'label',
             caption = concat({ei, ' - ', ele_name}),
-            tags = { [Gui.tag] = element_header_name },
+            tags = { [Gui.event_tag] = element_header_name },
         }
 
         Gui.set_data(middle_header, {stored_data = stored_data, element_index = ei})

--- a/features/gui/debug/main_view.lua
+++ b/features/gui/debug/main_view.lua
@@ -44,7 +44,7 @@ function Public.open_dubug(player)
 
     for i = 1, #pages do
         local page = pages[i]
-        local tab_button = tab_flow.add({type = 'flow'}).add {type = 'button', name = tab_name, caption = page.name}
+        local tab_button = tab_flow.add {type = 'button', name = tab_name, caption = page.name, tags = { [Gui.tag] = tab_name }}
         local tab_button_style = tab_button.style
 
         Gui.set_data(tab_button, {index = i, frame_data = data})
@@ -61,7 +61,7 @@ function Public.open_dubug(player)
         end
     end
 
-    frame.add {type = 'button', name = close_name, caption = 'Close'}
+    frame.add {type = 'button', caption = 'Close', tags = { [Gui.tag] = close_name }}
 end
 
 Gui.on_click(

--- a/features/gui/debug/main_view.lua
+++ b/features/gui/debug/main_view.lua
@@ -44,7 +44,7 @@ function Public.open_dubug(player)
 
     for i = 1, #pages do
         local page = pages[i]
-        local tab_button = tab_flow.add {type = 'button', name = tab_name, caption = page.name, tags = { [Gui.tag] = tab_name }}
+        local tab_button = tab_flow.add {type = 'button', name = tab_name, caption = page.name, tags = { [Gui.event_tag] = tab_name }}
         local tab_button_style = tab_button.style
 
         Gui.set_data(tab_button, {index = i, frame_data = data})
@@ -61,7 +61,7 @@ function Public.open_dubug(player)
         end
     end
 
-    frame.add {type = 'button', caption = 'Close', tags = { [Gui.tag] = close_name }}
+    frame.add {type = 'button', caption = 'Close', tags = { [Gui.event_tag] = close_name }}
 end
 
 Gui.on_click(

--- a/features/gui/debug/package_view.lua
+++ b/features/gui/debug/package_view.lua
@@ -22,40 +22,36 @@ local ignore = {
 }
 
 local file_label_name = Gui.uid_name()
-local left_panel_name = Gui.uid_name()
-local breadcrumbs_name = Gui.uid_name()
-local top_panel_name = Gui.uid_name()
 local variable_label_name = Gui.uid_name()
-local text_box_name = Gui.uid_name()
 
 Public.name = 'package'
 
 function Public.show(container)
     local main_flow = container.add {type = 'flow', direction = 'horizontal'}
 
-    local left_panel = main_flow.add {type = 'scroll-pane', name = left_panel_name}
+    local left_panel = main_flow.add {type = 'scroll-pane'}
     local left_panel_style = left_panel.style
     left_panel_style.width = 300
 
     for name, file in pairs(loaded) do
         if not ignore[name] then
             local file_label =
-                left_panel.add({type = 'flow'}).add {type = 'label', name = file_label_name, caption = name}
+                left_panel.add {type = 'label', caption = name, tags = { [Gui.tag] = file_label_name }}
             Gui.set_data(file_label, file)
         end
     end
 
     local right_flow = main_flow.add {type = 'flow', direction = 'vertical'}
 
-    local breadcrumbs = right_flow.add {type = 'label', name = breadcrumbs_name}
+    local breadcrumbs = right_flow.add {type = 'label'}
 
-    local top_panel = right_flow.add {type = 'scroll-pane', name = top_panel_name}
+    local top_panel = right_flow.add {type = 'scroll-pane'}
     local top_panel_style = top_panel.style
     top_panel_style.height = 200
     top_panel_style.maximal_width = 1000
     top_panel_style.horizontally_stretchable = true
 
-    local text_box = right_flow.add {type = 'text-box', name = text_box_name}
+    local text_box = right_flow.add {type = 'text-box'}
     text_box.read_only = true
     text_box.selectable = true
 
@@ -106,7 +102,7 @@ Gui.on_click(
         if file_type == 'table' then
             for k, v in pairs(file) do
                 local label =
-                    top_panel.add({type = 'flow'}).add {type = 'label', name = variable_label_name, caption = k}
+                    top_panel.add {type = 'label', caption = k, tags = { [Gui.tag] = variable_label_name }}
                 Gui.set_data(label, v)
             end
         else
@@ -131,7 +127,7 @@ Gui.on_click(
             Gui.clear(top_panel)
             for k, v in pairs(variable) do
                 local label =
-                    top_panel.add({type = 'flow'}).add {type = 'label', name = variable_label_name, caption = k}
+                    top_panel.add {type = 'label', caption = k, tags = { [Gui.tag] = variable_label_name }}
                 Gui.set_data(label, v)
             end
             return

--- a/features/gui/debug/package_view.lua
+++ b/features/gui/debug/package_view.lua
@@ -36,7 +36,7 @@ function Public.show(container)
     for name, file in pairs(loaded) do
         if not ignore[name] then
             local file_label =
-                left_panel.add {type = 'label', caption = name, tags = { [Gui.tag] = file_label_name }}
+                left_panel.add {type = 'label', caption = name, tags = { [Gui.event_tag] = file_label_name }}
             Gui.set_data(file_label, file)
         end
     end
@@ -102,7 +102,7 @@ Gui.on_click(
         if file_type == 'table' then
             for k, v in pairs(file) do
                 local label =
-                    top_panel.add {type = 'label', caption = k, tags = { [Gui.tag] = variable_label_name }}
+                    top_panel.add {type = 'label', caption = k, tags = { [Gui.event_tag] = variable_label_name }}
                 Gui.set_data(label, v)
             end
         else
@@ -127,7 +127,7 @@ Gui.on_click(
             Gui.clear(top_panel)
             for k, v in pairs(variable) do
                 local label =
-                    top_panel.add {type = 'label', caption = k, tags = { [Gui.tag] = variable_label_name }}
+                    top_panel.add {type = 'label', caption = k, tags = { [Gui.event_tag] = variable_label_name }}
                 Gui.set_data(label, v)
             end
             return

--- a/features/gui/debug/redmew_global_view.lua
+++ b/features/gui/debug/redmew_global_view.lua
@@ -11,8 +11,6 @@ local concat = table.concat
 local Public = {}
 
 local header_name = Gui.uid_name()
-local left_panel_name = Gui.uid_name()
-local right_panel_name = Gui.uid_name()
 local input_text_box_name = Gui.uid_name()
 local refresh_name = Gui.uid_name()
 
@@ -21,12 +19,12 @@ Public.name = 'Global'
 function Public.show(container)
     local main_flow = container.add {type = 'flow', direction = 'horizontal'}
 
-    local left_panel = main_flow.add {type = 'scroll-pane', name = left_panel_name}
+    local left_panel = main_flow.add {type = 'scroll-pane'}
     local left_panel_style = left_panel.style
     left_panel_style.width = 300
 
     for token_id, token_name in pairs(Global.names) do
-        local header = left_panel.add({type = 'flow'}).add {type = 'label', name = header_name, caption = token_name}
+        local header = left_panel.add({type = 'flow'}).add {type = 'label', caption = token_name, tags = { [Gui.tag] = header_name }}
         Gui.set_data(header, token_id)
     end
 
@@ -34,19 +32,19 @@ function Public.show(container)
 
     local right_top_flow = right_flow.add {type = 'flow', direction = 'horizontal'}
 
-    local input_text_box = right_top_flow.add {type = 'text-box', name = input_text_box_name}
+    local input_text_box = right_top_flow.add {type = 'text-box', tags = { [Gui.tag] = input_text_box_name }}
     local input_text_box_style = input_text_box.style
     input_text_box_style.horizontally_stretchable = true
     input_text_box_style.height = 32
     input_text_box_style.maximal_width = 1000
 
     local refresh_button =
-        right_top_flow.add {type = 'sprite-button', name = refresh_name, sprite = 'utility/reset', tooltip = 'refresh'}
+        right_top_flow.add {type = 'sprite-button', sprite = 'utility/reset', tooltip = 'refresh', tags = { [Gui.tag] = refresh_name }}
     local refresh_button_style = refresh_button.style
     refresh_button_style.width = 32
     refresh_button_style.height = 32
 
-    local right_panel = right_flow.add {type = 'text-box', name = right_panel_name}
+    local right_panel = right_flow.add {type = 'text-box'}
     right_panel.read_only = true
     right_panel.selectable = true
 

--- a/features/gui/debug/redmew_global_view.lua
+++ b/features/gui/debug/redmew_global_view.lua
@@ -24,7 +24,7 @@ function Public.show(container)
     left_panel_style.width = 300
 
     for token_id, token_name in pairs(Global.names) do
-        local header = left_panel.add({type = 'flow'}).add {type = 'label', caption = token_name, tags = { [Gui.tag] = header_name }}
+        local header = left_panel.add({type = 'flow'}).add {type = 'label', caption = token_name, tags = { [Gui.event_tag] = header_name }}
         Gui.set_data(header, token_id)
     end
 
@@ -32,14 +32,14 @@ function Public.show(container)
 
     local right_top_flow = right_flow.add {type = 'flow', direction = 'horizontal'}
 
-    local input_text_box = right_top_flow.add {type = 'text-box', tags = { [Gui.tag] = input_text_box_name }}
+    local input_text_box = right_top_flow.add {type = 'text-box', tags = { [Gui.event_tag] = input_text_box_name }}
     local input_text_box_style = input_text_box.style
     input_text_box_style.horizontally_stretchable = true
     input_text_box_style.height = 32
     input_text_box_style.maximal_width = 1000
 
     local refresh_button =
-        right_top_flow.add {type = 'sprite-button', sprite = 'utility/reset', tooltip = 'refresh', tags = { [Gui.tag] = refresh_name }}
+        right_top_flow.add {type = 'sprite-button', sprite = 'utility/reset', tooltip = 'refresh', tags = { [Gui.event_tag] = refresh_name }}
     local refresh_button_style = refresh_button.style
     refresh_button_style.width = 32
     refresh_button_style.height = 32

--- a/features/gui/description_generator.lua
+++ b/features/gui/description_generator.lua
@@ -137,7 +137,7 @@ local function draw_gui(event)
         return
     end
 
-    frame = center.add {type = 'frame', name = main_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = main_frame_name } }
+    frame = center.add {type = 'frame', name = main_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.event_tag] = main_frame_name } }
 
     local main_table = frame.add {type = 'table', column_count = 1}
 
@@ -164,7 +164,7 @@ local function draw_gui(event)
         type = 'radiobutton',
         caption = 'Vanilla',
         state = false,
-        tags = { [Gui.tag] = template_radio },
+        tags = { [Gui.event_tag] = template_radio },
     }
 
     Gui.set_data(radio, frame)
@@ -174,7 +174,7 @@ local function draw_gui(event)
         type = 'radiobutton',
         caption = 'Modded',
         state = false,
-        tags = { [Gui.tag] = template_radio },
+        tags = { [Gui.event_tag] = template_radio },
     }
 
     Gui.set_data(radio, frame)
@@ -194,7 +194,7 @@ local function draw_gui(event)
     left_flow.style.horizontal_align = 'left'
     left_flow.style.horizontally_stretchable = true
 
-    local generate_tag_button = left_flow.add {type = 'button', caption = 'Generate Tags', tags = { [Gui.tag] = generate_tags }}
+    local generate_tag_button = left_flow.add {type = 'button', caption = 'Generate Tags', tags = { [Gui.event_tag] = generate_tags }}
     Gui.set_data(generate_tag_button, frame)
 
     main_table.add {type = 'label', caption = 'Generated Server Tags (Reopen this gui to reset to the template)'}

--- a/features/gui/description_generator.lua
+++ b/features/gui/description_generator.lua
@@ -5,10 +5,10 @@ local Scenario_Info = require 'features.gui.info'
 
 local creators = storage.config.map_info
 
-local gui_frame = Gui.uid_name()
+local main_frame_name = Gui.uid_name()
 local generate_tags = Gui.uid_name()
 local template_radio = Gui.uid_name()
-local close_gui = Gui.uid_name()
+local close_button_name = Gui.uid_name()
 
 local function split(string, delimiter)
     if delimiter == nil then
@@ -130,14 +130,14 @@ local function draw_gui(event)
     local player = event.player
     local center = player.gui.center
 
-    local frame = center[gui_frame]
+    local frame = center[main_frame_name]
     if frame then
         Gui.remove_data_recursively(frame)
         frame.destroy()
         return
     end
 
-    frame = center.add {type = 'frame', name = gui_frame, caption = frame_caption, direction = 'vertical'}
+    frame = center.add {type = 'frame', name = main_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = main_frame_name } }
 
     local main_table = frame.add {type = 'table', column_count = 1}
 
@@ -160,21 +160,21 @@ local function draw_gui(event)
     local selection_flow = main_table.add {type = 'flow', direction = 'horizontal'}
 
     local radio =
-        selection_flow.add({type = 'flow'}).add {
+        selection_flow.add {
         type = 'radiobutton',
-        name = template_radio,
         caption = 'Vanilla',
-        state = false
+        state = false,
+        tags = { [Gui.tag] = template_radio },
     }
 
     Gui.set_data(radio, frame)
 
     radio =
-        selection_flow.add({type = 'flow'}).add {
+        selection_flow.add {
         type = 'radiobutton',
-        name = template_radio,
         caption = 'Modded',
-        state = false
+        state = false,
+        tags = { [Gui.tag] = template_radio },
     }
 
     Gui.set_data(radio, frame)
@@ -194,7 +194,7 @@ local function draw_gui(event)
     left_flow.style.horizontal_align = 'left'
     left_flow.style.horizontally_stretchable = true
 
-    local generate_tag_button = left_flow.add {type = 'button', name = generate_tags, caption = 'Generate Tags'}
+    local generate_tag_button = left_flow.add {type = 'button', caption = 'Generate Tags', tags = { [Gui.tag] = generate_tags }}
     Gui.set_data(generate_tag_button, frame)
 
     main_table.add {type = 'label', caption = 'Generated Server Tags (Reopen this gui to reset to the template)'}
@@ -213,7 +213,7 @@ local function draw_gui(event)
     left_flow.style.horizontal_align = 'left'
     left_flow.style.horizontally_stretchable = true
 
-    local close_button = Gui.make_close_button(left_flow, close_gui)
+    local close_button = Gui.make_close_button(left_flow, close_button_name)
     Gui.set_data(close_button, frame)
 
     local data = {
@@ -260,7 +260,7 @@ Gui.on_click(
 )
 
 Gui.on_click(
-    close_gui,
+    close_button_name,
     function(event)
         local frame = Gui.get_data(event.element)
 
@@ -270,7 +270,7 @@ Gui.on_click(
 )
 
 Gui.on_custom_close(
-    gui_frame,
+    main_frame_name,
     function(event)
         local element = event.element
         Gui.remove_data_recursively(element)

--- a/features/gui/evolution_progress.lua
+++ b/features/gui/evolution_progress.lua
@@ -130,7 +130,7 @@ local function on_nth_tick()
             10,
             function(container)
                 container.add({type = 'sprite', sprite = sprite})
-                local text = container.add({type = 'label', caption = caption, tags = { [Gui.tag] = Toast.close_toast_name }})
+                local text = container.add({type = 'label', caption = caption, tags = { [Gui.event_tag] = Toast.close_toast_name }})
                 local text_style = text.style
                 text_style.single_line = false
                 text_style.vertical_align = 'center'

--- a/features/gui/evolution_progress.lua
+++ b/features/gui/evolution_progress.lua
@@ -130,7 +130,7 @@ local function on_nth_tick()
             10,
             function(container)
                 container.add({type = 'sprite', sprite = sprite})
-                local text = container.add({type = 'label', caption = caption, name = Toast.close_toast_name})
+                local text = container.add({type = 'label', caption = caption, tags = { [Gui.tag] = Toast.close_toast_name }})
                 local text_style = text.style
                 text_style.single_line = false
                 text_style.vertical_align = 'center'

--- a/features/gui/experience.lua
+++ b/features/gui/experience.lua
@@ -267,7 +267,7 @@ Public.get_main_frame = function(player)
     end
 
     local data = {}
-    frame = Gui.add_left_element(player, { name = main_frame_name, type = 'frame', direction = 'vertical', tags = { [Gui.tag] = main_frame_name } })
+    frame = Gui.add_left_element(player, { name = main_frame_name, type = 'frame', direction = 'vertical', tags = { [Gui.event_tag] = main_frame_name } })
     Gui.set_style(frame, { maximal_width = 360 })
 
     local canvas = frame
@@ -295,7 +295,7 @@ Public.get_main_frame = function(player)
     end
     do -- Bonuses
         local toggled = gui_toggled[player.index].bonuses
-        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_bonuses or off_bonuses, tooltip = 'Hide/Show bonuses', tags = { [Gui.tag] = bonuses_button_name } }
+        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_bonuses or off_bonuses, tooltip = 'Hide/Show bonuses', tags = { [Gui.event_tag] = bonuses_button_name } }
         local deep = sp.add { type = 'frame', direction = 'vertical', style = 'deep_frame_in_shallow_frame_for_description' }
         Gui.set_style(deep, { padding = 0, minimal_height = 4 })
 
@@ -322,7 +322,7 @@ Public.get_main_frame = function(player)
     end
     do -- Rewards
         local toggled = gui_toggled[player.index].rewards
-        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_rewards or off_rewards, tooltip = 'Hide/Show rewards', tags = { [Gui.tag] = rewards_list_button_name } }
+        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_rewards or off_rewards, tooltip = 'Hide/Show rewards', tags = { [Gui.event_tag] = rewards_list_button_name } }
         local deep = sp.add { type = 'frame', style = 'deep_frame_in_shallow_frame_for_description', direction = 'vertical' }
         Gui.set_style(deep, { padding = 0, minimal_height = 4 })
 
@@ -544,7 +544,7 @@ local function on_player_created(event)
         type = 'sprite-button',
         sprite = 'entity/market',
         tooltip = { 'experience.gui_experience_button_tip' },
-        tags = { [Gui.tag] = main_button_name },
+        tags = { [Gui.event_tag] = main_button_name },
     })
     gui_toggled[player.index] = {
         bonuses = true,

--- a/features/gui/experience.lua
+++ b/features/gui/experience.lua
@@ -267,7 +267,7 @@ Public.get_main_frame = function(player)
     end
 
     local data = {}
-    frame = Gui.add_left_element(player, { name = main_frame_name, type = 'frame', direction = 'vertical' })
+    frame = Gui.add_left_element(player, { name = main_frame_name, type = 'frame', direction = 'vertical', tags = { [Gui.tag] = main_frame_name } })
     Gui.set_style(frame, { maximal_width = 360 })
 
     local canvas = frame
@@ -295,7 +295,7 @@ Public.get_main_frame = function(player)
     end
     do -- Bonuses
         local toggled = gui_toggled[player.index].bonuses
-        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_bonuses or off_bonuses, name = bonuses_button_name, tooltip = 'Hide/Show bonuses' }
+        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_bonuses or off_bonuses, tooltip = 'Hide/Show bonuses', tags = { [Gui.tag] = bonuses_button_name } }
         local deep = sp.add { type = 'frame', direction = 'vertical', style = 'deep_frame_in_shallow_frame_for_description' }
         Gui.set_style(deep, { padding = 0, minimal_height = 4 })
 
@@ -322,7 +322,7 @@ Public.get_main_frame = function(player)
     end
     do -- Rewards
         local toggled = gui_toggled[player.index].rewards
-        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_rewards or off_rewards, name = rewards_list_button_name, tooltip = 'Hide/Show rewards' }
+        local label = sp.add { type = 'label', style = 'bold_label', caption = toggled and on_rewards or off_rewards, tooltip = 'Hide/Show rewards', tags = { [Gui.tag] = rewards_list_button_name } }
         local deep = sp.add { type = 'frame', style = 'deep_frame_in_shallow_frame_for_description', direction = 'vertical' }
         Gui.set_style(deep, { padding = 0, minimal_height = 4 })
 
@@ -544,6 +544,7 @@ local function on_player_created(event)
         type = 'sprite-button',
         sprite = 'entity/market',
         tooltip = { 'experience.gui_experience_button_tip' },
+        tags = { [Gui.tag] = main_button_name },
     })
     gui_toggled[player.index] = {
         bonuses = true,

--- a/features/gui/info.lua
+++ b/features/gui/info.lua
@@ -172,7 +172,7 @@ end
 local pages = {
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = 'Welcome'}
+            local button = parent.add {type = 'button', tags = { [Gui.event_tag] = tab_button_name }, caption = 'Welcome'}
             return button
         end,
         content = function(parent)
@@ -255,7 +255,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = 'Rules'}
+            local button = parent.add {type = 'button', tags = { [Gui.event_tag] = tab_button_name }, caption = 'Rules'}
             return button
         end,
         content = function(parent)
@@ -289,7 +289,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = {'info.map_info_button'}}
+            local button = parent.add {type = 'button', tags = { [Gui.event_tag] = tab_button_name }, caption = {'info.map_info_button'}}
             return button
         end,
         content = function(parent, player)
@@ -317,7 +317,7 @@ local pages = {
             local map_name_textbox = grid.add({type = 'flow'}).add {
                 type = 'text-box',
                 text = editable_info[map_name_key],
-                tags = { [Gui.tag] = editable_textbox_name },
+                tags = { [Gui.event_tag] = editable_textbox_name },
             }
             map_name_textbox.read_only = read_only
 
@@ -331,7 +331,7 @@ local pages = {
             local map_description_textbox = grid.add({type = 'flow'}).add {
                 type = 'text-box',
                 text = editable_info[map_description_key],
-                tags = { [Gui.tag] = editable_textbox_name },
+                tags = { [Gui.event_tag] = editable_textbox_name },
             }
             map_description_textbox.read_only = read_only
             map_description_textbox.word_wrap = true
@@ -348,7 +348,7 @@ local pages = {
             local map_extra_info_textbox = grid.add({type = 'flow'}).add {
                 type = 'text-box',
                 text = editable_info[map_extra_info_key],
-                tags = { [Gui.tag] = editable_textbox_name },
+                tags = { [Gui.event_tag] = editable_textbox_name },
             }
             map_extra_info_textbox.read_only = read_only
             map_extra_info_textbox.word_wrap = true
@@ -362,7 +362,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = {'info.softmods_button'}}
+            local button = parent.add {type = 'button', tags = { [Gui.event_tag] = tab_button_name }, caption = {'info.softmods_button'}}
             return button
         end,
         content = function(parent, player)
@@ -470,7 +470,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = {'info.whats_new_button'}}
+            local button = parent.add {type = 'button', tags = { [Gui.event_tag] = tab_button_name }, caption = {'info.whats_new_button'}}
             return button
         end,
         content = function(parent, player)
@@ -489,7 +489,7 @@ local pages = {
             local new_info_textbox = new_info_flow.add {
                 type = 'text-box',
                 text = editable_info[new_info_key],
-                tags = { [Gui.tag] = editable_textbox_name },
+                tags = { [Gui.event_tag] = editable_textbox_name },
             }
             new_info_textbox.read_only = read_only
 
@@ -504,7 +504,7 @@ local pages = {
 }
 
 local function draw_main_frame(center, player)
-    local frame = center.add {type = 'frame', name = main_frame_name, direction = 'vertical', tags = { [Gui.tag] = main_frame_name }}
+    local frame = center.add {type = 'frame', name = main_frame_name, direction = 'vertical', tags = { [Gui.event_tag] = main_frame_name }}
     local frame_style = frame.style
     frame_style.height = 600
     frame_style.width = 650
@@ -646,7 +646,7 @@ local function player_created(event)
         sprite = 'virtual-signal/signal-info',
         tooltip = {'info.tooltip'},
         auto_toggle = true,
-        tags = { [Gui.tag] = main_button_name },
+        tags = { [Gui.event_tag] = main_button_name },
     })
 
     rewarded_players[player.index] = 0

--- a/features/gui/info.lua
+++ b/features/gui/info.lua
@@ -172,7 +172,7 @@ end
 local pages = {
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', name = tab_button_name, caption = 'Welcome'}
+            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = 'Welcome'}
             return button
         end,
         content = function(parent)
@@ -255,7 +255,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', name = tab_button_name, caption = 'Rules'}
+            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = 'Rules'}
             return button
         end,
         content = function(parent)
@@ -289,7 +289,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', name = tab_button_name, caption = {'info.map_info_button'}}
+            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = {'info.map_info_button'}}
             return button
         end,
         content = function(parent, player)
@@ -316,8 +316,8 @@ local pages = {
             grid.add {type = 'label', caption = {'info.map_name_label'}}
             local map_name_textbox = grid.add({type = 'flow'}).add {
                 type = 'text-box',
-                name = editable_textbox_name,
-                text = editable_info[map_name_key]
+                text = editable_info[map_name_key],
+                tags = { [Gui.tag] = editable_textbox_name },
             }
             map_name_textbox.read_only = read_only
 
@@ -330,8 +330,8 @@ local pages = {
             grid.add {type = 'label', caption = {'info.map_desc_label'}}
             local map_description_textbox = grid.add({type = 'flow'}).add {
                 type = 'text-box',
-                name = editable_textbox_name,
-                text = editable_info[map_description_key]
+                text = editable_info[map_description_key],
+                tags = { [Gui.tag] = editable_textbox_name },
             }
             map_description_textbox.read_only = read_only
             map_description_textbox.word_wrap = true
@@ -347,8 +347,8 @@ local pages = {
             grid.add {type = 'label', caption = {'info.map_extra_info_label'}}
             local map_extra_info_textbox = grid.add({type = 'flow'}).add {
                 type = 'text-box',
-                name = editable_textbox_name,
-                text = editable_info[map_extra_info_key]
+                text = editable_info[map_extra_info_key],
+                tags = { [Gui.tag] = editable_textbox_name },
             }
             map_extra_info_textbox.read_only = read_only
             map_extra_info_textbox.word_wrap = true
@@ -362,7 +362,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', name = tab_button_name, caption = {'info.softmods_button'}}
+            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = {'info.softmods_button'}}
             return button
         end,
         content = function(parent, player)
@@ -470,7 +470,7 @@ local pages = {
     },
     {
         tab_button = function(parent)
-            local button = parent.add {type = 'button', name = tab_button_name, caption = {'info.whats_new_button'}}
+            local button = parent.add {type = 'button', tags = { [Gui.tag] = tab_button_name }, caption = {'info.whats_new_button'}}
             return button
         end,
         content = function(parent, player)
@@ -488,8 +488,8 @@ local pages = {
 
             local new_info_textbox = new_info_flow.add {
                 type = 'text-box',
-                name = editable_textbox_name,
-                text = editable_info[new_info_key]
+                text = editable_info[new_info_key],
+                tags = { [Gui.tag] = editable_textbox_name },
             }
             new_info_textbox.read_only = read_only
 
@@ -504,7 +504,7 @@ local pages = {
 }
 
 local function draw_main_frame(center, player)
-    local frame = center.add {type = 'frame', name = main_frame_name, direction = 'vertical'}
+    local frame = center.add {type = 'frame', name = main_frame_name, direction = 'vertical', tags = { [Gui.tag] = main_frame_name }}
     local frame_style = frame.style
     frame_style.height = 600
     frame_style.width = 650
@@ -646,6 +646,7 @@ local function player_created(event)
         sprite = 'virtual-signal/signal-info',
         tooltip = {'info.tooltip'},
         auto_toggle = true,
+        tags = { [Gui.tag] = main_button_name },
     })
 
     rewarded_players[player.index] = 0

--- a/features/gui/paint.lua
+++ b/features/gui/paint.lua
@@ -200,6 +200,7 @@ local function player_created(event)
             sprite = 'utility/spray_icon',
             tooltip = {'paint.tooltip'},
             auto_toggle = true,
+            tags = { [Gui.tag] = main_button_name },
         }
     )
     b.style.padding = 2
@@ -213,20 +214,18 @@ local function draw_filters_table(event)
     end
 
     local frame =
-        center.add {type = 'frame', name = filters_table_name, direction = 'vertical', caption = {'paint.palette'}}
+        center.add {type = 'frame', name = filters_table_name, direction = 'vertical', caption = {'paint.palette'}, tags = { [Gui.tag] = filters_table_name }}
 
     local t = frame.add {type = 'table', column_count = 6}
     t.style.horizontal_spacing = 0
     t.style.vertical_spacing = 0
 
     for tile_name, _ in pairs(valid_filters) do
-        local flow = t.add {type = 'flow'}
-        local button =
-            flow.add {
+        local button = t.add {
             type = 'sprite-button',
-            name = filter_element_name,
             sprite = 'tile/' .. tile_name,
-            tooltip = get_tile_localised_name(tile_name)
+            tooltip = get_tile_localised_name(tile_name),
+            tags = { [Gui.tag] = filter_element_name },
         }
         Gui.set_data(button, {frame = frame, tile_name = tile_name})
         button.style = 'slot_button'
@@ -265,9 +264,9 @@ local function toggle(event)
         local brush =
             top_flow.add({type = 'flow'}).add {
             type = 'sprite-button',
-            name = filter_button_name,
             tooltip = get_tile_localised_name(tile_name) or {'paint.select_brush'},
-            sprite = tile_name and 'tile/' .. tile_name
+            sprite = tile_name and 'tile/' .. tile_name,
+            tags = { [Gui.tag] = filter_button_name },
         }
         brush.style = 'slot_button'
 
@@ -282,7 +281,7 @@ local function toggle(event)
         Gui.make_close_button(buttons_flow, main_button_name)
 
         local clear_brush =
-            buttons_flow.add {type = 'button', name = filter_clear_name, caption = {'paint.clear_brush'}}
+            buttons_flow.add {type = 'button', caption = {'paint.clear_brush'}, tags = { [Gui.tag] = filter_clear_name }}
         Gui.set_data(clear_brush, brush)
     end
 end
@@ -319,9 +318,6 @@ Gui.on_click(
     filter_element_name,
     function(event)
         local element = event.element
-        if not element or not element.valid then
-            return
-        end
 
         local data = Gui.get_data(element)
         local frame = data.frame

--- a/features/gui/paint.lua
+++ b/features/gui/paint.lua
@@ -200,7 +200,7 @@ local function player_created(event)
             sprite = 'utility/spray_icon',
             tooltip = {'paint.tooltip'},
             auto_toggle = true,
-            tags = { [Gui.tag] = main_button_name },
+            tags = { [Gui.event_tag] = main_button_name },
         }
     )
     b.style.padding = 2
@@ -214,7 +214,7 @@ local function draw_filters_table(event)
     end
 
     local frame =
-        center.add {type = 'frame', name = filters_table_name, direction = 'vertical', caption = {'paint.palette'}, tags = { [Gui.tag] = filters_table_name }}
+        center.add {type = 'frame', name = filters_table_name, direction = 'vertical', caption = {'paint.palette'}, tags = { [Gui.event_tag] = filters_table_name }}
 
     local t = frame.add {type = 'table', column_count = 6}
     t.style.horizontal_spacing = 0
@@ -225,7 +225,7 @@ local function draw_filters_table(event)
             type = 'sprite-button',
             sprite = 'tile/' .. tile_name,
             tooltip = get_tile_localised_name(tile_name),
-            tags = { [Gui.tag] = filter_element_name },
+            tags = { [Gui.event_tag] = filter_element_name },
         }
         Gui.set_data(button, {frame = frame, tile_name = tile_name})
         button.style = 'slot_button'
@@ -266,7 +266,7 @@ local function toggle(event)
             type = 'sprite-button',
             tooltip = get_tile_localised_name(tile_name) or {'paint.select_brush'},
             sprite = tile_name and 'tile/' .. tile_name,
-            tags = { [Gui.tag] = filter_button_name },
+            tags = { [Gui.event_tag] = filter_button_name },
         }
         brush.style = 'slot_button'
 
@@ -281,7 +281,7 @@ local function toggle(event)
         Gui.make_close_button(buttons_flow, main_button_name)
 
         local clear_brush =
-            buttons_flow.add {type = 'button', caption = {'paint.clear_brush'}, tags = { [Gui.tag] = filter_clear_name }}
+            buttons_flow.add {type = 'button', caption = {'paint.clear_brush'}, tags = { [Gui.event_tag] = filter_clear_name }}
         Gui.set_data(clear_brush, brush)
     end
 end

--- a/features/gui/player_list.lua
+++ b/features/gui/player_list.lua
@@ -142,7 +142,7 @@ local column_builders = {
             return a < b
         end,
         draw_heading = function(parent)
-            local label = parent.add {type = 'label', name = sprite_heading_name, caption = ' '}
+            local label = parent.add {type = 'label', caption = ' ', tags = { [Gui.tag] = sprite_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 32
@@ -172,7 +172,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.name_caption', sort_symbol}
-            local label = parent.add {type = 'label', name = player_name_heading_name, caption = caption}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = player_name_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 150
@@ -207,7 +207,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.time_caption', sort_symbol}
-            local label = parent.add {type = 'label', name = time_heading_name, caption = caption}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = time_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 125
@@ -242,7 +242,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.rank_caption', sort_symbol}
-            local label = parent.add {type = 'label', name = rank_heading_name, caption = caption}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = rank_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = rank_column_width
@@ -285,7 +285,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.distance_caption', sort_symbol}
-            local label = parent.add {type = 'label', name = distance_heading_name, caption = caption}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = distance_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 70
@@ -324,9 +324,9 @@ local column_builders = {
             local label =
                 parent.add {
                 type = 'label',
-                name = coin_heading_name,
                 caption = caption,
-                tooltip = 'Coins earned / spent.'
+                tooltip = 'Coins earned / spent.',
+                tags = { [Gui.tag] = coin_heading_name },
             }
             local label_style = label.style
             apply_heading_style(label_style)
@@ -355,7 +355,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.kills_caption', sort_symbol}
-            local label = parent.add {type = 'label', name = kills_heading_name, caption = caption}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = kills_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 80
@@ -384,7 +384,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.deaths_caption', sort_symbol}
-            local label = parent.add {type = 'label', name = deaths_heading_name, caption = caption}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = deaths_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 60
@@ -436,7 +436,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol, data)
             local caption = {'player_list.poke_caption', sort_symbol}
-            local label = parent.add {type = 'label', name = poke_name_heading_name, caption = caption}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = poke_name_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 60
@@ -452,7 +452,7 @@ local column_builders = {
             parent_style.width = 64
             parent_style.horizontal_align = 'center'
 
-            local label = parent.add {type = 'button', name = poke_cell_name, caption = cell_data.poke_count}
+            local label = parent.add {type = 'button', caption = cell_data.poke_count, tags = { [Gui.tag] = poke_cell_name }}
             local label_style = label.style
             label_style.horizontal_align = 'center'
             label_style.minimal_width = 32
@@ -482,9 +482,9 @@ local column_builders = {
             local label =
                 parent.add {
                 type = 'label',
-                name = report_heading_name,
                 caption = caption,
-                tooltip = {'player_list.report_tooltip'}
+                tooltip = {'player_list.report_tooltip'},
+                tags = { [Gui.tag] = report_heading_name },
             }
             local label_style = label.style
             apply_heading_style(label_style)
@@ -500,9 +500,9 @@ local column_builders = {
             local label =
                 parent.add {
                 type = 'sprite-button',
-                name = report_cell_name,
                 sprite = 'utility/force_editor_icon',
-                tooltip = {'player_list.report_button_tooltip', cell_data.name}
+                tooltip = {'player_list.report_button_tooltip', cell_data.name},
+                tags = { [Gui.tag] = report_cell_name },
             }
             local label_style = label.style
             label_style.horizontal_align = 'center'
@@ -636,10 +636,10 @@ local function draw_main_frame(left, player)
     local notify_checkbox =
         frame.add {
         type = 'checkbox',
-        name = notify_checkbox_name,
         state = state,
         caption = {'player_list.poke_notify_caption'},
-        tooltip = {'player_list.poke_notify_tooltip'}
+        tooltip = {'player_list.poke_notify_tooltip'},
+        tags = { [Gui.tag] = notify_checkbox_name },
     }
 
     Gui.make_close_button(frame, main_button_name)
@@ -705,6 +705,7 @@ local function player_created(event)
             sprite = 'entity/character',
             tooltip = {'player_list.tooltip'},
             auto_toggle = true,
+            tags = { [Gui.tag] = main_button_name },
         }
     )
 end

--- a/features/gui/player_list.lua
+++ b/features/gui/player_list.lua
@@ -142,7 +142,7 @@ local column_builders = {
             return a < b
         end,
         draw_heading = function(parent)
-            local label = parent.add {type = 'label', caption = ' ', tags = { [Gui.tag] = sprite_heading_name }}
+            local label = parent.add {type = 'label', caption = ' ', tags = { [Gui.event_tag] = sprite_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 32
@@ -172,7 +172,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.name_caption', sort_symbol}
-            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = player_name_heading_name }}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.event_tag] = player_name_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 150
@@ -207,7 +207,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.time_caption', sort_symbol}
-            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = time_heading_name }}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.event_tag] = time_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 125
@@ -242,7 +242,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.rank_caption', sort_symbol}
-            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = rank_heading_name }}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.event_tag] = rank_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = rank_column_width
@@ -285,7 +285,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.distance_caption', sort_symbol}
-            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = distance_heading_name }}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.event_tag] = distance_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 70
@@ -326,7 +326,7 @@ local column_builders = {
                 type = 'label',
                 caption = caption,
                 tooltip = 'Coins earned / spent.',
-                tags = { [Gui.tag] = coin_heading_name },
+                tags = { [Gui.event_tag] = coin_heading_name },
             }
             local label_style = label.style
             apply_heading_style(label_style)
@@ -355,7 +355,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.kills_caption', sort_symbol}
-            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = kills_heading_name }}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.event_tag] = kills_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 80
@@ -384,7 +384,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol)
             local caption = {'player_list.deaths_caption', sort_symbol}
-            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = deaths_heading_name }}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.event_tag] = deaths_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 60
@@ -436,7 +436,7 @@ local column_builders = {
         end,
         draw_heading = function(parent, sort_symbol, data)
             local caption = {'player_list.poke_caption', sort_symbol}
-            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.tag] = poke_name_heading_name }}
+            local label = parent.add {type = 'label', caption = caption, tags = { [Gui.event_tag] = poke_name_heading_name }}
             local label_style = label.style
             apply_heading_style(label_style)
             label_style.width = 60
@@ -452,7 +452,7 @@ local column_builders = {
             parent_style.width = 64
             parent_style.horizontal_align = 'center'
 
-            local label = parent.add {type = 'button', caption = cell_data.poke_count, tags = { [Gui.tag] = poke_cell_name }}
+            local label = parent.add {type = 'button', caption = cell_data.poke_count, tags = { [Gui.event_tag] = poke_cell_name }}
             local label_style = label.style
             label_style.horizontal_align = 'center'
             label_style.minimal_width = 32
@@ -484,7 +484,7 @@ local column_builders = {
                 type = 'label',
                 caption = caption,
                 tooltip = {'player_list.report_tooltip'},
-                tags = { [Gui.tag] = report_heading_name },
+                tags = { [Gui.event_tag] = report_heading_name },
             }
             local label_style = label.style
             apply_heading_style(label_style)
@@ -502,7 +502,7 @@ local column_builders = {
                 type = 'sprite-button',
                 sprite = 'utility/force_editor_icon',
                 tooltip = {'player_list.report_button_tooltip', cell_data.name},
-                tags = { [Gui.tag] = report_cell_name },
+                tags = { [Gui.event_tag] = report_cell_name },
             }
             local label_style = label.style
             label_style.horizontal_align = 'center'
@@ -639,7 +639,7 @@ local function draw_main_frame(left, player)
         state = state,
         caption = {'player_list.poke_notify_caption'},
         tooltip = {'player_list.poke_notify_tooltip'},
-        tags = { [Gui.tag] = notify_checkbox_name },
+        tags = { [Gui.event_tag] = notify_checkbox_name },
     }
 
     Gui.make_close_button(frame, main_button_name)
@@ -705,7 +705,7 @@ local function player_created(event)
             sprite = 'entity/character',
             tooltip = {'player_list.tooltip'},
             auto_toggle = true,
-            tags = { [Gui.tag] = main_button_name },
+            tags = { [Gui.event_tag] = main_button_name },
         }
     )
 end

--- a/features/gui/poll.lua
+++ b/features/gui/poll.lua
@@ -257,7 +257,7 @@ local function redraw_poll_viewer_content(data)
             type = 'sprite-button',
             sprite = 'utility/rename_icon',
             tooltip = 'Edit Poll.',
-            tags = { [Gui.tag] = poll_view_edit_name },
+            tags = { [Gui.event_tag] = poll_view_edit_name },
         }
 
         local edit_button_style = edit_button.style
@@ -282,7 +282,7 @@ local function redraw_poll_viewer_content(data)
             type = 'button',
             caption = a.voted_count,
             enabled = poll_enabled,
-            tags = { [Gui.tag] = poll_view_vote_name },
+            tags = { [Gui.event_tag] = poll_view_vote_name },
         }
 
         local tooltip = tooltips[a]
@@ -350,10 +350,10 @@ local function draw_main_frame(left, player)
     local poll_viewer_top_flow = frame.add {type = 'table', column_count = 5}
     poll_viewer_top_flow.style.horizontal_spacing = 0
 
-    local back_button = poll_viewer_top_flow.add {type = 'button', caption = '◀', tags = { [Gui.tag] = poll_view_move, sign = -1 }}
+    local back_button = poll_viewer_top_flow.add {type = 'button', caption = '◀', tags = { [Gui.event_tag] = poll_view_move, sign = -1 }}
     apply_direction_button_style(back_button)
 
-    local forward_button = poll_viewer_top_flow.add {type = 'button', caption = '▶', tags = { [Gui.tag] = poll_view_move, sign = 1 }}
+    local forward_button = poll_viewer_top_flow.add {type = 'button', caption = '▶', tags = { [Gui.event_tag] = poll_view_move, sign = 1 }}
     apply_direction_button_style(forward_button)
 
     local poll_index_label = poll_viewer_top_flow.add {type = 'label'}
@@ -393,7 +393,7 @@ local function draw_main_frame(left, player)
         state = state,
         caption = {'poll.notify_caption'},
         tooltip = {'poll.notify_tooltip'},
-        tags = { [Gui.tag] = notify_checkbox_name },
+        tags = { [Gui.event_tag] = notify_checkbox_name },
     }
     data.notify_checkbox = notify_checkbox
 
@@ -409,7 +409,7 @@ local function draw_main_frame(left, player)
         name = main_button_name,
         caption = {'common.close_button'},
         style = 'back_button',
-        tags = { [Gui.tag] = main_button_name },
+        tags = { [Gui.event_tag] = main_button_name },
     }
     apply_button_style(close_button)
 
@@ -418,7 +418,7 @@ local function draw_main_frame(left, player)
 
     if Rank.equal_or_greater_than(player.name, Ranks.regular) then
         local create_poll_button =
-            right_flow.add {type = 'button', caption = 'Create Poll', tags = { [Gui.tag] = create_poll_button_name }}
+            right_flow.add {type = 'button', caption = 'Create Poll', tags = { [Gui.event_tag] = create_poll_button_name }}
         apply_button_style(create_poll_button)
     else
         local create_poll_button =
@@ -509,7 +509,7 @@ local function redraw_create_poll_content(data)
         minimum_value = 0,
         maximum_value = duration_slider_max,
         value = math.floor(data.duration * inv_tick_duration_step),
-        tags = { [Gui.tag] = create_poll_duration_name },
+        tags = { [Gui.event_tag] = create_poll_duration_name },
     }
     duration_slider.style.width = 80
 
@@ -523,10 +523,10 @@ local function redraw_create_poll_content(data)
 
     grid.add {type = 'flow'}
     local question_label =
-        grid.add {type = 'label', caption = 'Question:', tags = { [Gui.tag] = create_poll_label_name }}
+        grid.add {type = 'label', caption = 'Question:', tags = { [Gui.event_tag] = create_poll_label_name }}
 
     local question_textfield =
-        grid.add {type = 'textfield', text = data.question, tags = { [Gui.tag] = create_poll_question_name }}
+        grid.add {type = 'textfield', text = data.question, tags = { [Gui.event_tag] = create_poll_question_name }}
     question_textfield.style.width = 215
 
     Gui.set_data(question_label, question_textfield)
@@ -543,7 +543,7 @@ local function redraw_create_poll_content(data)
                 type = 'sprite-button',
                 sprite = 'utility/trash',
                 tooltip = 'Delete answer field.',
-                tags = { [Gui.tag] = create_poll_delete_answer_name },
+                tags = { [Gui.event_tag] = create_poll_delete_answer_name },
             }
             delete_button.style.height = 26
             delete_button.style.width = 26
@@ -555,10 +555,10 @@ local function redraw_create_poll_content(data)
         local label = grid.add {
             type = 'label',
             caption = table.concat {'Answer #', count, ':'},
-            tags = { [Gui.tag] = create_poll_label_name },
+            tags = { [Gui.event_tag] = create_poll_label_name },
         }
 
-        local textfield = grid.add {type = 'textfield', text = answer.text, tags = { [Gui.tag] = create_poll_answer_name }}
+        local textfield = grid.add {type = 'textfield', text = answer.text, tags = { [Gui.event_tag] = create_poll_answer_name }}
         textfield.style.width = 215
         Gui.set_data(textfield, {answers = answers, count = count})
 
@@ -635,7 +635,7 @@ local function draw_create_poll_frame(parent, player, previous_data)
         scroll_pane.add {
         type = 'button',
         caption = 'Add Answer',
-        tags = { [Gui.tag] = create_poll_add_answer_name},
+        tags = { [Gui.event_tag] = create_poll_add_answer_name},
     }
     apply_button_style(add_answer_button)
     Gui.set_data(add_answer_button, data)
@@ -651,12 +651,12 @@ local function draw_create_poll_frame(parent, player, previous_data)
         type = 'button',
         caption = {'common.close_button'},
         style = 'back_button',
-        tags = { [Gui.tag] = create_poll_close_name },
+        tags = { [Gui.event_tag] = create_poll_close_name },
     }
     apply_button_style(close_button)
     Gui.set_data(close_button, frame)
 
-    local clear_button = left_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.tag] = create_poll_clear_name }}
+    local clear_button = left_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.event_tag] = create_poll_clear_name }}
     apply_button_style(clear_button)
     Gui.set_data(clear_button, data)
 
@@ -665,12 +665,12 @@ local function draw_create_poll_frame(parent, player, previous_data)
 
     if edit_mode then
         local delete_button =
-            right_flow.add {type = 'button', caption = {'common.delete'}, tags = { [Gui.tag] = create_poll_delete_name }}
+            right_flow.add {type = 'button', caption = {'common.delete'}, tags = { [Gui.event_tag] = create_poll_delete_name }}
         apply_button_style(delete_button)
         Gui.set_data(delete_button, data)
     end
 
-    local confirm_button = right_flow.add {type = 'button', caption = confirm_text, tags = { [Gui.tag] = confirm_name }}
+    local confirm_button = right_flow.add {type = 'button', caption = confirm_text, tags = { [Gui.event_tag] = confirm_name }}
     apply_button_style(confirm_button)
     Gui.set_data(confirm_button, data)
 end
@@ -854,7 +854,7 @@ local function player_created(event)
             sprite = 'item/programmable-speaker',
             tooltip = {'poll.tooltip'},
             auto_toggle = true,
-            tags = { [Gui.tag] = main_button_name },
+            tags = { [Gui.event_tag] = main_button_name },
         }
     )
 end

--- a/features/gui/poll.lua
+++ b/features/gui/poll.lua
@@ -60,8 +60,7 @@ local main_frame_name = Gui.uid_name()
 local create_poll_button_name = Gui.uid_name()
 local notify_checkbox_name = Gui.uid_name()
 
-local poll_view_back_name = Gui.uid_name()
-local poll_view_forward_name = Gui.uid_name()
+local poll_view_move = Gui.uid_name()
 local poll_view_vote_name = Gui.uid_name()
 local poll_view_edit_name = Gui.uid_name()
 
@@ -256,9 +255,9 @@ local function redraw_poll_viewer_content(data)
         local edit_button =
             question_flow.add {
             type = 'sprite-button',
-            name = poll_view_edit_name,
             sprite = 'utility/rename_icon',
-            tooltip = 'Edit Poll.'
+            tooltip = 'Edit Poll.',
+            tags = { [Gui.tag] = poll_view_edit_name },
         }
 
         local edit_button_style = edit_button.style
@@ -281,9 +280,9 @@ local function redraw_poll_viewer_content(data)
         local vote_button =
             vote_button_flow.add {
             type = 'button',
-            name = poll_view_vote_name,
             caption = a.voted_count,
-            enabled = poll_enabled
+            enabled = poll_enabled,
+            tags = { [Gui.tag] = poll_view_vote_name },
         }
 
         local tooltip = tooltips[a]
@@ -351,10 +350,10 @@ local function draw_main_frame(left, player)
     local poll_viewer_top_flow = frame.add {type = 'table', column_count = 5}
     poll_viewer_top_flow.style.horizontal_spacing = 0
 
-    local back_button = poll_viewer_top_flow.add {type = 'button', name = poll_view_back_name, caption = '◀'}
+    local back_button = poll_viewer_top_flow.add {type = 'button', caption = '◀', tags = { [Gui.tag] = poll_view_move, sign = -1 }}
     apply_direction_button_style(back_button)
 
-    local forward_button = poll_viewer_top_flow.add {type = 'button', name = poll_view_forward_name, caption = '▶'}
+    local forward_button = poll_viewer_top_flow.add {type = 'button', caption = '▶', tags = { [Gui.tag] = poll_view_move, sign = 1 }}
     apply_direction_button_style(forward_button)
 
     local poll_index_label = poll_viewer_top_flow.add {type = 'label'}
@@ -391,10 +390,10 @@ local function draw_main_frame(left, player)
     local notify_checkbox =
         frame.add {
         type = 'checkbox',
-        name = notify_checkbox_name,
         state = state,
         caption = {'poll.notify_caption'},
-        tooltip = {'poll.notify_tooltip'}
+        tooltip = {'poll.notify_tooltip'},
+        tags = { [Gui.tag] = notify_checkbox_name },
     }
     data.notify_checkbox = notify_checkbox
 
@@ -409,7 +408,8 @@ local function draw_main_frame(left, player)
         type = 'button',
         name = main_button_name,
         caption = {'common.close_button'},
-        style = 'back_button'
+        style = 'back_button',
+        tags = { [Gui.tag] = main_button_name },
     }
     apply_button_style(close_button)
 
@@ -418,7 +418,7 @@ local function draw_main_frame(left, player)
 
     if Rank.equal_or_greater_than(player.name, Ranks.regular) then
         local create_poll_button =
-            right_flow.add {type = 'button', name = create_poll_button_name, caption = 'Create Poll'}
+            right_flow.add {type = 'button', caption = 'Create Poll', tags = { [Gui.tag] = create_poll_button_name }}
         apply_button_style(create_poll_button)
     else
         local create_poll_button =
@@ -506,10 +506,10 @@ local function redraw_create_poll_content(data)
     local duration_slider =
         duration_flow.add {
         type = 'slider',
-        name = create_poll_duration_name,
         minimum_value = 0,
         maximum_value = duration_slider_max,
-        value = math.floor(data.duration * inv_tick_duration_step)
+        value = math.floor(data.duration * inv_tick_duration_step),
+        tags = { [Gui.tags] = create_poll_duration_name },
     }
     duration_slider.style.width = 80
 
@@ -523,10 +523,10 @@ local function redraw_create_poll_content(data)
 
     grid.add {type = 'flow'}
     local question_label =
-        grid.add({type = 'flow'}).add {type = 'label', name = create_poll_label_name, caption = 'Question:'}
+        grid.add {type = 'label', caption = 'Question:', tags = { [Gui.tag] = create_poll_label_name }}
 
     local question_textfield =
-        grid.add({type = 'flow'}).add {type = 'textfield', name = create_poll_question_name, text = data.question}
+        grid.add {type = 'textfield', text = data.question, tags = { [Gui.tag] = create_poll_question_name }}
     question_textfield.style.width = 215
 
     Gui.set_data(question_label, question_textfield)
@@ -541,9 +541,9 @@ local function redraw_create_poll_content(data)
             delete_button =
                 delete_flow.add {
                 type = 'sprite-button',
-                name = create_poll_delete_answer_name,
                 sprite = 'utility/trash',
-                tooltip = 'Delete answer field.'
+                tooltip = 'Delete answer field.',
+                tags = { [Gui.tag] = create_poll_delete_answer_name },
             }
             delete_button.style.height = 26
             delete_button.style.width = 26
@@ -552,17 +552,13 @@ local function redraw_create_poll_content(data)
             delete_flow.style.width = 26
         end
 
-        local label_flow = grid.add {type = 'flow'}
-        local label =
-            label_flow.add {
+        local label = grid.add {
             type = 'label',
-            name = create_poll_label_name,
-            caption = table.concat {'Answer #', count, ':'}
+            caption = table.concat {'Answer #', count, ':'},
+            tags = { [Gui.tag] = create_poll_label_name },
         }
 
-        local textfield_flow = grid.add {type = 'flow'}
-
-        local textfield = textfield_flow.add {type = 'textfield', name = create_poll_answer_name, text = answer.text}
+        local textfield = grid.add {type = 'textfield', text = answer.text, tags = { [Gui.tag] = create_poll_answer_name }}
         textfield.style.width = 215
         Gui.set_data(textfield, {answers = answers, count = count})
 
@@ -638,8 +634,8 @@ local function draw_create_poll_frame(parent, player, previous_data)
     local add_answer_button =
         scroll_pane.add {
         type = 'button',
-        name = create_poll_add_answer_name,
-        caption = 'Add Answer'
+        caption = 'Add Answer',
+        tags = { [Gui.tag] = create_poll_add_answer_name},
     }
     apply_button_style(add_answer_button)
     Gui.set_data(add_answer_button, data)
@@ -653,14 +649,14 @@ local function draw_create_poll_frame(parent, player, previous_data)
     local close_button =
         left_flow.add {
         type = 'button',
-        name = create_poll_close_name,
         caption = {'common.close_button'},
-        style = 'back_button'
+        style = 'back_button',
+        tags = { [Gui.tag] = create_poll_close_name },
     }
     apply_button_style(close_button)
     Gui.set_data(close_button, frame)
 
-    local clear_button = left_flow.add {type = 'button', name = create_poll_clear_name, caption = 'Clear'}
+    local clear_button = left_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.tag] = create_poll_clear_name }}
     apply_button_style(clear_button)
     Gui.set_data(clear_button, data)
 
@@ -669,12 +665,12 @@ local function draw_create_poll_frame(parent, player, previous_data)
 
     if edit_mode then
         local delete_button =
-            right_flow.add {type = 'button', name = create_poll_delete_name, caption = {'common.delete'}}
+            right_flow.add {type = 'button', caption = {'common.delete'}, tags = { [Gui.tag] = create_poll_delete_name }}
         apply_button_style(delete_button)
         Gui.set_data(delete_button, data)
     end
 
-    local confirm_button = right_flow.add {type = 'button', name = confirm_name, caption = confirm_text}
+    local confirm_button = right_flow.add {type = 'button', caption = confirm_text, tags = { [Gui.tag] = confirm_name }}
     apply_button_style(confirm_button)
     Gui.set_data(confirm_button, data)
 end
@@ -1220,7 +1216,8 @@ Gui.on_checked_state_changed(
     end
 )
 
-local function do_direction(event, sign)
+local function do_direction(event)
+    local sign = event.tags.sign
     local count
     if event.shift then
         count = #polls
@@ -1240,19 +1237,7 @@ local function do_direction(event, sign)
     update_poll_viewer(data)
 end
 
-Gui.on_click(
-    poll_view_back_name,
-    function(event)
-        do_direction(event, -1)
-    end
-)
-
-Gui.on_click(
-    poll_view_forward_name,
-    function(event)
-        do_direction(event, 1)
-    end
-)
+Gui.on_click(poll_view_move, do_direction)
 
 Gui.on_click(poll_view_vote_name, vote)
 

--- a/features/gui/poll.lua
+++ b/features/gui/poll.lua
@@ -509,7 +509,7 @@ local function redraw_create_poll_content(data)
         minimum_value = 0,
         maximum_value = duration_slider_max,
         value = math.floor(data.duration * inv_tick_duration_step),
-        tags = { [Gui.tags] = create_poll_duration_name },
+        tags = { [Gui.tag] = create_poll_duration_name },
     }
     duration_slider.style.width = 80
 
@@ -854,6 +854,7 @@ local function player_created(event)
             sprite = 'item/programmable-speaker',
             tooltip = {'poll.tooltip'},
             auto_toggle = true,
+            tags = { [Gui.tag] = main_button_name },
         }
     )
 end

--- a/features/gui/popup.lua
+++ b/features/gui/popup.lua
@@ -89,7 +89,7 @@ local function show_popup(player, message, title_text, sprite_path, popup_name)
     ok_button_flow.style.horizontally_stretchable = true
     ok_button_flow.style.horizontal_align  = 'center'
 
-    local ok_button = ok_button_flow.add {type = 'button', caption = {'popup.confirm_btn'}, tags = { [Gui.tag] = close_name }}
+    local ok_button = ok_button_flow.add {type = 'button', caption = {'popup.confirm_btn'}, tags = { [Gui.event_tag] = close_name }}
     Gui.set_data(ok_button, frame)
 end
 

--- a/features/gui/popup.lua
+++ b/features/gui/popup.lua
@@ -89,7 +89,7 @@ local function show_popup(player, message, title_text, sprite_path, popup_name)
     ok_button_flow.style.horizontally_stretchable = true
     ok_button_flow.style.horizontal_align  = 'center'
 
-    local ok_button = ok_button_flow.add {type = 'button', name = close_name, caption = {'popup.confirm_btn'}}
+    local ok_button = ok_button_flow.add {type = 'button', caption = {'popup.confirm_btn'}, tags = { [Gui.tag] = close_name }}
     Gui.set_data(ok_button, frame)
 end
 

--- a/features/gui/production_hud.lua
+++ b/features/gui/production_hud.lua
@@ -101,7 +101,7 @@ local function init_hud(parent, items)
                 'production_hud.item_tooltip',
                 { '?', { 'item-name.' .. name }, { 'entity-name.' .. name }, { 'fluid-name.' .. name } },
             },
-            tags = { [Gui.tag] = action_remove_item, name = name },
+            tags = { [Gui.event_tag] = action_remove_item, name = name },
         }
         Gui.set_style(flow, { padding = 2, vertical_align = 'center' })
         Gui.add_pusher(flow)
@@ -186,7 +186,7 @@ Public.get_main_frame = function(player)
             type = 'sprite-button',
             caption = to_time[settings.precision_index],
             style = 'frame_button',
-            tags = { [Gui.tag] = action_scroll_precision_index},
+            tags = { [Gui.event_tag] = action_scroll_precision_index},
         }
         data.action_scroll_precision_index = button
         Gui.set_style(button, { height = 24, width = 48, font_color = { 255, 255, 255 } })
@@ -199,7 +199,7 @@ Public.get_main_frame = function(player)
             tooltip = { 'production_hud.new_item_tooltip' },
             elem_type = 'signal',
             signal = { type = 'virtual', name = 'shape-cross' },
-            tags = { [Gui.tag] = action_add_item },
+            tags = { [Gui.event_tag] = action_add_item },
         }
         Gui.set_style(button, { size = 24, font_color = { 255, 255, 255 } })
         Gui.set_data(button, data)
@@ -315,7 +315,7 @@ Event.add(defines.events.on_player_created, function(event)
         type = 'sprite-button',
         sprite = 'utility/side_menu_production_icon',
         tooltip = { 'production_hud.feature_tooltip' },
-        tags = { [Gui.tag] = main_button_name },
+        tags = { [Gui.event_tag] = main_button_name },
     })
 
     player_settings[player.index] = {

--- a/features/gui/production_hud.lua
+++ b/features/gui/production_hud.lua
@@ -101,7 +101,7 @@ local function init_hud(parent, items)
                 'production_hud.item_tooltip',
                 { '?', { 'item-name.' .. name }, { 'entity-name.' .. name }, { 'fluid-name.' .. name } },
             },
-            tags = { name = name },
+            tags = { [Gui.tag] = action_remove_item, name = name },
         }
         Gui.set_style(flow, { padding = 2, vertical_align = 'center' })
         Gui.add_pusher(flow)
@@ -184,9 +184,9 @@ Public.get_main_frame = function(player)
         --- Display time
         button = flow.add {
             type = 'sprite-button',
-            name = action_scroll_precision_index,
             caption = to_time[settings.precision_index],
             style = 'frame_button',
+            tags = { [Gui.tag] = action_scroll_precision_index},
         }
         data.action_scroll_precision_index = button
         Gui.set_style(button, { height = 24, width = 48, font_color = { 255, 255, 255 } })
@@ -195,11 +195,11 @@ Public.get_main_frame = function(player)
         --- Add new
         button = flow.add {
             type = 'choose-elem-button',
-            name = action_add_item,
             style = 'frame_button',
             tooltip = { 'production_hud.new_item_tooltip' },
             elem_type = 'signal',
             signal = { type = 'virtual', name = 'shape-cross' },
+            tags = { [Gui.tag] = action_add_item },
         }
         Gui.set_style(button, { size = 24, font_color = { 255, 255, 255 } })
         Gui.set_data(button, data)
@@ -315,6 +315,7 @@ Event.add(defines.events.on_player_created, function(event)
         type = 'sprite-button',
         sprite = 'utility/side_menu_production_icon',
         tooltip = { 'production_hud.feature_tooltip' },
+        tags = { [Gui.tag] = main_button_name },
     })
 
     player_settings[player.index] = {

--- a/features/gui/radio.lua
+++ b/features/gui/radio.lua
@@ -2,7 +2,6 @@ local Gui = require 'utils.gui'
 local Command = require 'utils.command'
 local Event = require 'utils.event'
 
-local main_button_name = Gui.uid_name()
 local radio_frame = Gui.uid_name()
 local close_radio = Gui.uid_name()
 
@@ -89,7 +88,7 @@ local function draw_radio(event)
         return
     end
 
-    frame = center.add {type = 'frame', name = radio_frame, caption = frame_caption, direction = 'vertical'}
+    frame = center.add {type = 'frame', name = radio_frame, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = radio_frame }}
     local scroll_pane =
         frame.add {
         type = 'scroll-pane',
@@ -152,8 +151,6 @@ local function draw_radio(event)
 
     player.opened = frame
 end
-
-Gui.on_click(main_button_name, draw_radio)
 
 Gui.on_click(
     close_radio,

--- a/features/gui/radio.lua
+++ b/features/gui/radio.lua
@@ -88,7 +88,7 @@ local function draw_radio(event)
         return
     end
 
-    frame = center.add {type = 'frame', name = radio_frame, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = radio_frame }}
+    frame = center.add {type = 'frame', name = radio_frame, caption = frame_caption, direction = 'vertical', tags = { [Gui.event_tag] = radio_frame }}
     local scroll_pane =
         frame.add {
         type = 'scroll-pane',

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -23,7 +23,7 @@ local function player_created(event)
             name = main_button_name,
             sprite = 'item/iron-gear-wheel',
             tooltip = {'redmew_settings_gui.tooltip'},
-            tags = { [Gui.tag] = main_button_name },
+            tags = { [Gui.event_tag] = main_button_name },
         }
     )
 end
@@ -89,7 +89,7 @@ local function draw_main_frame(center, player)
             name = main_frame_name,
             direction = 'vertical',
             caption = {'redmew_settings_gui.frame_title'},
-            tags = { [Gui.tag] = main_frame_name },
+            tags = { [Gui.event_tag] = main_frame_name },
         }
     )
 
@@ -154,7 +154,7 @@ local function draw_main_frame(center, player)
     left_flow.style.horizontally_stretchable = true
 
     local close_button =
-        left_flow.add({type = 'button', caption = {'redmew_settings_gui.button_cancel'}, tags = { [Gui.tag] = main_button_name }})
+        left_flow.add({type = 'button', caption = {'redmew_settings_gui.button_cancel'}, tags = { [Gui.event_tag] = main_button_name }})
     close_button.style = 'back_button'
 
     local right_flow = bottom_flow.add({type = 'flow'})
@@ -162,7 +162,7 @@ local function draw_main_frame(center, player)
 
     local save_button =
         right_flow.add(
-        {type = 'button', caption = {'redmew_settings_gui.button_save_changes'}, tags = { [Gui.tag] = save_changes_button_name }}
+        {type = 'button', caption = {'redmew_settings_gui.button_save_changes'}, tags = { [Gui.event_tag] = save_changes_button_name }}
     )
     save_button.style = 'confirm_button'
 

--- a/features/gui/redmew_settings.lua
+++ b/features/gui/redmew_settings.lua
@@ -22,7 +22,8 @@ local function player_created(event)
             type = 'sprite-button',
             name = main_button_name,
             sprite = 'item/iron-gear-wheel',
-            tooltip = {'redmew_settings_gui.tooltip'}
+            tooltip = {'redmew_settings_gui.tooltip'},
+            tags = { [Gui.tag] = main_button_name },
         }
     )
 end
@@ -87,7 +88,8 @@ local function draw_main_frame(center, player)
             type = 'frame',
             name = main_frame_name,
             direction = 'vertical',
-            caption = {'redmew_settings_gui.frame_title'}
+            caption = {'redmew_settings_gui.frame_title'},
+            tags = { [Gui.tag] = main_frame_name },
         }
     )
 
@@ -152,7 +154,7 @@ local function draw_main_frame(center, player)
     left_flow.style.horizontally_stretchable = true
 
     local close_button =
-        left_flow.add({type = 'button', name = main_button_name, caption = {'redmew_settings_gui.button_cancel'}})
+        left_flow.add({type = 'button', caption = {'redmew_settings_gui.button_cancel'}, tags = { [Gui.tag] = main_button_name }})
     close_button.style = 'back_button'
 
     local right_flow = bottom_flow.add({type = 'flow'})
@@ -160,7 +162,7 @@ local function draw_main_frame(center, player)
 
     local save_button =
         right_flow.add(
-        {type = 'button', name = save_changes_button_name, caption = {'redmew_settings_gui.button_save_changes'}}
+        {type = 'button', caption = {'redmew_settings_gui.button_save_changes'}, tags = { [Gui.tag] = save_changes_button_name }}
     )
     save_button.style = 'confirm_button'
 

--- a/features/gui/rich_text.lua
+++ b/features/gui/rich_text.lua
@@ -32,7 +32,7 @@ local function draw_rich_text(event)
         return
     end
 
-    frame = center.add {type = 'frame', name = rich_text_frame, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = rich_text_frame }}
+    frame = center.add {type = 'frame', name = rich_text_frame, caption = frame_caption, direction = 'vertical', tags = { [Gui.event_tag] = rich_text_frame }}
 
     local main_table = frame.add {type = 'table', column_count = 1}
 
@@ -56,7 +56,7 @@ local function draw_rich_text(event)
             type = 'radiobutton',
             caption = value,
             state = value == sprite_type,
-            tags = { [Gui.tag] = rich_text_image_type },
+            tags = { [Gui.event_tag] = rich_text_image_type },
         }
 
         if value == sprite_type then
@@ -70,7 +70,7 @@ local function draw_rich_text(event)
         icons_flow.add {
         type = 'choose-elem-button',
         elem_type = sprite_type,
-        tags = { [Gui.tag] = rich_text_choose_image },
+        tags = { [Gui.event_tag] = rich_text_choose_image },
     }
 
     Gui.set_data(choose, frame)
@@ -126,7 +126,7 @@ Gui.on_click(
             frame_data.icons_flow.add {
             type = 'choose-elem-button',
             elem_type = radio.caption,
-            tags = { [Gui.tag] = rich_text_choose_image },
+            tags = { [Gui.event_tag] = rich_text_choose_image },
         }
         Gui.set_data(choose, frame)
 

--- a/features/gui/rich_text.lua
+++ b/features/gui/rich_text.lua
@@ -32,7 +32,7 @@ local function draw_rich_text(event)
         return
     end
 
-    frame = center.add {type = 'frame', name = rich_text_frame, caption = frame_caption, direction = 'vertical'}
+    frame = center.add {type = 'frame', name = rich_text_frame, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = rich_text_frame }}
 
     local main_table = frame.add {type = 'table', column_count = 1}
 
@@ -52,11 +52,11 @@ local function draw_rich_text(event)
             selection_flow.style.top_margin = 7
         end
         local radio =
-            selection_flow.add({type = 'flow'}).add {
+            selection_flow.add {
             type = 'radiobutton',
-            name = rich_text_image_type,
             caption = value,
-            state = value == sprite_type
+            state = value == sprite_type,
+            tags = { [Gui.tag] = rich_text_image_type },
         }
 
         if value == sprite_type then
@@ -69,8 +69,8 @@ local function draw_rich_text(event)
     local choose =
         icons_flow.add {
         type = 'choose-elem-button',
-        name = rich_text_choose_image,
-        elem_type = sprite_type
+        elem_type = sprite_type,
+        tags = { [Gui.tag] = rich_text_choose_image },
     }
 
     Gui.set_data(choose, frame)
@@ -125,8 +125,8 @@ Gui.on_click(
         choose =
             frame_data.icons_flow.add {
             type = 'choose-elem-button',
-            name = rich_text_choose_image,
-            elem_type = radio.caption
+            elem_type = radio.caption,
+            tags = { [Gui.tag] = rich_text_choose_image },
         }
         Gui.set_data(choose, frame)
 

--- a/features/gui/score.lua
+++ b/features/gui/score.lua
@@ -96,7 +96,7 @@ local function player_created(event)
             sprite = get_score_sprite(),
             tooltip = {'score.tooltip'},
             auto_toggle = true,
-            tags = { [Gui.tag] = main_button_name},
+            tags = { [Gui.event_tag] = main_button_name},
         }
     )
 end

--- a/features/gui/score.lua
+++ b/features/gui/score.lua
@@ -96,6 +96,7 @@ local function player_created(event)
             sprite = get_score_sprite(),
             tooltip = {'score.tooltip'},
             auto_toggle = true,
+            tags = { [Gui.tag] = main_button_name},
         }
     )
 end

--- a/features/gui/shortcuts.lua
+++ b/features/gui/shortcuts.lua
@@ -84,7 +84,7 @@ local function add_shortcut_selection_row(player, parent, child)
     type = 'checkbox',
     caption = child.caption,
     state = player_data[child.name],
-    tags = { action = checkbox_action_name, name = child.name },
+    tags = { [Gui.tag] = checkbox_action_name, name = child.name },
   }
   Gui.set_style(checkbox, { minimal_width = 160, horizontally_stretchable = true })
 end
@@ -179,7 +179,7 @@ function Public.get_main_frame(player)
         sprite = s.sprite,
         hovered_sprite = s.hovered_sprite,
         tooltip = s.tooltip,
-        tags = { action = shortcut_action_name, name = button_name },
+        tags = { [Gui.tag] = shortcut_action_name, name = button_name },
       }
       Gui.set_style(button, { font_color = { 165, 165, 165 } })
       if player_data[button_name] == nil then
@@ -224,49 +224,24 @@ Gui.on_click(settings_button_name, function(event)
   Public.toggle_shortcuts_settings(event.player)
 end)
 
-Event.add(defines.events.on_gui_checked_state_changed, function(event)
+Gui.on_checked_state_changed(checkbox_action_name, function(event)
   local element = event.element
-  if not (element and element.valid) then
-    return
-  end
-
-  local player = game.get_player(event.player_index)
-  if not (player and player.valid) then
-    return
-  end
-
-  local action_name = element.tags and element.tags.action
-  if action_name and action_name == checkbox_action_name then
-    local name = element.tags.name
-    local frame = Public.get_main_frame(player)
-    for _, button in pairs(frame.children[1].table_frame.table.children) do
-      if button.tags.name == name then
-        local player_data = get_player_preferences(player)
-        player_data[name] = element.state
-        button.visible = element.state
-      end
+  local player = event.player
+  local name = element.tags.name
+  local frame = Public.get_main_frame(player)
+  for _, button in pairs(frame.children[1].table_frame.table.children) do
+    if button.tags.name == name then
+      local player_data = get_player_preferences(player)
+      player_data[name] = element.state
+      button.visible = element.state
     end
   end
 end)
 
-Event.add(defines.events.on_gui_click, function(event)
-  local element = event.element
-  if not (element and element.valid) then
-    return
-  end
-
-  local player = game.get_player(event.player_index)
-  if not (player and player.valid) then
-    return
-  end
-
-  local action_name = element.tags and element.tags.action
-  if action_name and action_name == shortcut_action_name then
-    local name = element.tags.name
-    local shortcut = shortcut_buttons[name]
-    if shortcut and shortcut.action then
-      shortcut.action(player, event)
-    end
+Gui.on_click(shortcut_action_name, function(event)
+  local shortcut = shortcut_buttons[event.element.tags.name]
+  if shortcut and shortcut.action then
+    shortcut.action(event.player, event)
   end
 end)
 

--- a/features/gui/shortcuts.lua
+++ b/features/gui/shortcuts.lua
@@ -84,7 +84,7 @@ local function add_shortcut_selection_row(player, parent, child)
     type = 'checkbox',
     caption = child.caption,
     state = player_data[child.name],
-    tags = { [Gui.tag] = checkbox_action_name, name = child.name },
+    tags = { [Gui.event_tag] = checkbox_action_name, name = child.name },
   }
   Gui.set_style(checkbox, { minimal_width = 160, horizontally_stretchable = true })
 end
@@ -99,7 +99,7 @@ function Public.on_player_created(player)
     name = main_button_name,
     sprite = 'utility/hand_black',
     tooltip = {'player_shortcuts.info_tooltip'},
-    tags = { [Gui.tag] = main_button_name },
+    tags = { [Gui.event_tag] = main_button_name },
   })
   b.style.padding = 2
 end
@@ -180,7 +180,7 @@ function Public.get_main_frame(player)
         sprite = s.sprite,
         hovered_sprite = s.hovered_sprite,
         tooltip = s.tooltip,
-        tags = { [Gui.tag] = shortcut_action_name, name = button_name },
+        tags = { [Gui.event_tag] = shortcut_action_name, name = button_name },
       }
       Gui.set_style(button, { font_color = { 165, 165, 165 } })
       if player_data[button_name] == nil then
@@ -205,7 +205,7 @@ function Public.get_main_frame(player)
       tooltip = {'player_shortcuts.settings_tooltip'},
       mouse_button_filter = { 'left' },
       auto_toggle = true,
-      tags = { [Gui.tag] = settings_button_name },
+      tags = { [Gui.event_tag] = settings_button_name },
     }
 
     local widget = right_flow.add { type = 'empty-widget', style = 'draggable_space', ignored_by_interaction = true }

--- a/features/gui/shortcuts.lua
+++ b/features/gui/shortcuts.lua
@@ -99,6 +99,7 @@ function Public.on_player_created(player)
     name = main_button_name,
     sprite = 'utility/hand_black',
     tooltip = {'player_shortcuts.info_tooltip'},
+    tags = { [Gui.tag] = main_button_name },
   })
   b.style.padding = 2
 end
@@ -199,12 +200,12 @@ function Public.get_main_frame(player)
 
     right_flow.add {
       type = 'sprite-button',
-      name = settings_button_name,
       style = 'shortcut_bar_expand_button',
       sprite = 'utility/expand_dots',
       tooltip = {'player_shortcuts.settings_tooltip'},
       mouse_button_filter = { 'left' },
       auto_toggle = true,
+      tags = { [Gui.tag] = settings_button_name },
     }
 
     local widget = right_flow.add { type = 'empty-widget', style = 'draggable_space', ignored_by_interaction = true }

--- a/features/gui/tag_group.lua
+++ b/features/gui/tag_group.lua
@@ -130,7 +130,6 @@ local edit_tag_button_name = Gui.uid_name()
 local notify_checkbox_name = Gui.uid_name()
 
 local create_tag_frame_name = Gui.uid_name()
-local create_tag_choose_icon_name = Gui.uid_name()
 local create_tag_icon_type_name = Gui.uid_name()
 local confirm_create_tag_name = Gui.uid_name()
 local delete_tag_name = Gui.uid_name()
@@ -149,6 +148,7 @@ local function player_created(event)
             caption = 'tag',
             tooltip = {'tag_group.tooltip'},
             auto_toggle = true,
+            tags = { [Gui.tag] = main_button_name },
         }
     )
 end
@@ -174,9 +174,9 @@ local function draw_main_frame_content(parent)
             local edit_button =
                 row.add {
                 type = 'sprite-button',
-                name = edit_tag_button_name,
                 sprite = 'utility/rename_icon',
-                tooltip = {'tag_group.edit_group'}
+                tooltip = {'tag_group.edit_group'},
+                tags = { [Gui.tag] = edit_tag_button_name },
             }
             edit_button.style.top_padding = 0
             edit_button.style.bottom_padding = 0
@@ -187,15 +187,15 @@ local function draw_main_frame_content(parent)
         local tag_button =
             row.add {
             type = 'sprite-button',
-            name = tag_button_name,
             sprite = path,
-            tooltip = tag_name
+            tooltip = tag_name,
+            tags = { [Gui.tag] = tag_button_name },
         }
 
         tag_button.style.maximal_height = 32
         Gui.set_data(tag_button, tag_name)
 
-        local tag_label = row.add {type = 'label', name = tag_label_name, caption = tag_name .. size}
+        local tag_label = row.add {type = 'label', caption = tag_name .. size, tags = { [Gui.tag] = tag_label_name }}
         tag_label.style.left_padding = 4
         tag_label.style.minimal_width = 120
         Gui.set_data(tag_label, {tag_name = tag_name, path = path})
@@ -247,10 +247,10 @@ local function draw_main_frame(player)
     local notify_checkbox =
         main_frame.add {
         type = 'checkbox',
-        name = notify_checkbox_name,
         state = state,
         caption = {'tag_group.notify_caption'},
-        tooltip = {'tag_group.notify_tooltip'}
+        tooltip = {'tag_group.notify_tooltip'},
+        tags = { [Gui.tag] = notify_checkbox_name },
     }
 
     local bottom_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
@@ -264,10 +264,10 @@ local function draw_main_frame(player)
     local right_flow = bottom_flow.add {type = 'flow', direction = 'horizontal'}
     right_flow.style.horizontal_align = 'right'
 
-    right_flow.add {type = 'button', name = clear_button_name, caption = {'tag_group.clear_tag'}}
+    right_flow.add {type = 'button', caption = {'tag_group.clear_tag'}, tags = { [Gui.tag] = clear_button_name }}
 
     if Rank.equal_or_greater_than(player.name, Ranks.regular) then
-        right_flow.add {type = 'button', name = create_tag_button_name, caption = {'tag_group.create_tag'}}
+        right_flow.add {type = 'button', caption = {'tag_group.create_tag'}, tags = { [Gui.tag] = create_tag_button_name }}
     end
 
     Gui.set_data(main_frame, notify_checkbox)
@@ -368,7 +368,7 @@ local function draw_create_tag_frame(event, tag_data)
         frame.destroy()
     end
 
-    frame = center.add({type = 'frame', name = create_tag_frame_name, caption = frame_caption, direction = 'vertical'})
+    frame = center.add({type = 'frame', name = create_tag_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = create_tag_frame_name }})
 
     if tag_data then
         local text = LocaleBuilder.new({'common.created_by', tag_data.created_by or '<Server>'})
@@ -393,12 +393,11 @@ local function draw_create_tag_frame(event, tag_data)
 
     local focus
     for _, value in ipairs(choices) do
-        local radio =
-            selection_flow.add({type = 'flow'}).add {
+        local radio = selection_flow.add {
             type = 'radiobutton',
-            name = create_tag_icon_type_name,
             caption = value,
-            state = value == spirte_type
+            state = value == spirte_type,
+            tags = { [Gui.tag] = create_tag_icon_type_name },
         }
 
         if value == spirte_type then
@@ -411,7 +410,6 @@ local function draw_create_tag_frame(event, tag_data)
     local choose =
         icons_flow.add {
         type = 'choose-elem-button',
-        name = create_tag_choose_icon_name,
         elem_type = spirte_type
     }
 
@@ -444,11 +442,11 @@ local function draw_create_tag_frame(event, tag_data)
     right_flow.style.horizontal_align = 'right'
 
     if tag_data then
-        local delete_button = right_flow.add {type = 'button', name = delete_tag_name, caption = {'common.delete'}}
+        local delete_button = right_flow.add {type = 'button', caption = {'common.delete'}, tags = { [Gui.tag] = delete_tag_name }}
         Gui.set_data(delete_button, frame)
     end
 
-    local confirm_button = right_flow.add {type = 'button', name = confirm_create_tag_name, caption = confirm_caption}
+    local confirm_button = right_flow.add {type = 'button', caption = confirm_caption, tags = { [Gui.tag] = confirm_create_tag_name }}
     Gui.set_data(confirm_button, frame)
 
     local data = {
@@ -596,7 +594,6 @@ Gui.on_click(
         choose =
             frame_data.icons_flow.add {
             type = 'choose-elem-button',
-            name = create_tag_choose_icon_name,
             elem_type = radio.caption
         }
 

--- a/features/gui/tag_group.lua
+++ b/features/gui/tag_group.lua
@@ -148,7 +148,7 @@ local function player_created(event)
             caption = 'tag',
             tooltip = {'tag_group.tooltip'},
             auto_toggle = true,
-            tags = { [Gui.tag] = main_button_name },
+            tags = { [Gui.event_tag] = main_button_name },
         }
     )
 end
@@ -176,7 +176,7 @@ local function draw_main_frame_content(parent)
                 type = 'sprite-button',
                 sprite = 'utility/rename_icon',
                 tooltip = {'tag_group.edit_group'},
-                tags = { [Gui.tag] = edit_tag_button_name },
+                tags = { [Gui.event_tag] = edit_tag_button_name },
             }
             edit_button.style.top_padding = 0
             edit_button.style.bottom_padding = 0
@@ -189,13 +189,13 @@ local function draw_main_frame_content(parent)
             type = 'sprite-button',
             sprite = path,
             tooltip = tag_name,
-            tags = { [Gui.tag] = tag_button_name },
+            tags = { [Gui.event_tag] = tag_button_name },
         }
 
         tag_button.style.maximal_height = 32
         Gui.set_data(tag_button, tag_name)
 
-        local tag_label = row.add {type = 'label', caption = tag_name .. size, tags = { [Gui.tag] = tag_label_name }}
+        local tag_label = row.add {type = 'label', caption = tag_name .. size, tags = { [Gui.event_tag] = tag_label_name }}
         tag_label.style.left_padding = 4
         tag_label.style.minimal_width = 120
         Gui.set_data(tag_label, {tag_name = tag_name, path = path})
@@ -250,7 +250,7 @@ local function draw_main_frame(player)
         state = state,
         caption = {'tag_group.notify_caption'},
         tooltip = {'tag_group.notify_tooltip'},
-        tags = { [Gui.tag] = notify_checkbox_name },
+        tags = { [Gui.event_tag] = notify_checkbox_name },
     }
 
     local bottom_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
@@ -264,10 +264,10 @@ local function draw_main_frame(player)
     local right_flow = bottom_flow.add {type = 'flow', direction = 'horizontal'}
     right_flow.style.horizontal_align = 'right'
 
-    right_flow.add {type = 'button', caption = {'tag_group.clear_tag'}, tags = { [Gui.tag] = clear_button_name }}
+    right_flow.add {type = 'button', caption = {'tag_group.clear_tag'}, tags = { [Gui.event_tag] = clear_button_name }}
 
     if Rank.equal_or_greater_than(player.name, Ranks.regular) then
-        right_flow.add {type = 'button', caption = {'tag_group.create_tag'}, tags = { [Gui.tag] = create_tag_button_name }}
+        right_flow.add {type = 'button', caption = {'tag_group.create_tag'}, tags = { [Gui.event_tag] = create_tag_button_name }}
     end
 
     Gui.set_data(main_frame, notify_checkbox)
@@ -368,7 +368,7 @@ local function draw_create_tag_frame(event, tag_data)
         frame.destroy()
     end
 
-    frame = center.add({type = 'frame', name = create_tag_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = create_tag_frame_name }})
+    frame = center.add({type = 'frame', name = create_tag_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.event_tag] = create_tag_frame_name }})
 
     if tag_data then
         local text = LocaleBuilder.new({'common.created_by', tag_data.created_by or '<Server>'})
@@ -397,7 +397,7 @@ local function draw_create_tag_frame(event, tag_data)
             type = 'radiobutton',
             caption = value,
             state = value == spirte_type,
-            tags = { [Gui.tag] = create_tag_icon_type_name },
+            tags = { [Gui.event_tag] = create_tag_icon_type_name },
         }
 
         if value == spirte_type then
@@ -442,11 +442,11 @@ local function draw_create_tag_frame(event, tag_data)
     right_flow.style.horizontal_align = 'right'
 
     if tag_data then
-        local delete_button = right_flow.add {type = 'button', caption = {'common.delete'}, tags = { [Gui.tag] = delete_tag_name }}
+        local delete_button = right_flow.add {type = 'button', caption = {'common.delete'}, tags = { [Gui.event_tag] = delete_tag_name }}
         Gui.set_data(delete_button, frame)
     end
 
-    local confirm_button = right_flow.add {type = 'button', caption = confirm_caption, tags = { [Gui.tag] = confirm_create_tag_name }}
+    local confirm_button = right_flow.add {type = 'button', caption = confirm_caption, tags = { [Gui.event_tag] = confirm_create_tag_name }}
     Gui.set_data(confirm_button, frame)
 
     local data = {

--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -257,7 +257,7 @@ local function redraw_tasks(data, enabled)
             type = 'sprite-button',
             sprite = 'utility/trash',
             tooltip = delete_button_tooltip,
-            tags = { [Gui.tag] = delete_task_button_name },
+            tags = { [Gui.event_tag] = delete_task_button_name },
         }
         delete_button.enabled = enabled
         apply_button_style(delete_button)
@@ -268,7 +268,7 @@ local function redraw_tasks(data, enabled)
             type = 'sprite-button',
             sprite = 'utility/rename_icon',
             tooltip = edit_button_tooltip,
-            tags = { [Gui.tag] = edit_task_button_name },
+            tags = { [Gui.event_tag] = edit_task_button_name },
         }
         edit_button.enabled = enabled
         apply_button_style(edit_button)
@@ -279,7 +279,7 @@ local function redraw_tasks(data, enabled)
             type = 'button',
             caption = '▲',
             tooltip = up_button_tooltip,
-            tags = { [Gui.tag] = move_task_up_button_name },
+            tags = { [Gui.event_tag] = move_task_up_button_name },
         }
         up_button.enabled = enabled and task_index ~= 1
         apply_direction_button_style(up_button)
@@ -289,13 +289,13 @@ local function redraw_tasks(data, enabled)
             type = 'button',
             caption = '▼',
             tooltip = down_button_tooltip,
-            tags = { [Gui.tag] = move_task_down_button_name },
+            tags = { [Gui.event_tag] = move_task_down_button_name },
         }
         down_button.enabled = enabled and task_index ~= task_count
         apply_direction_button_style(down_button)
         Gui.set_data(down_button, task_index)
 
-        local volunteer_button = parent.add {type = 'button', tags = { [Gui.tag] = volunteer_task_button_name }}
+        local volunteer_button = parent.add {type = 'button', tags = { [Gui.event_tag] = volunteer_task_button_name }}
         local volunteer_button_style = volunteer_button.style
         volunteer_button_style.font = 'default-small'
         volunteer_button_style.height = 26
@@ -346,7 +346,7 @@ local function draw_main_frame(left, player)
         type = 'sprite-button',
         sprite = 'utility/rename_icon',
         tooltip = edit_announcements_button_tooltip,
-        tags = { [Gui.tag] = announcements_edit_button_name },
+        tags = { [Gui.event_tag] = announcements_edit_button_name },
     }
     edit_announcements_button.enabled = enabled
     apply_button_style(edit_announcements_button)
@@ -379,7 +379,7 @@ local function draw_main_frame(left, player)
         type = 'sprite-button',
         sprite = 'utility/add',
         tooltip = add_task_button_tooltip,
-        tags = { [Gui.tag] = add_task_button_name },
+        tags = { [Gui.event_tag] = add_task_button_name },
     }
     add_task_button.enabled = enabled
     apply_button_style(add_task_button)
@@ -416,7 +416,7 @@ local function draw_main_frame(left, player)
         state = state,
         caption = {'tasklist.notify_caption'},
         tooltip = {'tasklist.notify_tooltip'},
-        tags = { [Gui.tag] = notify_checkbox_name },
+        tags = { [Gui.event_tag] = notify_checkbox_name },
     }
     data.notify_checkbox = notify_checkbox
 
@@ -587,7 +587,7 @@ local function draw_create_task_frame(left, previous_task)
     end
 
     local frame =
-        left.add {type = 'frame', name = create_task_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = create_task_frame_name}}
+        left.add {type = 'frame', name = create_task_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.event_tag] = create_task_frame_name}}
     frame.style.width = 470
 
     local textbox = frame.add {type = 'textfield', text = text}
@@ -599,13 +599,13 @@ local function draw_create_task_frame(left, previous_task)
     local close_button = Gui.make_close_button(bottom_flow, create_task_close_button_name)
     Gui.set_data(close_button, frame)
 
-    local clear_button = bottom_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.tag] = create_task_clear_button_name }}
+    local clear_button = bottom_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.event_tag] = create_task_clear_button_name }}
     Gui.set_data(clear_button, textbox)
 
     bottom_flow.add({type = 'flow'}).style.horizontally_stretchable = true
 
     local confirm_button =
-        bottom_flow.add {type = 'button', caption = confirm_button_caption, tags = { [Gui.tag] = confirm_button_name }}
+        bottom_flow.add {type = 'button', caption = confirm_button_caption, tags = { [Gui.event_tag] = confirm_button_name }}
     Gui.set_data(confirm_button, {frame = frame, textbox = textbox, previous_task = previous_task})
 end
 
@@ -623,7 +623,7 @@ local function player_created(event)
             tooltip = {'tasklist.tooltip'},
             number = #tasks or 0,
             auto_toggle = true,
-            tags = { [Gui.tag] = main_button_name },
+            tags = { [Gui.event_tag] = main_button_name },
         }
     )
 end
@@ -731,7 +731,7 @@ Gui.on_click(
         local editing_players_label = top_flow.add {type = 'label'}
 
         local textbox =
-            frame.add {type = 'text-box', text = announcements.edit_text, tags = { [Gui.tag] = edit_announcements_textbox_name }}
+            frame.add {type = 'text-box', text = announcements.edit_text, tags = { [Gui.event_tag] = edit_announcements_textbox_name }}
         --textbox.word_wrap = true
         local textbox_style = textbox.style
         textbox_style.width = 450
@@ -742,10 +742,10 @@ Gui.on_click(
         local bottom_flow = frame.add {type = 'flow'}
 
         local close_button = Gui.make_close_button(bottom_flow, edit_close_button_name)
-        local clear_button = bottom_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.tag] = edit_clear_button_name }}
-        local reset_button = bottom_flow.add {type = 'button', caption = 'Reset', tags = { [Gui.tag] = edit_reset_button_name }}
+        local clear_button = bottom_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.event_tag] = edit_clear_button_name }}
+        local reset_button = bottom_flow.add {type = 'button', caption = 'Reset', tags = { [Gui.event_tag] = edit_reset_button_name }}
         bottom_flow.add({type = 'flow'}).style.horizontally_stretchable = true
-        local confirm_button = bottom_flow.add {type = 'button', caption = 'Confirm', tags = { [Gui.tag] = edit_confirm_button_name }}
+        local confirm_button = bottom_flow.add {type = 'button', caption = 'Confirm', tags = { [Gui.event_tag] = edit_confirm_button_name }}
 
         Gui.set_data(close_button, frame)
         Gui.set_data(clear_button, textbox)

--- a/features/gui/tasklist.lua
+++ b/features/gui/tasklist.lua
@@ -253,50 +253,49 @@ local function redraw_tasks(data, enabled)
 
     for task_index, task in ipairs(tasks) do
         local delete_button =
-            parent.add({type = 'flow'}).add {
+            parent.add {
             type = 'sprite-button',
-            name = delete_task_button_name,
             sprite = 'utility/trash',
-            tooltip = delete_button_tooltip
+            tooltip = delete_button_tooltip,
+            tags = { [Gui.tag] = delete_task_button_name },
         }
         delete_button.enabled = enabled
         apply_button_style(delete_button)
         Gui.set_data(delete_button, task_index)
 
         local edit_button =
-            parent.add({type = 'flow'}).add {
+            parent.add {
             type = 'sprite-button',
-            name = edit_task_button_name,
             sprite = 'utility/rename_icon',
-            tooltip = edit_button_tooltip
+            tooltip = edit_button_tooltip,
+            tags = { [Gui.tag] = edit_task_button_name },
         }
         edit_button.enabled = enabled
         apply_button_style(edit_button)
         Gui.set_data(edit_button, task)
 
         local up_button =
-            parent.add({type = 'flow'}).add {
+            parent.add {
             type = 'button',
-            name = move_task_up_button_name,
             caption = '▲',
-            tooltip = up_button_tooltip
+            tooltip = up_button_tooltip,
+            tags = { [Gui.tag] = move_task_up_button_name },
         }
         up_button.enabled = enabled and task_index ~= 1
         apply_direction_button_style(up_button)
         Gui.set_data(up_button, task_index)
         local down_button =
-            parent.add({type = 'flow'}).add {
+            parent.add {
             type = 'button',
-            name = move_task_down_button_name,
             caption = '▼',
-            tooltip = down_button_tooltip
+            tooltip = down_button_tooltip,
+            tags = { [Gui.tag] = move_task_down_button_name },
         }
         down_button.enabled = enabled and task_index ~= task_count
         apply_direction_button_style(down_button)
         Gui.set_data(down_button, task_index)
 
-        local volunteer_button_flow = parent.add {type = 'flow'}
-        local volunteer_button = volunteer_button_flow.add {type = 'button', name = volunteer_task_button_name}
+        local volunteer_button = parent.add {type = 'button', tags = { [Gui.tag] = volunteer_task_button_name }}
         local volunteer_button_style = volunteer_button.style
         volunteer_button_style.font = 'default-small'
         volunteer_button_style.height = 26
@@ -345,9 +344,9 @@ local function draw_main_frame(left, player)
     local edit_announcements_button =
         announcements_header_flow.add {
         type = 'sprite-button',
-        name = announcements_edit_button_name,
         sprite = 'utility/rename_icon',
-        tooltip = edit_announcements_button_tooltip
+        tooltip = edit_announcements_button_tooltip,
+        tags = { [Gui.tag] = announcements_edit_button_name },
     }
     edit_announcements_button.enabled = enabled
     apply_button_style(edit_announcements_button)
@@ -378,9 +377,9 @@ local function draw_main_frame(left, player)
     local add_task_button =
         tasks_header_flow.add {
         type = 'sprite-button',
-        name = add_task_button_name,
         sprite = 'utility/add',
-        tooltip = add_task_button_tooltip
+        tooltip = add_task_button_tooltip,
+        tags = { [Gui.tag] = add_task_button_name },
     }
     add_task_button.enabled = enabled
     apply_button_style(add_task_button)
@@ -414,10 +413,10 @@ local function draw_main_frame(left, player)
     local notify_checkbox =
         frame.add {
         type = 'checkbox',
-        name = notify_checkbox_name,
         state = state,
         caption = {'tasklist.notify_caption'},
-        tooltip = {'tasklist.notify_tooltip'}
+        tooltip = {'tasklist.notify_tooltip'},
+        tags = { [Gui.tag] = notify_checkbox_name },
     }
     data.notify_checkbox = notify_checkbox
 
@@ -588,7 +587,7 @@ local function draw_create_task_frame(left, previous_task)
     end
 
     local frame =
-        left.add {type = 'frame', name = create_task_frame_name, caption = frame_caption, direction = 'vertical'}
+        left.add {type = 'frame', name = create_task_frame_name, caption = frame_caption, direction = 'vertical', tags = { [Gui.tag] = create_task_frame_name}}
     frame.style.width = 470
 
     local textbox = frame.add {type = 'textfield', text = text}
@@ -600,13 +599,13 @@ local function draw_create_task_frame(left, previous_task)
     local close_button = Gui.make_close_button(bottom_flow, create_task_close_button_name)
     Gui.set_data(close_button, frame)
 
-    local clear_button = bottom_flow.add {type = 'button', name = create_task_clear_button_name, caption = 'Clear'}
+    local clear_button = bottom_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.tag] = create_task_clear_button_name }}
     Gui.set_data(clear_button, textbox)
 
     bottom_flow.add({type = 'flow'}).style.horizontally_stretchable = true
 
     local confirm_button =
-        bottom_flow.add {type = 'button', name = confirm_button_name, caption = confirm_button_caption}
+        bottom_flow.add {type = 'button', caption = confirm_button_caption, tags = { [Gui.tag] = confirm_button_name }}
     Gui.set_data(confirm_button, {frame = frame, textbox = textbox, previous_task = previous_task})
 end
 
@@ -624,6 +623,7 @@ local function player_created(event)
             tooltip = {'tasklist.tooltip'},
             number = #tasks or 0,
             auto_toggle = true,
+            tags = { [Gui.tag] = main_button_name },
         }
     )
 end
@@ -731,7 +731,7 @@ Gui.on_click(
         local editing_players_label = top_flow.add {type = 'label'}
 
         local textbox =
-            frame.add {type = 'text-box', name = edit_announcements_textbox_name, text = announcements.edit_text}
+            frame.add {type = 'text-box', text = announcements.edit_text, tags = { [Gui.tag] = edit_announcements_textbox_name }}
         --textbox.word_wrap = true
         local textbox_style = textbox.style
         textbox_style.width = 450
@@ -742,10 +742,10 @@ Gui.on_click(
         local bottom_flow = frame.add {type = 'flow'}
 
         local close_button = Gui.make_close_button(bottom_flow, edit_close_button_name)
-        local clear_button = bottom_flow.add {type = 'button', name = edit_clear_button_name, caption = 'Clear'}
-        local reset_button = bottom_flow.add {type = 'button', name = edit_reset_button_name, caption = 'Reset'}
+        local clear_button = bottom_flow.add {type = 'button', caption = 'Clear', tags = { [Gui.tag] = edit_clear_button_name }}
+        local reset_button = bottom_flow.add {type = 'button', caption = 'Reset', tags = { [Gui.tag] = edit_reset_button_name }}
         bottom_flow.add({type = 'flow'}).style.horizontally_stretchable = true
-        local confirm_button = bottom_flow.add {type = 'button', name = edit_confirm_button_name, caption = 'Confirm'}
+        local confirm_button = bottom_flow.add {type = 'button', caption = 'Confirm', tags = { [Gui.tag] = edit_confirm_button_name }}
 
         Gui.set_data(close_button, frame)
         Gui.set_data(clear_button, textbox)

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -55,7 +55,7 @@ local function get_toast(element)
         return nil
     end
 
-    if element.tags[Gui.tag] == toast_frame_name then
+    if element.tags[Gui.event_tag] == toast_frame_name then
         return element.parent
     end
 
@@ -85,13 +85,13 @@ local function toast_to(player, duration, sound)
     local flow_frame = frame_holder.add { type = 'flow', direction = 'vertical' }
 
     local frame =
-        flow_frame.add({type = 'frame', direction = 'vertical', tags = { [Gui.tag] = toast_frame_name } })
+        flow_frame.add({type = 'frame', direction = 'vertical', tags = { [Gui.event_tag] = toast_frame_name } })
     frame.style.width = 300
 
-    local container = frame.add({type = 'flow', direction = 'horizontal', tags = { [Gui.tag] = toast_container_name }})
+    local container = frame.add({type = 'flow', direction = 'horizontal', tags = { [Gui.event_tag] = toast_container_name }})
     container.style.horizontally_stretchable = true
 
-    local progressbar = frame.add({type = 'progressbar', tags = { [Gui.tag] = toast_progress_name }})
+    local progressbar = frame.add({type = 'progressbar', tags = { [Gui.event_tag] = toast_progress_name }})
     local style = progressbar.style
     style.width = 290
     style.height = 4
@@ -224,7 +224,7 @@ function Public.toast_player(player, duration, message)
         player,
         duration,
         function(container)
-            local label = container.add({type = 'label', caption = message, tags = { [Gui.tag] = close_toast_name }})
+            local label = container.add({type = 'label', caption = message, tags = { [Gui.event_tag] = close_toast_name }})
             label.style.single_line = false
         end
     )

--- a/features/gui/toast.lua
+++ b/features/gui/toast.lua
@@ -31,7 +31,6 @@ Global.register(
     'toast'
 )
 
-local toast_flow_name = Gui.uid_name()
 local toast_frame_name = Gui.uid_name()
 local toast_container_name = Gui.uid_name()
 local toast_progress_name = Gui.uid_name()
@@ -56,7 +55,7 @@ local function get_toast(element)
         return nil
     end
 
-    if element.name == toast_frame_name then
+    if element.tags[Gui.tag] == toast_frame_name then
         return element.parent
     end
 
@@ -81,18 +80,18 @@ end
 ---@param duration number in seconds
 ---@param sound string sound to play, nil to not play anything
 local function toast_to(player, duration, sound)
-    local frame_holder = Gui.add_left_element(player, { type = 'flow', name = toast_flow_name, direction = 'vertical' })
+    local frame_holder = Gui.add_left_element(player, { type = 'flow', direction = 'vertical' })
 
     local flow_frame = frame_holder.add { type = 'flow', direction = 'vertical' }
 
     local frame =
-        flow_frame.add({type = 'frame', name = toast_frame_name, direction = 'vertical' })
+        flow_frame.add({type = 'frame', direction = 'vertical', tags = { [Gui.tag] = toast_frame_name } })
     frame.style.width = 300
 
-    local container = frame.add({type = 'flow', name = toast_container_name, direction = 'horizontal'})
+    local container = frame.add({type = 'flow', direction = 'horizontal', tags = { [Gui.tag] = toast_container_name }})
     container.style.horizontally_stretchable = true
 
-    local progressbar = frame.add({type = 'progressbar', name = toast_progress_name})
+    local progressbar = frame.add({type = 'progressbar', tags = { [Gui.tag] = toast_progress_name }})
     local style = progressbar.style
     style.width = 290
     style.height = 4
@@ -225,7 +224,7 @@ function Public.toast_player(player, duration, message)
         player,
         duration,
         function(container)
-            local label = container.add({type = 'label', name = close_toast_name, caption = message})
+            local label = container.add({type = 'label', caption = message, tags = { [Gui.tag] = close_toast_name }})
             label.style.single_line = false
         end
     )

--- a/features/infinite_storage_chest.lua
+++ b/features/infinite_storage_chest.lua
@@ -214,7 +214,8 @@ local function gui_opened(event)
         type = 'frame',
         name = chest_gui_frame_name,
         caption = 'Infinite Storage Chest',
-        direction = 'vertical'
+        direction = 'vertical',
+        tags = { [Gui.tag] = chest_gui_frame_name },
     }
 
     local text =

--- a/features/infinite_storage_chest.lua
+++ b/features/infinite_storage_chest.lua
@@ -215,7 +215,7 @@ local function gui_opened(event)
         name = chest_gui_frame_name,
         caption = 'Infinite Storage Chest',
         direction = 'vertical',
-        tags = { [Gui.tag] = chest_gui_frame_name },
+        tags = { [Gui.event_tag] = chest_gui_frame_name },
     }
 
     local text =

--- a/features/market_chest.lua
+++ b/features/market_chest.lua
@@ -15,8 +15,7 @@ local b_bucket = Buckets.get_bucket
 local register_on_object_destroyed = script.register_on_object_destroyed
 
 local relative_frame_name = Gui.uid_name()
-local offer_tag_name = Gui.uid_name()
-local request_tag_name = Gui.uid_name()
+local button_tag_name = Gui.uid_name()
 local standard_market_name = 'fish_market'
 
 -- What market provides
@@ -222,7 +221,7 @@ Event.add(defines.events.on_gui_opened, function(event)
       sprite = 'item/'..name,
       number = value,
       tooltip = {'market_chest.item_tooltip', value},
-      tags = { name = request_tag_name, item = name, id = entity.unit_number },
+      tags = { [Gui.tag] = button_tag_name, name = 'request', item = name, id = entity.unit_number },
       toggled = data.request and data.request == name,
     }
     Gui.set_data(button, tables)
@@ -239,7 +238,7 @@ Event.add(defines.events.on_gui_opened, function(event)
       sprite = 'item/'..name,
       number = value,
       tooltip = {'market_chest.item_tooltip', value},
-      tags = { name = offer_tag_name, item = name, id = entity.unit_number },
+      tags = { [Gui.tag] = button_tag_name, name = 'offer', item = name, id = entity.unit_number },
       toggled = data.offer and data.offer == name,
     }
     Gui.set_data(button, tables)
@@ -248,17 +247,8 @@ Event.add(defines.events.on_gui_opened, function(event)
   this.relative_gui[event.player_index] = frame
 end)
 
-Event.add(defines.events.on_gui_click, function(event)
+Gui.on_click(button_tag_name, function(event)
   local element = event.element
-  if not (element and element.valid) then
-    return
-  end
-
-  local tag = element.tags and element.tags.name
-  if not tag or not (tag == request_tag_name or tag == offer_tag_name) then
-    return
-  end
-
   local toggled = not element.toggled
   for _, button in pairs(element.parent.children) do
     button.toggled = false
@@ -268,9 +258,9 @@ Event.add(defines.events.on_gui_click, function(event)
   local item_name = element.tags.item
   local data = b_get(this.chests, element.tags.id)
 
-  if tag == request_tag_name then
+  if element.tags.name == 'request' then
     data.request = toggled and item_name or nil
-  elseif tag == offer_tag_name then
+  elseif element.tags.name == 'offer' then
     data.offer = toggled and item_name or nil
   end
 

--- a/features/market_chest.lua
+++ b/features/market_chest.lua
@@ -221,7 +221,7 @@ Event.add(defines.events.on_gui_opened, function(event)
       sprite = 'item/'..name,
       number = value,
       tooltip = {'market_chest.item_tooltip', value},
-      tags = { [Gui.tag] = button_tag_name, name = 'request', item = name, id = entity.unit_number },
+      tags = { [Gui.event_tag] = button_tag_name, name = 'request', item = name, id = entity.unit_number },
       toggled = data.request and data.request == name,
     }
     Gui.set_data(button, tables)
@@ -238,7 +238,7 @@ Event.add(defines.events.on_gui_opened, function(event)
       sprite = 'item/'..name,
       number = value,
       tooltip = {'market_chest.item_tooltip', value},
-      tags = { [Gui.tag] = button_tag_name, name = 'offer', item = name, id = entity.unit_number },
+      tags = { [Gui.event_tag] = button_tag_name, name = 'offer', item = name, id = entity.unit_number },
       toggled = data.offer and data.offer == name,
     }
     Gui.set_data(button, tables)

--- a/features/redmew_qol.lua
+++ b/features/redmew_qol.lua
@@ -337,14 +337,8 @@ end
 
 local loader_crafter_frame_for_player_name = Gui.uid_name()
 local loader_crafter_frame_for_assembly_machine_name = Gui.uid_name()
-local player_craft_loader_1 = Gui.uid_name()
-local player_craft_loader_2 = Gui.uid_name()
-local player_craft_loader_3 = Gui.uid_name()
-local player_craft_loader_4 = Gui.uid_name()
-local machine_craft_loader_1 = Gui.uid_name()
-local machine_craft_loader_2 = Gui.uid_name()
-local machine_craft_loader_3 = Gui.uid_name()
-local machine_craft_loader_4 = Gui.uid_name()
+local player_craft_loader_btn = Gui.uid_name()
+local machine_craft_loader_btn = Gui.uid_name()
 
 local open_gui_token = Token.register(function(data)
     local player = data.player
@@ -387,9 +381,9 @@ local function draw_loader_frame_for_player(parent, player)
     if recipes['loader'] and recipes['loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = player_craft_loader_1,
             elem_type = 'recipe',
-            recipe = 'loader'
+            recipe = 'loader',
+            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'loader' },
         }
         button.locked = true
     end
@@ -397,9 +391,9 @@ local function draw_loader_frame_for_player(parent, player)
     if recipes['fast-loader'] and recipes['fast-loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = player_craft_loader_2,
             elem_type = 'recipe',
-            recipe = 'fast-loader'
+            recipe = 'fast-loader',
+            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'fast-loader' },
         }
         button.locked = true
     end
@@ -407,9 +401,9 @@ local function draw_loader_frame_for_player(parent, player)
     if recipes['express-loader'] and recipes['express-loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = player_craft_loader_3,
             elem_type = 'recipe',
-            recipe = 'express-loader'
+            recipe = 'express-loader',
+            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'express-loader' },
         }
         button.locked = true
     end
@@ -417,9 +411,9 @@ local function draw_loader_frame_for_player(parent, player)
     if recipes['turbo-loader'] and recipes['turbo-loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = player_craft_loader_4,
             elem_type = 'recipe',
-            recipe = 'turbo-loader'
+            recipe = 'turbo-loader',
+            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'turbo-loader' },
         }
         button.locked = true
     end
@@ -454,9 +448,9 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
     if recipes['loader'] and recipes['loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = machine_craft_loader_1,
             elem_type = 'recipe',
-            recipe = 'loader'
+            recipe = 'loader',
+            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)
@@ -465,9 +459,9 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
     if recipes['fast-loader'] and recipes['fast-loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = machine_craft_loader_2,
             elem_type = 'recipe',
-            recipe = 'fast-loader'
+            recipe = 'fast-loader',
+            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'fast-loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)
@@ -476,9 +470,9 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
     if recipes['express-loader'] and recipes['express-loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = machine_craft_loader_3,
             elem_type = 'recipe',
-            recipe = 'express-loader'
+            recipe = 'express-loader',
+            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'express-loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)
@@ -487,16 +481,17 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
     if recipes['turbo-loader'] and recipes['turbo-loader'].enabled then
         local button = frame.add {
             type = 'choose-elem-button',
-            name = machine_craft_loader_4,
             elem_type = 'recipe',
-            recipe = 'turbo-loader'
+            recipe = 'turbo-loader',
+            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'turbo-loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)
     end
 end
 
-local function player_craft_loaders(event, loader_name)
+local function player_craft_loaders(event)
+    local loader_name = event.tags.loader_name
     local player = event.player
     if not player.force.recipes[loader_name].enabled then
         return
@@ -520,23 +515,10 @@ local function player_craft_loaders(event, loader_name)
     player.begin_crafting {count = count, recipe = loader_name}
 end
 
-Gui.on_click(player_craft_loader_1, function(event)
-    player_craft_loaders(event, 'loader')
-end)
+Gui.on_click(player_craft_loader_btn, player_craft_loaders)
 
-Gui.on_click(player_craft_loader_2, function(event)
-    player_craft_loaders(event, 'fast-loader')
-end)
-
-Gui.on_click(player_craft_loader_3, function(event)
-    player_craft_loaders(event, 'express-loader')
-end)
-
-Gui.on_click(player_craft_loader_4, function(event)
-    player_craft_loaders(event, 'turbo-loader')
-end)
-
-local function set_assembly_machine_recipe(event, loader_name)
+local function set_assembly_machine_recipe(event)
+    local loader_name = event.tags.loader_name
     if not event.player.force.recipes[loader_name].enabled then
         return
     end
@@ -547,21 +529,7 @@ local function set_assembly_machine_recipe(event, loader_name)
     Task.set_timeout_in_ticks(2, open_gui_token, {player = event.player, entity = entity})
 end
 
-Gui.on_click(machine_craft_loader_1, function(event)
-    set_assembly_machine_recipe(event, 'loader')
-end)
-
-Gui.on_click(machine_craft_loader_2, function(event)
-    set_assembly_machine_recipe(event, 'fast-loader')
-end)
-
-Gui.on_click(machine_craft_loader_3, function(event)
-    set_assembly_machine_recipe(event, 'express-loader')
-end)
-
-Gui.on_click(machine_craft_loader_4, function(event)
-    set_assembly_machine_recipe(event, 'turbo-loader')
-end)
+Gui.on_click(machine_craft_loader_btn, set_assembly_machine_recipe)
 
 if config.loaders then
     Event.add(defines.events.on_research_finished, function(event)

--- a/features/redmew_qol.lua
+++ b/features/redmew_qol.lua
@@ -383,7 +383,7 @@ local function draw_loader_frame_for_player(parent, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'loader',
-            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'loader' },
+            tags = { [Gui.event_tag] = player_craft_loader_btn, loader_name = 'loader' },
         }
         button.locked = true
     end
@@ -393,7 +393,7 @@ local function draw_loader_frame_for_player(parent, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'fast-loader',
-            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'fast-loader' },
+            tags = { [Gui.event_tag] = player_craft_loader_btn, loader_name = 'fast-loader' },
         }
         button.locked = true
     end
@@ -403,7 +403,7 @@ local function draw_loader_frame_for_player(parent, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'express-loader',
-            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'express-loader' },
+            tags = { [Gui.event_tag] = player_craft_loader_btn, loader_name = 'express-loader' },
         }
         button.locked = true
     end
@@ -413,7 +413,7 @@ local function draw_loader_frame_for_player(parent, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'turbo-loader',
-            tags = { [Gui.tag] = player_craft_loader_btn, loader_name = 'turbo-loader' },
+            tags = { [Gui.event_tag] = player_craft_loader_btn, loader_name = 'turbo-loader' },
         }
         button.locked = true
     end
@@ -450,7 +450,7 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'loader',
-            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'loader' },
+            tags = { [Gui.event_tag] = machine_craft_loader_btn, loader_name = 'loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)
@@ -461,7 +461,7 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'fast-loader',
-            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'fast-loader' },
+            tags = { [Gui.event_tag] = machine_craft_loader_btn, loader_name = 'fast-loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)
@@ -472,7 +472,7 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'express-loader',
-            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'express-loader' },
+            tags = { [Gui.event_tag] = machine_craft_loader_btn, loader_name = 'express-loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)
@@ -483,7 +483,7 @@ local function draw_loader_frame_for_assembly_machine(parent, entity, player)
             type = 'choose-elem-button',
             elem_type = 'recipe',
             recipe = 'turbo-loader',
-            tags = { [Gui.tag] = machine_craft_loader_btn, loader_name = 'turbo-loader' },
+            tags = { [Gui.event_tag] = machine_craft_loader_btn, loader_name = 'turbo-loader' },
         }
         button.locked = true
         Gui.set_data(button, entity)

--- a/features/report.lua
+++ b/features/report.lua
@@ -88,8 +88,8 @@ local function draw_report(parent, report_id)
     local msg_label = msg_label_pane.add {type = 'label', caption = 'Message: ' .. message}
     local jail_offender_button = parent.add {
         type = 'button',
-        name = jail_offender_button_name,
-        caption = jail_offender_button_caption
+        caption = jail_offender_button_caption,
+        tags = { [Gui.tag] = jail_offender_button_name },
     }
     jail_offender_button.style.height = 24
     jail_offender_button.style.font = 'default-small'
@@ -117,7 +117,8 @@ Module.show_reports = function(player)
         type = 'frame',
         name = report_frame_name,
         direction = 'vertical',
-        caption = 'User reports'
+        caption = 'User reports',
+        tags = { [Gui.tag] = report_frame_name },
     }
     report_frame.style.maximal_width = 700
     player.opened = report_frame
@@ -133,8 +134,8 @@ Module.show_reports = function(player)
             local button_cell = tab_flow.add {type = 'flow', caption = 'reportuid' .. k}
             button_cell.add {
                 type = 'button',
-                name = report_tab_button_name,
-                caption = game.get_player(report.reported_player_index).name
+                caption = game.get_player(report.reported_player_index).name,
+                tags = { [Gui.tag] = report_tab_button_name },
             }
         end
     end
@@ -144,7 +145,7 @@ Module.show_reports = function(player)
         horizontal_scroll_policy = 'never',
         vertical_scroll_policy = 'never'
     }
-    report_frame.add {type = 'button', name = report_close_button_name, caption = 'Close'}
+    report_frame.add {type = 'button', caption = 'Close', tags = { [Gui.tag] = report_close_button_name }}
 
     draw_report(report_body, #reports)
 end

--- a/features/report.lua
+++ b/features/report.lua
@@ -89,7 +89,7 @@ local function draw_report(parent, report_id)
     local jail_offender_button = parent.add {
         type = 'button',
         caption = jail_offender_button_caption,
-        tags = { [Gui.tag] = jail_offender_button_name },
+        tags = { [Gui.event_tag] = jail_offender_button_name },
     }
     jail_offender_button.style.height = 24
     jail_offender_button.style.font = 'default-small'
@@ -118,7 +118,7 @@ Module.show_reports = function(player)
         name = report_frame_name,
         direction = 'vertical',
         caption = 'User reports',
-        tags = { [Gui.tag] = report_frame_name },
+        tags = { [Gui.event_tag] = report_frame_name },
     }
     report_frame.style.maximal_width = 700
     player.opened = report_frame
@@ -135,7 +135,7 @@ Module.show_reports = function(player)
             button_cell.add {
                 type = 'button',
                 caption = game.get_player(report.reported_player_index).name,
-                tags = { [Gui.tag] = report_tab_button_name },
+                tags = { [Gui.event_tag] = report_tab_button_name },
             }
         end
     end
@@ -145,7 +145,7 @@ Module.show_reports = function(player)
         horizontal_scroll_policy = 'never',
         vertical_scroll_policy = 'never'
     }
-    report_frame.add {type = 'button', caption = 'Close', tags = { [Gui.tag] = report_close_button_name }}
+    report_frame.add {type = 'button', caption = 'Close', tags = { [Gui.event_tag] = report_close_button_name }}
 
     draw_report(report_body, #reports)
 end

--- a/features/restart_command.lua
+++ b/features/restart_command.lua
@@ -299,7 +299,8 @@ local function draw_main_frame(player)
         type = 'frame',
         name = main_frame_name,
         caption = 'Configure Restart',
-        direction = 'vertical'
+        direction = 'vertical',
+        tags = { [Gui.tag] = main_frame_name },
     }
 
     local is_scenario = start_game_data.type == game_types.scenario
@@ -307,15 +308,15 @@ local function draw_main_frame(player)
     radio_button_flow.add {type = 'label', caption = 'Type:'}
     local scenario_radio_button = radio_button_flow.add {
         type = 'radiobutton',
-        name = scenario_radio_button_name,
         caption = 'scenario',
-        state = is_scenario
+        state = is_scenario,
+        tags = { [Gui.tag] = scenario_radio_button_name },
     }
     local save_radio_button = radio_button_flow.add {
         type = 'radiobutton',
-        name = save_radio_button_name,
         caption = 'save',
-        state = not is_scenario
+        state = not is_scenario,
+        tags = { [Gui.tag] = save_radio_button_name },
     }
 
     local radio_data = {scenario_radio_button = scenario_radio_button, save_radio_button = save_radio_button}
@@ -325,23 +326,23 @@ local function draw_main_frame(player)
 
     local name_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
     name_flow.add {type = 'label', caption = 'Name:'}
-    local name_textfield = name_flow.add {type = 'textfield', name = name_textfield_name, text = start_game_data.name}
+    local name_textfield = name_flow.add {type = 'textfield', text = start_game_data.name, tags = { [Gui.tag] = name_textfield_name }}
     name_textfield.style.horizontally_stretchable = true
     name_textfield.style.maximal_width = 600
 
     local is_set_mod_pack = start_game_data.mod_pack ~= nil
     local set_mod_pack_checkbox = main_frame.add {
         type = 'checkbox',
-        name = set_mod_pack_checkbox_name,
         caption = 'Set mod pack (uncheck to not change current)',
-        state = is_set_mod_pack
+        state = is_set_mod_pack,
+        tags = { [Gui.tag] = set_mod_pack_checkbox_name },
     }
     local mod_pack_name_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
     mod_pack_name_flow.add {type = 'label', caption = 'Mod Pack (empty to set none):'}
     local mod_pack_name_textfield = mod_pack_name_flow.add {
         type = 'textfield',
-        name = mod_pack_name_textfield_name,
-        text = memory.mod_pack_text
+        text = memory.mod_pack_text,
+        tags = { [Gui.tag] = mod_pack_name_textfield_name },
     }
     mod_pack_name_textfield.enabled = is_set_mod_pack
 
@@ -350,9 +351,9 @@ local function draw_main_frame(player)
     if memory.use_map_poll_result ~= nil then
         main_frame.add {
             type = 'checkbox',
-            name = use_map_poll_result_checkbox_name,
             caption = 'Use map poll result',
-            state = memory.use_map_poll_result
+            state = memory.use_map_poll_result,
+            tags = { [Gui.tag] = use_map_poll_result_checkbox_name },
         }
     end
 
@@ -360,7 +361,7 @@ local function draw_main_frame(player)
         for mod_pack_name, mod_pack_value in pairs(memory.known_mod_packs) do
             local mod_pack_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
             mod_pack_flow.add {type = 'label', caption = mod_pack_name .. ':'}
-            local mod_pack_textfield = mod_pack_flow.add {type = 'textfield', name = known_mod_pack_textfield_name, text = mod_pack_value}
+            local mod_pack_textfield = mod_pack_flow.add {type = 'textfield', text = mod_pack_value, tags = { [Gui.tag] = known_mod_pack_textfield_name } }
             Gui.set_data(mod_pack_textfield, mod_pack_name)
         end
     end
@@ -372,9 +373,9 @@ local function draw_main_frame(player)
 
     bottom_flow.add {
         type = 'button',
-        name = close_button_name,
         caption = {'common.close_button'},
-        style = 'back_button'
+        style = 'back_button',
+        tags = { [Gui.tag] = close_button_name },
     }
 end
 

--- a/features/restart_command.lua
+++ b/features/restart_command.lua
@@ -300,7 +300,7 @@ local function draw_main_frame(player)
         name = main_frame_name,
         caption = 'Configure Restart',
         direction = 'vertical',
-        tags = { [Gui.tag] = main_frame_name },
+        tags = { [Gui.event_tag] = main_frame_name },
     }
 
     local is_scenario = start_game_data.type == game_types.scenario
@@ -310,13 +310,13 @@ local function draw_main_frame(player)
         type = 'radiobutton',
         caption = 'scenario',
         state = is_scenario,
-        tags = { [Gui.tag] = scenario_radio_button_name },
+        tags = { [Gui.event_tag] = scenario_radio_button_name },
     }
     local save_radio_button = radio_button_flow.add {
         type = 'radiobutton',
         caption = 'save',
         state = not is_scenario,
-        tags = { [Gui.tag] = save_radio_button_name },
+        tags = { [Gui.event_tag] = save_radio_button_name },
     }
 
     local radio_data = {scenario_radio_button = scenario_radio_button, save_radio_button = save_radio_button}
@@ -326,7 +326,7 @@ local function draw_main_frame(player)
 
     local name_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
     name_flow.add {type = 'label', caption = 'Name:'}
-    local name_textfield = name_flow.add {type = 'textfield', text = start_game_data.name, tags = { [Gui.tag] = name_textfield_name }}
+    local name_textfield = name_flow.add {type = 'textfield', text = start_game_data.name, tags = { [Gui.event_tag] = name_textfield_name }}
     name_textfield.style.horizontally_stretchable = true
     name_textfield.style.maximal_width = 600
 
@@ -335,14 +335,14 @@ local function draw_main_frame(player)
         type = 'checkbox',
         caption = 'Set mod pack (uncheck to not change current)',
         state = is_set_mod_pack,
-        tags = { [Gui.tag] = set_mod_pack_checkbox_name },
+        tags = { [Gui.event_tag] = set_mod_pack_checkbox_name },
     }
     local mod_pack_name_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
     mod_pack_name_flow.add {type = 'label', caption = 'Mod Pack (empty to set none):'}
     local mod_pack_name_textfield = mod_pack_name_flow.add {
         type = 'textfield',
         text = memory.mod_pack_text,
-        tags = { [Gui.tag] = mod_pack_name_textfield_name },
+        tags = { [Gui.event_tag] = mod_pack_name_textfield_name },
     }
     mod_pack_name_textfield.enabled = is_set_mod_pack
 
@@ -353,7 +353,7 @@ local function draw_main_frame(player)
             type = 'checkbox',
             caption = 'Use map poll result',
             state = memory.use_map_poll_result,
-            tags = { [Gui.tag] = use_map_poll_result_checkbox_name },
+            tags = { [Gui.event_tag] = use_map_poll_result_checkbox_name },
         }
     end
 
@@ -361,7 +361,7 @@ local function draw_main_frame(player)
         for mod_pack_name, mod_pack_value in pairs(memory.known_mod_packs) do
             local mod_pack_flow = main_frame.add {type = 'flow', direction = 'horizontal'}
             mod_pack_flow.add {type = 'label', caption = mod_pack_name .. ':'}
-            local mod_pack_textfield = mod_pack_flow.add {type = 'textfield', text = mod_pack_value, tags = { [Gui.tag] = known_mod_pack_textfield_name } }
+            local mod_pack_textfield = mod_pack_flow.add {type = 'textfield', text = mod_pack_value, tags = { [Gui.event_tag] = known_mod_pack_textfield_name } }
             Gui.set_data(mod_pack_textfield, mod_pack_name)
         end
     end
@@ -375,7 +375,7 @@ local function draw_main_frame(player)
         type = 'button',
         caption = {'common.close_button'},
         style = 'back_button',
-        tags = { [Gui.tag] = close_button_name },
+        tags = { [Gui.event_tag] = close_button_name },
     }
 end
 

--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -324,12 +324,12 @@ local function redraw_market_items(data)
                 :add({'retailer.item_with_player_limit_description', item_player_limit - player_limit, item_player_limit})
         end
 
-        local button = grid.add({type = 'flow'}).add({
+        local button = grid.add({
             type = 'sprite-button',
-            name = item_button_name,
             sprite = item.sprite,
             number = stack_count,
             tooltip = tooltip,
+            tags = { [Gui.tag] = item_button_name },
         })
         button.style = 'slot_button'
 
@@ -363,6 +363,7 @@ local function draw_market_frame(player, group_name)
         name = market_frame_name,
         caption = Retailer.get_market_group_label(group_name),
         direction = 'vertical',
+        tags = { [Gui.tag] = market_frame_name },
     })
 
     local scroll_pane = frame.add({type = 'scroll-pane'})
@@ -393,19 +394,19 @@ local function draw_market_frame(player, group_name)
 
     local count_text = bottom_grid.add({
         type = 'text-box',
-        name = count_text_name,
         text = '1',
+        tags = { [Gui.tag] = count_text_name },
     })
 
     local count_slider = frame.add({
         type = 'slider',
-        name = count_slider_name,
         minimum_value = 1,
         maximum_value = 7,
         value = 1,
+        tags = { [Gui.tag] = count_slider_name },
     })
 
-    frame.add({name = market_frame_close_button_name, type = 'button', caption = 'Close'})
+    frame.add({type = 'button', caption = 'Close', tags = { [Gui.tag] = market_frame_close_button_name }})
 
     count_slider.style.width = 115
     count_text.style.width = 45

--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -329,7 +329,7 @@ local function redraw_market_items(data)
             sprite = item.sprite,
             number = stack_count,
             tooltip = tooltip,
-            tags = { [Gui.tag] = item_button_name },
+            tags = { [Gui.event_tag] = item_button_name },
         })
         button.style = 'slot_button'
 
@@ -363,7 +363,7 @@ local function draw_market_frame(player, group_name)
         name = market_frame_name,
         caption = Retailer.get_market_group_label(group_name),
         direction = 'vertical',
-        tags = { [Gui.tag] = market_frame_name },
+        tags = { [Gui.event_tag] = market_frame_name },
     })
 
     local scroll_pane = frame.add({type = 'scroll-pane'})
@@ -395,7 +395,7 @@ local function draw_market_frame(player, group_name)
     local count_text = bottom_grid.add({
         type = 'text-box',
         text = '1',
-        tags = { [Gui.tag] = count_text_name },
+        tags = { [Gui.event_tag] = count_text_name },
     })
 
     local count_slider = frame.add({
@@ -403,10 +403,10 @@ local function draw_market_frame(player, group_name)
         minimum_value = 1,
         maximum_value = 7,
         value = 1,
-        tags = { [Gui.tag] = count_slider_name },
+        tags = { [Gui.event_tag] = count_slider_name },
     })
 
-    frame.add({type = 'button', caption = 'Close', tags = { [Gui.tag] = market_frame_close_button_name }})
+    frame.add({type = 'button', caption = 'Close', tags = { [Gui.event_tag] = market_frame_close_button_name }})
 
     count_slider.style.width = 115
     count_text.style.width = 45

--- a/features/snake/gui.lua
+++ b/features/snake/gui.lua
@@ -15,7 +15,7 @@ local function show_gui_for_player(player)
         type = 'button',
         name = main_button_name,
         caption = {'snake.name'},
-        tags = { [Gui.tag] = main_button_name },
+        tags = { [Gui.event_tag] = main_button_name },
     })
 end
 

--- a/features/snake/gui.lua
+++ b/features/snake/gui.lua
@@ -14,7 +14,8 @@ local function show_gui_for_player(player)
     Gui.add_top_element(player, {
         type = 'button',
         name = main_button_name,
-        caption = {'snake.name'}
+        caption = {'snake.name'},
+        tags = { [Gui.tag] = main_button_name },
     })
 end
 

--- a/features/train_station_teleport.lua
+++ b/features/train_station_teleport.lua
@@ -49,7 +49,7 @@ Event.add(defines.events.on_gui_opened, function(event)
   local canvas = frame.add { type = 'frame', style = 'inside_deep_frame', direction = 'vertical' }
   Gui.set_style(canvas, { padding = 4 })
 
-  local button = canvas.add { type = 'button', caption = 'Teleport' , style = 'confirm_button_without_tooltip', tags = { [Gui.tag] = teleport_button_name } }
+  local button = canvas.add { type = 'button', caption = 'Teleport' , style = 'confirm_button_without_tooltip', tags = { [Gui.event_tag] = teleport_button_name } }
   Gui.set_data(button, { entity = entity })
 
   this.relative_gui[event.player_index] = frame

--- a/features/train_station_teleport.lua
+++ b/features/train_station_teleport.lua
@@ -6,7 +6,6 @@ local Gui = require 'utils.gui'
 local Global = require 'utils.global'
 local config = require 'config'.train_station_teleport
 
-local relative_frame_name = Gui.uid_name()
 local teleport_button_name = Gui.uid_name()
 
 local this = {
@@ -39,7 +38,6 @@ Event.add(defines.events.on_gui_opened, function(event)
   local player = game.get_player(event.player_index)
   local frame = player.gui.relative.add {
     type = 'frame',
-    name = relative_frame_name,
     direction = 'vertical',
     anchor = {
       gui = defines.relative_gui_type.train_stop_gui,
@@ -51,7 +49,7 @@ Event.add(defines.events.on_gui_opened, function(event)
   local canvas = frame.add { type = 'frame', style = 'inside_deep_frame', direction = 'vertical' }
   Gui.set_style(canvas, { padding = 4 })
 
-  local button = canvas.add { type = 'button', name = teleport_button_name, caption = 'Teleport' , style = 'confirm_button_without_tooltip' }
+  local button = canvas.add { type = 'button', caption = 'Teleport' , style = 'confirm_button_without_tooltip', tags = { [Gui.tag] = teleport_button_name } }
   Gui.set_data(button, { entity = entity })
 
   this.relative_gui[event.player_index] = frame

--- a/map_gen/maps/crash_site/crash_site_toast.lua
+++ b/map_gen/maps/crash_site/crash_site_toast.lua
@@ -13,9 +13,9 @@ function Public.do_outpost_toast(market, message)
             local sprite =
                 container.add {
                 type = 'sprite-button',
-                name = find_outpost_name,
                 sprite = 'utility/search_icon',
-                style = 'slot_button'
+                style = 'slot_button',
+                tags = { [Gui.tag] = find_outpost_name },
             }
 
             Gui.set_data(sprite, { position = market.position, surface_index = market.surface.index })
@@ -23,8 +23,8 @@ function Public.do_outpost_toast(market, message)
             local label =
                 container.add {
                 type = 'label',
-                name = Toast.close_toast_name,
-                caption = message
+                caption = message,
+                tags = { [Gui.tag] = Toast.close_toast_name },
             }
             local label_style = label.style
             label_style.single_line = false

--- a/map_gen/maps/crash_site/crash_site_toast.lua
+++ b/map_gen/maps/crash_site/crash_site_toast.lua
@@ -15,7 +15,7 @@ function Public.do_outpost_toast(market, message)
                 type = 'sprite-button',
                 sprite = 'utility/search_icon',
                 style = 'slot_button',
-                tags = { [Gui.tag] = find_outpost_name },
+                tags = { [Gui.event_tag] = find_outpost_name },
             }
 
             Gui.set_data(sprite, { position = market.position, surface_index = market.surface.index })
@@ -24,7 +24,7 @@ function Public.do_outpost_toast(market, message)
                 container.add {
                 type = 'label',
                 caption = message,
-                tags = { [Gui.tag] = Toast.close_toast_name },
+                tags = { [Gui.event_tag] = Toast.close_toast_name },
             }
             local label_style = label.style
             label_style.single_line = false

--- a/map_gen/maps/frontier/modules/restart.lua
+++ b/map_gen/maps/frontier/modules/restart.lua
@@ -2,7 +2,6 @@ local AdminPanel = require 'features.gui.admin_panel.core'
 local Color = require 'resources.color_presets'
 local Core = require 'utils.core'
 local Discord = require 'resources.discord'
-local Event = require 'utils.event'
 local Global = require 'utils.global'
 local Gui = require 'utils.gui'
 local PlayerStats = require 'features.player_stats'
@@ -130,13 +129,13 @@ local function show_values(parent, parent_data, params)
   local current = flow.add {
     type = 'text-box',
     style = 'short_number_textfield',
-    tags = { name = textbox_tag_name },
+    tags = { [Gui.tag] = textbox_tag_name },
     text = current_value,
   }
   local modifier = flow.add {
     type = 'text-box',
     style = 'short_number_textfield',
-    tags = { name = textbox_tag_name },
+    tags = { [Gui.tag] = textbox_tag_name },
     text = modifier_value,
   }
   local predicted = flow.add {
@@ -342,22 +341,10 @@ Gui.on_click(main_button_name, function(event)
   end
 end)
 
-Event.add(defines.events.on_gui_text_changed, function(event)
-  local element = event.element
-  if not (element and element.valid) then
-    return
-  end
-
-  local tag = element.tags and element.tags.name
-  if not tag then
-    return
-  end
-
-  if tag == textbox_tag_name then
-    local data = Gui.get_data(element)
-    local current, modifier = data.current, data.modifier
-    data.predicted.text = tostring(safe_add(current.text, modifier.text))
-  end
+Gui.on_text_changed(textbox_tag_name, function(event)
+  local data = Gui.get_data(event.element)
+  local current, modifier = data.current, data.modifier
+  data.predicted.text = tostring(safe_add(current.text, modifier.text))
 end)
 
 Gui.on_click(reset_button_name, function(event)

--- a/map_gen/maps/frontier/modules/restart.lua
+++ b/map_gen/maps/frontier/modules/restart.lua
@@ -68,7 +68,7 @@ pages[#pages +1] = {
   type = 'sprite-button',
   sprite = 'utility/map',
   tooltip = '[font=default-bold]Scenario manager[/font]',
-  tags = { [Gui.tag] = main_button_name },
+  tags = { [Gui.event_tag] = main_button_name },
   auto_toggle = true,
 }
 
@@ -127,13 +127,13 @@ local function show_values(parent, parent_data, params)
   local current = flow.add {
     type = 'text-box',
     style = 'short_number_textfield',
-    tags = { [Gui.tag] = textbox_tag_name },
+    tags = { [Gui.event_tag] = textbox_tag_name },
     text = current_value,
   }
   local modifier = flow.add {
     type = 'text-box',
     style = 'short_number_textfield',
-    tags = { [Gui.tag] = textbox_tag_name },
+    tags = { [Gui.event_tag] = textbox_tag_name },
     text = modifier_value,
   }
   local predicted = flow.add {
@@ -206,21 +206,21 @@ local function draw_gui(player)
       style = 'red_back_button',
       caption = 'Reset',
       tooltip = 'Resets all values to previous configuration',
-      tags = { [Gui.tag] = reset_button_name },
+      tags = { [Gui.event_tag] = reset_button_name },
     }
     local save = button_flow.add {
       type = 'button',
       style = 'forward_button',
       caption = 'Save',
       tooltip = 'Save modifiers configuration for later',
-      tags = { [Gui.tag] = save_button_name },
+      tags = { [Gui.event_tag] = save_button_name },
     }
     local apply = button_flow.add {
       type = 'button',
       style = 'confirm_double_arrow_button',
       caption = 'Apply',
       tooltip = 'Apply modifiers to current configuration now',
-      tags = { [Gui.tag] = apply_button_name },
+      tags = { [Gui.event_tag] = apply_button_name },
     }
     Gui.set_style(apply, { left_margin = -9 })
     Gui.set_data(save, data)
@@ -240,7 +240,7 @@ local function draw_gui(player)
       type = 'drop-down',
       items = restart_mode_text,
       selected_index = mode,
-      tags = { [Gui.tag] = mode_dropdown_name },
+      tags = { [Gui.event_tag] = mode_dropdown_name },
     }
 
     local row_2 = restart_settings.add { type = 'flow', direction = 'horizontal' }
@@ -254,14 +254,14 @@ local function draw_gui(player)
       style = 'red_back_button',
       caption = 'Abort',
       tooltip = 'Abort any restart action',
-      tags = { [Gui.tag] = abort_button_name },
+      tags = { [Gui.event_tag] = abort_button_name },
     }
     row_2.add {
       type = 'button',
       style = 'red_confirm_button',
       caption = 'Restart',
       tooltip = 'A save of current map will be automatically\ncreated before restarting',
-      tags = { [Gui.tag] = restart_button_name },
+      tags = { [Gui.event_tag] = restart_button_name },
     }
   end
 
@@ -305,14 +305,14 @@ local function draw_gui(player)
       style = 'red_back_button',
       caption = 'Clear',
       tooltip = 'Clear load settings',
-      tags = { [Gui.tag] = load_clear_button_name },
+      tags = { [Gui.event_tag] = load_clear_button_name },
     }
     local confirm = row_2.add {
       type = 'button',
       style = 'confirm_button',
       caption = 'Confirm',
       tooltip = 'Confirm load settings',
-      tags = { [Gui.tag] = load_confirm_button_name },
+      tags = { [Gui.event_tag] = load_confirm_button_name },
     }
 
     Gui.set_data(confirm, { name = t12, mod_pack = t22 })

--- a/map_gen/maps/frontier/modules/restart.lua
+++ b/map_gen/maps/frontier/modules/restart.lua
@@ -21,8 +21,6 @@ local apply_button_name = Gui.uid_name()
 local mode_dropdown_name = Gui.uid_name()
 local abort_button_name = Gui.uid_name()
 local restart_button_name = Gui.uid_name()
-local switch_save_button_name = Gui.uid_name()
-local switch_mod_pack_button_name = Gui.uid_name()
 local load_clear_button_name = Gui.uid_name()
 local load_confirm_button_name = Gui.uid_name()
 
@@ -70,7 +68,7 @@ pages[#pages +1] = {
   type = 'sprite-button',
   sprite = 'utility/map',
   tooltip = '[font=default-bold]Scenario manager[/font]',
-  name = main_button_name,
+  tags = { [Gui.tag] = main_button_name },
   auto_toggle = true,
 }
 
@@ -205,24 +203,24 @@ local function draw_gui(player)
     Gui.add_pusher(button_flow)
     button_flow.add {
       type = 'button',
-      name = reset_button_name,
       style = 'red_back_button',
       caption = 'Reset',
       tooltip = 'Resets all values to previous configuration',
+      tags = { [Gui.tag] = reset_button_name },
     }
     local save = button_flow.add {
       type = 'button',
-      name = save_button_name,
       style = 'forward_button',
       caption = 'Save',
       tooltip = 'Save modifiers configuration for later',
+      tags = { [Gui.tag] = save_button_name },
     }
     local apply = button_flow.add {
       type = 'button',
-      name = apply_button_name,
       style = 'confirm_double_arrow_button',
       caption = 'Apply',
       tooltip = 'Apply modifiers to current configuration now',
+      tags = { [Gui.tag] = apply_button_name },
     }
     Gui.set_style(apply, { left_margin = -9 })
     Gui.set_data(save, data)
@@ -240,9 +238,9 @@ local function draw_gui(player)
     Gui.add_pusher(row_1)
     row_1.add {
       type = 'drop-down',
-      name = mode_dropdown_name,
       items = restart_mode_text,
-      selected_index = mode
+      selected_index = mode,
+      tags = { [Gui.tag] = mode_dropdown_name },
     }
 
     local row_2 = restart_settings.add { type = 'flow', direction = 'horizontal' }
@@ -253,17 +251,17 @@ local function draw_gui(player)
     Gui.add_pusher(row_2)
     row_2.add {
       type = 'button',
-      name = abort_button_name,
       style = 'red_back_button',
       caption = 'Abort',
-      tooltip = 'Abort any restart action'
+      tooltip = 'Abort any restart action',
+      tags = { [Gui.tag] = abort_button_name },
     }
     row_2.add {
       type = 'button',
-      name = restart_button_name,
       style = 'red_confirm_button',
       caption = 'Restart',
-      tooltip = 'A save of current map will be automatically\ncreated before restarting'
+      tooltip = 'A save of current map will be automatically\ncreated before restarting',
+      tags = { [Gui.tag] = restart_button_name },
     }
   end
 
@@ -289,7 +287,6 @@ local function draw_gui(player)
     }
     local t12 = table_1.add {
       type = 'textfield',
-      name = switch_save_button_name,
       text = switch_map.name or 'i.e. frontier-special.zip',
     }
     table_1.add {
@@ -298,7 +295,6 @@ local function draw_gui(player)
     }
     local t22 = table_1.add {
       type = 'textfield',
-      name = switch_mod_pack_button_name,
       text = switch_map.mod_pack or 'i.e. frontier_modpack',
     }
 
@@ -306,17 +302,17 @@ local function draw_gui(player)
     Gui.add_pusher(row_2)
     row_2.add {
       type = 'button',
-      name = load_clear_button_name,
       style = 'red_back_button',
       caption = 'Clear',
       tooltip = 'Clear load settings',
+      tags = { [Gui.tag] = load_clear_button_name },
     }
     local confirm = row_2.add {
       type = 'button',
-      name = load_confirm_button_name,
       style = 'confirm_button',
       caption = 'Confirm',
       tooltip = 'Confirm load settings',
+      tags = { [Gui.tag] = load_confirm_button_name },
     }
 
     Gui.set_data(confirm, { name = t12, mod_pack = t22 })

--- a/map_gen/maps/frontier/modules/spawn_shop.lua
+++ b/map_gen/maps/frontier/modules/spawn_shop.lua
@@ -135,7 +135,7 @@ function SpawnShop.draw_gui(player)
 
   local this = Public.get()
 
-  frame = player.gui.screen.add { type = 'frame', name = SpawnShop.main_frame_name, direction = 'vertical' }
+  frame = player.gui.screen.add { type = 'frame', name = SpawnShop.main_frame_name, direction = 'vertical', tags = { [Gui.tag] = SpawnShop.main_frame_name } }
   Gui.set_style(frame, {
     horizontally_stretchable = true,
     natural_width = 760,
@@ -158,11 +158,11 @@ function SpawnShop.draw_gui(player)
 
     flow.add {
       type = 'sprite-button',
-      name = SpawnShop.close_button_name,
       sprite = 'utility/close',
       clicked_sprite = 'utility/close_black',
       style = 'close_button',
-      tooltip = {'gui.close-instruction'}
+      tooltip = {'gui.close-instruction'},
+      tags = { [Gui.tag] = SpawnShop.close_button_name },
     }
   end
 
@@ -221,7 +221,7 @@ function SpawnShop.draw_gui(player)
     end
     Gui.add_pusher(col_3)
     local col_3_2 = col_3.add { type = 'flow', direction = 'vertical' }
-    local upgrade_button = col_3_2.add { type = 'button', name = SpawnShop.upgrade_button_name, style = 'confirm_button', caption = 'Upgrade', tags = { name = p.name } }
+    local upgrade_button = col_3_2.add { type = 'button', style = 'confirm_button', caption = 'Upgrade', tags = { [Gui.tag] = SpawnShop.upgrade_button_name, name = p.name } }
     upgrade_button.enabled = SpawnShop.can_purchase(player, p.name)
   end
 
@@ -244,10 +244,10 @@ function SpawnShop.draw_gui(player)
   subfooter.add { type = 'label', caption = 'Refresh prices ', style = 'caption_label' }
   local refresh_button = subfooter.add {
     type = 'sprite-button',
-    name = SpawnShop.refresh_button_name,
     sprite = 'utility/refresh',
     style = 'tool_button',
-    tooltip = this.spawn_shop_funds > 0 and {'frontier.tt_shop_refresh_button'} or {'frontier.tt_shop_disabled_refresh_button'}
+    tooltip = this.spawn_shop_funds > 0 and {'frontier.tt_shop_refresh_button'} or {'frontier.tt_shop_disabled_refresh_button'},
+    tags = { [Gui.tag] = SpawnShop.refresh_button_name },
   }
   refresh_button.enabled = this.spawn_shop_funds > 0
   local tick = this.spawn_shop_cooldown[player.index]

--- a/map_gen/maps/frontier/modules/spawn_shop.lua
+++ b/map_gen/maps/frontier/modules/spawn_shop.lua
@@ -135,7 +135,7 @@ function SpawnShop.draw_gui(player)
 
   local this = Public.get()
 
-  frame = player.gui.screen.add { type = 'frame', name = SpawnShop.main_frame_name, direction = 'vertical', tags = { [Gui.tag] = SpawnShop.main_frame_name } }
+  frame = player.gui.screen.add { type = 'frame', name = SpawnShop.main_frame_name, direction = 'vertical', tags = { [Gui.event_tag] = SpawnShop.main_frame_name } }
   Gui.set_style(frame, {
     horizontally_stretchable = true,
     natural_width = 760,
@@ -162,7 +162,7 @@ function SpawnShop.draw_gui(player)
       clicked_sprite = 'utility/close_black',
       style = 'close_button',
       tooltip = {'gui.close-instruction'},
-      tags = { [Gui.tag] = SpawnShop.close_button_name },
+      tags = { [Gui.event_tag] = SpawnShop.close_button_name },
     }
   end
 
@@ -221,7 +221,7 @@ function SpawnShop.draw_gui(player)
     end
     Gui.add_pusher(col_3)
     local col_3_2 = col_3.add { type = 'flow', direction = 'vertical' }
-    local upgrade_button = col_3_2.add { type = 'button', style = 'confirm_button', caption = 'Upgrade', tags = { [Gui.tag] = SpawnShop.upgrade_button_name, name = p.name } }
+    local upgrade_button = col_3_2.add { type = 'button', style = 'confirm_button', caption = 'Upgrade', tags = { [Gui.event_tag] = SpawnShop.upgrade_button_name, name = p.name } }
     upgrade_button.enabled = SpawnShop.can_purchase(player, p.name)
   end
 
@@ -247,7 +247,7 @@ function SpawnShop.draw_gui(player)
     sprite = 'utility/refresh',
     style = 'tool_button',
     tooltip = this.spawn_shop_funds > 0 and {'frontier.tt_shop_refresh_button'} or {'frontier.tt_shop_disabled_refresh_button'},
-    tags = { [Gui.tag] = SpawnShop.refresh_button_name },
+    tags = { [Gui.event_tag] = SpawnShop.refresh_button_name },
   }
   refresh_button.enabled = this.spawn_shop_funds > 0
   local tick = this.spawn_shop_cooldown[player.index]

--- a/map_gen/maps/frontier/scenario.lua
+++ b/map_gen/maps/frontier/scenario.lua
@@ -1,6 +1,7 @@
 local Command = require 'utils.command'
 local Event = require 'utils.event'
 local DebugTerrain = require 'map_gen.maps.frontier.shared.debug_terrain'
+local Gui = require 'utils.gui'
 local math = require 'utils.math'
 local Ranks = require 'resources.ranks'
 local ScenarioInfo = require 'features.gui.info'
@@ -359,44 +360,21 @@ local function on_gui_opened(event)
 end
 Event.add(defines.events.on_gui_opened, on_gui_opened)
 
-local function on_gui_closed(event)
-  local element = event.element
-  if not (element and element.valid) then
-    return
-  end
+Gui.on_custom_close(SpawnShop.main_frame_name, function(event)
+  SpawnShop.destroy_gui(event.player)
+end)
 
-  local player = game.get_player(event.player_index)
-  if not (player and player.valid) then
-    return
-  end
+Gui.on_click(SpawnShop.close_button_name, function(event)
+  SpawnShop.destroy_gui(event.player)
+end)
 
-  if element.name == SpawnShop.main_frame_name then
-    SpawnShop.destroy_gui(player)
-  end
-end
-Event.add(defines.events.on_gui_closed, on_gui_closed)
+Gui.on_click(SpawnShop.refresh_button_name, function(event)
+  SpawnShop.on_player_refresh(event.player)
+end)
 
-local function on_gui_click(event)
-  local element = event.element
-  if not (element and element.valid) then
-    return
-  end
-
-  local player = game.get_player(event.player_index)
-  if not (player and player.valid) then
-    return
-  end
-
-  local name = element.name
-  if name == SpawnShop.close_button_name then
-    SpawnShop.destroy_gui(player)
-  elseif name == SpawnShop.refresh_button_name then
-    SpawnShop.on_player_refresh(player)
-  elseif name == SpawnShop.upgrade_button_name then
-    SpawnShop.on_player_purchase(player, element.tags.name)
-  end
-end
-Event.add(defines.events.on_gui_click, on_gui_click)
+Gui.on_click(SpawnShop.upgrade_button_name, function(event)
+  SpawnShop.on_player_purchase(event.player)
+end)
 
 local function on_init()
   Lobby.on_init()

--- a/map_gen/maps/quadrants/switch_team.lua
+++ b/map_gen/maps/quadrants/switch_team.lua
@@ -102,7 +102,7 @@ local function redraw_quadrant_button(data)
     left_flow.add(
         {
             type = 'button',
-            tags = { [Gui.tag] = btn_teleport, quadrant = 2 },
+            tags = { [Gui.event_tag] = btn_teleport, quadrant = 2 },
             caption = {'quadrants.switch_quadrant2', #game.forces['quadrant2'].connected_players},
             tooltip = {'quadrants.switch_quadrant2_tip'}
         }
@@ -110,7 +110,7 @@ local function redraw_quadrant_button(data)
     right_flow.add(
         {
             type = 'button',
-            tags = { [Gui.tag] = btn_teleport, quadrant = 1 },
+            tags = { [Gui.event_tag] = btn_teleport, quadrant = 1 },
             caption = {'quadrants.switch_quadrant1', #game.forces['quadrant1'].connected_players},
             tooltip = {'quadrants.switch_quadrant1_tip'}
         }
@@ -124,7 +124,7 @@ local function redraw_quadrant_button(data)
     left_flow.add(
         {
             type = 'button',
-            tags = { [Gui.tag] = btn_teleport, quadrant = 3 },
+            tags = { [Gui.event_tag] = btn_teleport, quadrant = 3 },
             caption = {'quadrants.switch_quadrant3', #game.forces['quadrant3'].connected_players},
             tooltip = {'quadrants.switch_quadrant3_tip'}
         }
@@ -132,7 +132,7 @@ local function redraw_quadrant_button(data)
     right_flow.add(
         {
             type = 'button',
-            tags = { [Gui.tag] = btn_teleport, quadrant = 4 },
+            tags = { [Gui.event_tag] = btn_teleport, quadrant = 4 },
             caption = {'quadrants.switch_quadrant4', #game.forces['quadrant4'].connected_players},
             tooltip = {'quadrants.switch_quadrant4_tip'}
         }
@@ -148,7 +148,7 @@ local function redraw_chest_button(data, player)
         left_flow.add(
         {
             type = 'button',
-            tags = { [Gui.tag] = btn_toggle },
+            tags = { [Gui.event_tag] = btn_toggle },
             caption = {'quadrants.switch_chest', toggle_status},
             tooltip = {'quadrants.switch_chest_tip'}
         }

--- a/map_gen/maps/quadrants/switch_team.lua
+++ b/map_gen/maps/quadrants/switch_team.lua
@@ -9,10 +9,7 @@ local Global = require 'utils.global'
 
 local gui = {}
 
-local btn_q1 = Gui.uid_name()
-local btn_q2 = Gui.uid_name()
-local btn_q3 = Gui.uid_name()
-local btn_q4 = Gui.uid_name()
+local btn_teleport = Gui.uid_name()
 local btn_toggle = Gui.uid_name()
 
 local spawn_locations = {
@@ -52,7 +49,8 @@ local quadrant_message = {
     }
 }
 
-local function teleport(event, quadrant)
+local function teleport(event)
+    local quadrant = event.tags.quadrant
     local player = event.player
     player.clear_cursor()
     local toggle_status = toggle_chest_status[player.index]
@@ -104,7 +102,7 @@ local function redraw_quadrant_button(data)
     left_flow.add(
         {
             type = 'button',
-            name = btn_q2,
+            tags = { [Gui.tag] = btn_teleport, quadrant = 2 },
             caption = {'quadrants.switch_quadrant2', #game.forces['quadrant2'].connected_players},
             tooltip = {'quadrants.switch_quadrant2_tip'}
         }
@@ -112,7 +110,7 @@ local function redraw_quadrant_button(data)
     right_flow.add(
         {
             type = 'button',
-            name = btn_q1,
+            tags = { [Gui.tag] = btn_teleport, quadrant = 1 },
             caption = {'quadrants.switch_quadrant1', #game.forces['quadrant1'].connected_players},
             tooltip = {'quadrants.switch_quadrant1_tip'}
         }
@@ -126,7 +124,7 @@ local function redraw_quadrant_button(data)
     left_flow.add(
         {
             type = 'button',
-            name = btn_q3,
+            tags = { [Gui.tag] = btn_teleport, quadrant = 3 },
             caption = {'quadrants.switch_quadrant3', #game.forces['quadrant3'].connected_players},
             tooltip = {'quadrants.switch_quadrant3_tip'}
         }
@@ -134,7 +132,7 @@ local function redraw_quadrant_button(data)
     right_flow.add(
         {
             type = 'button',
-            name = btn_q4,
+            tags = { [Gui.tag] = btn_teleport, quadrant = 4 },
             caption = {'quadrants.switch_quadrant4', #game.forces['quadrant4'].connected_players},
             tooltip = {'quadrants.switch_quadrant4_tip'}
         }
@@ -150,7 +148,7 @@ local function redraw_chest_button(data, player)
         left_flow.add(
         {
             type = 'button',
-            name = btn_toggle,
+            tags = { [Gui.tag] = btn_toggle },
             caption = {'quadrants.switch_chest', toggle_status},
             tooltip = {'quadrants.switch_chest_tip'}
         }
@@ -263,30 +261,8 @@ local function toggle_chest(event)
     toggle(event)
 end
 
-Gui.on_click(
-    btn_q1,
-    function(event)
-        teleport(event, 1)
-    end
-)
-Gui.on_click(
-    btn_q2,
-    function(event)
-        teleport(event, 2)
-    end
-)
-Gui.on_click(
-    btn_q3,
-    function(event)
-        teleport(event, 3)
-    end
-)
-Gui.on_click(
-    btn_q4,
-    function(event)
-        teleport(event, 4)
-    end
-)
+Gui.on_click(btn_teleport, teleport)
+
 Gui.on_click(
     btn_toggle,
     function(event)

--- a/map_gen/maps/space_race/gui/join_gui.lua
+++ b/map_gen/maps/space_race/gui/join_gui.lua
@@ -81,13 +81,13 @@ function Public.show_gui(event)
     label.style.single_line = false
     label.style.font = 'default'
 
-    local join_usa_button = usa_button_flow.add {type = 'button', caption = 'Join United Factory Workers', tags = { [Gui.tag] = join_USA }}
+    local join_usa_button = usa_button_flow.add {type = 'button', caption = 'Join United Factory Workers', tags = { [Gui.event_tag] = join_USA }}
 
     label = ussr_button_flow.add {type = 'label', caption = ussr_connected .. ' online / ' .. ussr_players .. ' total'}
     label.style.horizontal_align = 'center'
     label.style.single_line = false
     label.style.font = 'default'
-    local join_ussr_button = ussr_button_flow.add {type = 'button', caption = 'Join Union of Factory Employees', tags = { [Gui.tag] = join_USSR }}
+    local join_ussr_button = ussr_button_flow.add {type = 'button', caption = 'Join Union of Factory Employees', tags = { [Gui.event_tag] = join_USSR }}
 
     Gui.set_data(join_usa_button, frame)
     Gui.set_data(join_ussr_button, frame)

--- a/map_gen/maps/space_race/gui/join_gui.lua
+++ b/map_gen/maps/space_race/gui/join_gui.lua
@@ -81,13 +81,13 @@ function Public.show_gui(event)
     label.style.single_line = false
     label.style.font = 'default'
 
-    local join_usa_button = usa_button_flow.add {type = 'button', name = join_USA, caption = 'Join United Factory Workers'}
+    local join_usa_button = usa_button_flow.add {type = 'button', caption = 'Join United Factory Workers', tags = { [Gui.tag] = join_USA }}
 
     label = ussr_button_flow.add {type = 'label', caption = ussr_connected .. ' online / ' .. ussr_players .. ' total'}
     label.style.horizontal_align = 'center'
     label.style.single_line = false
     label.style.font = 'default'
-    local join_ussr_button = ussr_button_flow.add {type = 'button', name = join_USSR, caption = 'Join Union of Factory Employees'}
+    local join_ussr_button = ussr_button_flow.add {type = 'button', caption = 'Join Union of Factory Employees', tags = { [Gui.tag] = join_USSR }}
 
     Gui.set_data(join_usa_button, frame)
     Gui.set_data(join_ussr_button, frame)

--- a/map_gen/maps/space_race/gui/wait_gui.lua
+++ b/map_gen/maps/space_race/gui/wait_gui.lua
@@ -67,7 +67,7 @@ function Public.show_gui(event)
     ok_button_flow.style.horizontally_stretchable = true
     ok_button_flow.style.horizontal_align = 'center'
 
-    local ok_button = ok_button_flow.add {type = 'button', name = waiting_close_name, caption = snake_button_text}
+    local ok_button = ok_button_flow.add {type = 'button', caption = snake_button_text, tags = { [Gui.tag] = waiting_close_name }}
     Gui.set_data(ok_button, frame)
 end
 

--- a/map_gen/maps/space_race/gui/wait_gui.lua
+++ b/map_gen/maps/space_race/gui/wait_gui.lua
@@ -67,7 +67,7 @@ function Public.show_gui(event)
     ok_button_flow.style.horizontally_stretchable = true
     ok_button_flow.style.horizontal_align = 'center'
 
-    local ok_button = ok_button_flow.add {type = 'button', caption = snake_button_text, tags = { [Gui.tag] = waiting_close_name }}
+    local ok_button = ok_button_flow.add {type = 'button', caption = snake_button_text, tags = { [Gui.event_tag] = waiting_close_name }}
     Gui.set_data(ok_button, frame)
 end
 

--- a/map_gen/maps/space_race/gui/won_gui.lua
+++ b/map_gen/maps/space_race/gui/won_gui.lua
@@ -64,7 +64,7 @@ function Public.show_gui(event, force)
     ok_button_flow.style.horizontally_stretchable = true
     ok_button_flow.style.horizontal_align = 'center'
 
-    local ok_button = ok_button_flow.add {type = 'button', name = won_close_name, caption = snake_button_text}
+    local ok_button = ok_button_flow.add {type = 'button', caption = snake_button_text, tags = { [Gui.tag] = won_close_name }}
     Gui.set_data(ok_button, frame)
 end
 

--- a/map_gen/maps/space_race/gui/won_gui.lua
+++ b/map_gen/maps/space_race/gui/won_gui.lua
@@ -64,7 +64,7 @@ function Public.show_gui(event, force)
     ok_button_flow.style.horizontally_stretchable = true
     ok_button_flow.style.horizontal_align = 'center'
 
-    local ok_button = ok_button_flow.add {type = 'button', caption = snake_button_text, tags = { [Gui.tag] = won_close_name }}
+    local ok_button = ok_button_flow.add {type = 'button', caption = snake_button_text, tags = { [Gui.event_tag] = won_close_name }}
     Gui.set_data(ok_button, frame)
 end
 

--- a/map_gen/maps/tetris/view.lua
+++ b/map_gen/maps/tetris/view.lua
@@ -195,7 +195,7 @@ local function player_joined(event)
         return
     end
 
-    Gui.add_top_element(player, { name = main_button_name, type = 'sprite-button', sprite = 'utility/force_editor_icon', tags = { [Gui.tag] = main_button_name } })
+    Gui.add_top_element(player, { name = main_button_name, type = 'sprite-button', sprite = 'utility/force_editor_icon', tags = { [Gui.event_tag] = main_button_name } })
     toggle(player)
 end
 

--- a/map_gen/maps/tetris/view.lua
+++ b/map_gen/maps/tetris/view.lua
@@ -195,7 +195,7 @@ local function player_joined(event)
         return
     end
 
-    Gui.add_top_element(player, { name = main_button_name, type = 'sprite-button', sprite = 'utility/force_editor_icon' })
+    Gui.add_top_element(player, { name = main_button_name, type = 'sprite-button', sprite = 'utility/force_editor_icon', tags = { [Gui.tag] = main_button_name } })
     toggle(player)
 end
 

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -365,6 +365,7 @@ Event.add(
 
         local b = Gui.add_top_element(player, {
             type = 'button',
+            name = toggle_button_name,
             caption = '<',
             tooltip = {'gui_util.button_tooltip'},
             tags = { [Gui.tag] = toggle_button_name },

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -18,6 +18,8 @@ local Gui = {}
 local data = {}
 local element_map = {}
 
+Gui.tag = '__@level-RedMew__'
+
 Gui.token =
     Global.register(
     {data = data, element_map = element_map},
@@ -234,7 +236,8 @@ local function handler_factory(event_id)
             return
         end
 
-        local handler = handlers[element.name]
+        local tag = element.tags[Gui.tag]
+        local handler = handlers[element.name] or handlers[tag]
         if not handler then
             return
         end

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -18,7 +18,7 @@ local Gui = {}
 local data = {}
 local element_map = {}
 
-Gui.tag = '__@level-RedMew__'
+Gui.tag = '__@level-RedMew__event_handler_tag__'
 
 Gui.token =
     Global.register(
@@ -237,10 +237,11 @@ local function handler_factory(event_id)
         end
 
         local tag = element.tags[Gui.tag]
-        local handler = handlers[element.name] or handlers[tag]
+        local handler = tag and handlers[tag]
         if not handler then
             return
         end
+        event.tags = element.tags
 
         local player = game.get_player(event.player_index)
         if not player or not player.valid then
@@ -364,9 +365,9 @@ Event.add(
 
         local b = Gui.add_top_element(player, {
             type = 'button',
-            name = toggle_button_name,
             caption = '<',
-            tooltip = {'gui_util.button_tooltip'}
+            tooltip = {'gui_util.button_tooltip'},
+            tags = { [Gui.tag] = toggle_button_name },
         })
 
         Gui.set_style(b, {
@@ -422,9 +423,9 @@ function Gui.make_close_button(parent, name)
     local button =
         parent.add {
         type = 'button',
-        name = name,
         caption = {'common.close_button'},
-        style = 'back_button'
+        style = 'back_button',
+        tags = { [Gui.tag] = name },
     }
 
     Styles.default_close(button.style)

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -18,7 +18,7 @@ local Gui = {}
 local data = {}
 local element_map = {}
 
-Gui.tag = '__@level-RedMew__event_handler_tag__'
+Gui.event_tag = '__@level-RedMew__event_handler_tag__'
 
 Gui.token =
     Global.register(
@@ -236,7 +236,7 @@ local function handler_factory(event_id)
             return
         end
 
-        local tag = element.tags[Gui.tag]
+        local tag = element.tags[Gui.event_tag]
         local handler = tag and handlers[tag]
         if not handler then
             return
@@ -368,7 +368,7 @@ Event.add(
             name = toggle_button_name,
             caption = '<',
             tooltip = {'gui_util.button_tooltip'},
-            tags = { [Gui.tag] = toggle_button_name },
+            tags = { [Gui.event_tag] = toggle_button_name },
         })
 
         Gui.set_style(b, {
@@ -426,7 +426,7 @@ function Gui.make_close_button(parent, name)
         type = 'button',
         caption = {'common.close_button'},
         style = 'back_button',
-        tags = { [Gui.tag] = name },
+        tags = { [Gui.event_tag] = name },
     }
 
     Styles.default_close(button.style)

--- a/utils/test/viewer.lua
+++ b/utils/test/viewer.lua
@@ -134,7 +134,7 @@ end
 local function draw_tests_test(container, test, depth)
     local flow = container.add {type = 'flow'}
 
-    local label = flow.add {type = 'label', caption = test.name, tags = { [Gui.tag] = test_label_name }}
+    local label = flow.add {type = 'label', caption = test.name, tags = { [Gui.event_tag] = test_label_name }}
     local label_style = label.style
 
     local is_selected = is_test_selected(test, container.player_index)
@@ -156,12 +156,12 @@ local function draw_tests_module(container, module)
         flow.add {
         type = 'label',
         caption = module.is_open and down_arrow or right_arrow,
-        tags = { [Gui.tag] = module_arrow_name }
+        tags = { [Gui.event_tag] = module_arrow_name }
     }
     arrow.style.left_margin = module.depth * 15
     Gui.set_data(arrow, {module = module, container = container})
 
-    local label = flow.add { type = 'label', caption = caption, tags = { [Gui.tag] = module_label_name }}
+    local label = flow.add { type = 'label', caption = caption, tags = { [Gui.event_tag] = module_label_name }}
 
     local label_style = label.style
     local is_selected = is_module_selected(module, container.player_index)
@@ -220,22 +220,22 @@ local function draw_error_text_box(container)
 end
 
 local function create_main_frame(center)
-    local frame = center.add {type = 'frame', name = main_frame_name, caption = 'Test Runner', direction = 'vertical', tags = { [Gui.tag] = main_frame_name } }
+    local frame = center.add {type = 'frame', name = main_frame_name, caption = 'Test Runner', direction = 'vertical', tags = { [Gui.event_tag] = main_frame_name } }
     local frame_style = frame.style
     frame_style.width = 800
     frame_style.height = 600
 
     local top_flow = frame.add {type = 'flow', direction = 'horizontal'}
-    top_flow.add {type = 'button', caption = 'Run All', tags = { [Gui.tag] = run_all_button_name }}
+    top_flow.add {type = 'button', caption = 'Run All', tags = { [Gui.event_tag] = run_all_button_name }}
     top_flow.add {
         type = 'button',
         caption = 'Run Selected',
-        tags = { [Gui.tag] = run_selected_button_name },
+        tags = { [Gui.event_tag] = run_selected_button_name },
     }
     top_flow.add {
         type = 'checkbox',
         caption = 'Stop on first error',
-        tags = { [Gui.tag] = stop_on_error_checkbox_name },
+        tags = { [Gui.event_tag] = stop_on_error_checkbox_name },
         state = stop_on_first_error_by_player_index[center.player_index] or false
     }
 
@@ -244,7 +244,7 @@ local function create_main_frame(center)
     local error_text_box = draw_error_text_box(frame)
     Gui.set_data(frame, {error_text_box = error_text_box})
 
-    local close_button = frame.add {type = 'button', caption = 'Close', tags = { [Gui.tag] = close_main_frame_name }}
+    local close_button = frame.add {type = 'button', caption = 'Close', tags = { [Gui.event_tag] = close_main_frame_name }}
     Gui.set_data(close_button, frame)
 end
 

--- a/utils/test/viewer.lua
+++ b/utils/test/viewer.lua
@@ -27,7 +27,6 @@ local test_label_name = Gui.uid_name()
 local run_all_button_name = Gui.uid_name()
 local run_selected_button_name = Gui.uid_name()
 local stop_on_error_checkbox_name = Gui.uid_name()
-local error_test_box_name = Gui.uid_name()
 
 local selected_test_info_by_player_index = {}
 local stop_on_first_error_by_player_index = {}
@@ -135,7 +134,7 @@ end
 local function draw_tests_test(container, test, depth)
     local flow = container.add {type = 'flow'}
 
-    local label = flow.add {type = 'label', name = test_label_name, caption = test.name}
+    local label = flow.add {type = 'label', caption = test.name, tags = { [Gui.tag] = test_label_name }}
     local label_style = label.style
 
     local is_selected = is_test_selected(test, container.player_index)
@@ -156,13 +155,13 @@ local function draw_tests_module(container, module)
     local arrow =
         flow.add {
         type = 'label',
-        name = module_arrow_name,
-        caption = module.is_open and down_arrow or right_arrow
+        caption = module.is_open and down_arrow or right_arrow,
+        tags = { [Gui.tag] = module_arrow_name }
     }
     arrow.style.left_margin = module.depth * 15
     Gui.set_data(arrow, {module = module, container = container})
 
-    local label = flow.add {type = 'label', name = module_label_name, caption = caption}
+    local label = flow.add { type = 'label', caption = caption, tags = { [Gui.tag] = module_label_name }}
 
     local label_style = label.style
     local is_selected = is_module_selected(module, container.player_index)
@@ -212,7 +211,7 @@ end
 local function draw_error_text_box(container)
     local text = get_text_box_error(container.player_index)
 
-    local text_box = container.add {type = 'text-box', name = error_test_box_name, text = text}
+    local text_box = container.add {type = 'text-box', text = text}
     local style = text_box.style
     style.vertically_stretchable = true
     style.horizontally_stretchable = true
@@ -221,22 +220,22 @@ local function draw_error_text_box(container)
 end
 
 local function create_main_frame(center)
-    local frame = center.add {type = 'frame', name = main_frame_name, caption = 'Test Runner', direction = 'vertical'}
+    local frame = center.add {type = 'frame', name = main_frame_name, caption = 'Test Runner', direction = 'vertical', tags = { [Gui.tag] = main_frame_name } }
     local frame_style = frame.style
     frame_style.width = 800
     frame_style.height = 600
 
     local top_flow = frame.add {type = 'flow', direction = 'horizontal'}
-    top_flow.add {type = 'button', name = run_all_button_name, caption = 'Run All'}
+    top_flow.add {type = 'button', caption = 'Run All', tags = { [Gui.tag] = run_all_button_name }}
     top_flow.add {
         type = 'button',
-        name = run_selected_button_name,
-        caption = 'Run Selected'
+        caption = 'Run Selected',
+        tags = { [Gui.tag] = run_selected_button_name },
     }
     top_flow.add {
         type = 'checkbox',
-        name = stop_on_error_checkbox_name,
         caption = 'Stop on first error',
+        tags = { [Gui.tag] = stop_on_error_checkbox_name },
         state = stop_on_first_error_by_player_index[center.player_index] or false
     }
 
@@ -245,7 +244,7 @@ local function create_main_frame(center)
     local error_text_box = draw_error_text_box(frame)
     Gui.set_data(frame, {error_text_box = error_text_box})
 
-    local close_button = frame.add {type = 'button', name = close_main_frame_name, caption = 'Close'}
+    local close_button = frame.add {type = 'button', caption = 'Close', tags = { [Gui.tag] = close_main_frame_name }}
     Gui.set_data(close_button, frame)
 end
 


### PR DESCRIPTION
Proposal to extend gui handlers registration to tags as well.

## Scope
This PR adds a new `.tag` field (internally `__@level-RedMew__event_handler_tag__`) to the `utils.gui.lua` module, that can be used to associate an handler to the value assigned to this key-value pair inside a `LuaGuiElement::tags`
This allows children of the same `LuaGuiELement` to share "name" and handlers, and keeps the same syntax currently used for `name`.

### Relevant changes:
```lua
---@ utils.gui.lua

Gui.tag = '__@level-RedMew__'

local function handler_factory(event_id)
    local handlers

    local function on_event(event)
        ...
        local element = event.element
        local tag = element.tags[Gui.tag]
        local handler = handlers[element.name] or handlers[tag] -- searches for registered tags too
        if not handler then
            return
        end
        ...
        handler(event)
    end
end
```

## Examples
Comparison and usage of current/proposed changes

### 1. Current behavior with `LuaGuiElement::name`

```lua
local button_name = Gui.uid_name()

-- @ element creation
local button = parent.add { name = button_name, type = 'button' }

-- @ handler registration
Gui.on_click(button_name, function(event) ... end)
```

### 2. Extension to `LuaGuiElement::tags`
In addition to `name`, `tags` are also filtered by the gui handler factory, allowing such syntax:

```lua
local button_tag = Gui.uid_name()

-- @ element creation
local button_1 = parent.add { type = 'button', tags = { [Gui.tag] = button_tag }
local button_2 = parent.add { type = 'button', tags = { [Gui.tag] = button_tag }
local button_3 = parent.add { type = 'button', tags = { [Gui.tag] = button_tag }

-- @ handler registration
Gui.on_click(button_tag, function(event) ... end)
```

### Notes:
1. Usage of name is not deprecated, both `name` and `tags` can be used to register the handler
2. Registering 2 different handlers via name and tag to the same LuaGuiElement will result in only 1 being called, as `name` (more domain specific) will take precedence over `tags`
3. It is considered a bad practice to register multiple handlers via name+tags to the same LuaGuiElement


### Edit:
1. Usage of name to register gui event handlers has been deprecated in favor if usage of tags.
2. Tags will handle all eventhandlers, while names are currently used to index parent-children relations (see top toolbar and `player.gui.screen|center|left|top`)