### PR TITLE
diggy: fixed error on open popup on placing solar panel

### DIFF
--- a/map_gen/maps/diggy/feature/night_time.lua
+++ b/map_gen/maps/diggy/feature/night_time.lua
@@ -7,6 +7,7 @@
 -- dependencies
 local Event = require 'utils.event'
 local RS = require 'map_gen.shared.redmew_surface'
+local Popup = require 'features.gui.popup'
 
 -- this
 local NightTime = {}
@@ -19,7 +20,7 @@ local function on_built_entity(event)
     local player = game.get_player(event.player_index)
     local entity = event.entity
     if (entity.name == 'solar-panel') then
-        require 'features.gui.popup'.player(
+        Popup.player(
             player, {'diggy.night_time_warning'}
         )
     end


### PR DESCRIPTION
There is a popup, that should be shown, when a player places a solar panel in diggy scenario, so he get informed, that it will not work. But the code raises an error instead of showning the popup, because the required statement was used directly in the event function (what is not working). So extracting the required statement to the top of the file and use it in event function does the trick. So Popup is shown again.