### PR TITLE
Fix config restart gui names overlap

### DIFF
--- a/features/restart_command.lua
+++ b/features/restart_command.lua
@@ -360,7 +360,7 @@ local function draw_main_frame(player)
         local grid = main_frame.add { type = 'table', style = 'player_input_table', column_count = 2 }
         for mod_pack_name, mod_pack_value in pairs(memory.known_mod_packs) do
             grid.add {type = 'label', caption = mod_pack_name}
-            local mod_pack_textfield = grid.add {type = 'textfield', name = known_mod_pack_textfield_name, text = mod_pack_value}
+            local mod_pack_textfield = grid.add({type = 'flow'}).add {type = 'textfield', name = known_mod_pack_textfield_name, text = mod_pack_value}
             Gui.set_data(mod_pack_textfield, mod_pack_name)
         end
     end


### PR DESCRIPTION
Nests named elements inside an additional flow to avoid name overlps