### PR TITLE
Update moderation workflow

### DIFF
--- a/features/rank_system.lua
+++ b/features/rank_system.lua
@@ -143,7 +143,7 @@ local function on_player_joined(event)
 end
 
 local function on_player_removed(event)
-    guests[event.player.index] = nil
+    guests[event.player_index] = nil
     local player = game.get_player(event.player_index)
     if player then
         player_ranks[player.name] = nil

--- a/features/save_manager.lua
+++ b/features/save_manager.lua
@@ -23,7 +23,6 @@ local function remove_player_data(event)
     schedule_data_removal({ 'save_manager.remove_player', player.name }, { event.player_index })
 end
 
-Event.add(defines.events.on_player_kicked, remove_player_data)
 Event.add(defines.events.on_player_banned, remove_player_data)
 
 Event.on_nth_tick(config.inactive_interval or DEFAULT_INACTIVE_INTERVAL, function()

--- a/features/save_manager.lua
+++ b/features/save_manager.lua
@@ -1,7 +1,18 @@
 local Event = require 'utils.event'
 local config = require 'config'.save_manager
+local Task = require 'utils.task'
+local Token = require 'utils.token'
 
 local DEFAULT_INACTIVE_INTERVAL = 60 * 60 * 60 * 24 * 30 -- a month
+
+local remove_players_token = Token.register(function(data)
+    game.print(data.message)
+    game.remove_offline_players(data.players)
+end)
+
+local function schedule_data_removal(message, players)
+    Task.set_timeout(5, remove_players_token, { message = message, players = players })
+end
 
 local function remove_player_data(event)
     local player = game.get_player(event.player_index)
@@ -9,10 +20,10 @@ local function remove_player_data(event)
         return
     end
 
-    game.print({ 'save_manager.remove_player', player.name })
-    game.remove_offline_players({ player.index })
+    schedule_data_removal({ 'save_manager.remove_player', player.name }, { event.player_index })
 end
 
+Event.add(defines.events.on_player_kicked, remove_player_data)
 Event.add(defines.events.on_player_banned, remove_player_data)
 
 Event.on_nth_tick(config.inactive_interval or DEFAULT_INACTIVE_INTERVAL, function()
@@ -26,7 +37,6 @@ Event.on_nth_tick(config.inactive_interval or DEFAULT_INACTIVE_INTERVAL, functio
     end
 
     if #idx_to_remove > 0 then
-        game.print({ 'save_manager.cleanup', #idx_to_remove })
-        game.remove_offline_players(idx_to_remove)
+        schedule_data_removal({ 'save_manager.cleanup', #idx_to_remove }, idx_to_remove)
     end
 end)

--- a/resources/discord.lua
+++ b/resources/discord.lua
@@ -5,7 +5,7 @@ return {
     channel_names = {
         bot_playground = 'bot-playground',
         map_promotion = 'map-promotion',
-        moderation_log = 'moderation-log',
+        moderation_log = 'mod-log',
         helpdesk = 'helpdesk',
         danger_ores = 'danger-ores',
         crash_site = 'crash-site',


### PR DESCRIPTION
Updating scenarios to log moderation alerts in new channel `#mod-log` instead of deprecated `#moderation-log`.

Unfortunately refbot does not seem to post on new or old channels anymore, only on`#bot-playground`

Message seems fine from the server logs tho

```
Script @__level__/utils/core.lua:73: ## - (ADMIN) Server: RedRafe has been jailed by RedRafe
Script @__level__/utils/core.lua:227: [Admin-Command] <server> used: jail RedRafe
[DISCORD-NAMED-EMBED-RAW]mod-log **RedRafe has jailed RedRafe**\nServer: s30 - [color=green]RedMew[/color] - Testing\nGame time: 0 minutes\nPlayer online time: 0 minutes
```