### PR TITLE
Increase autodeconstruct task timer

### DIFF
--- a/features/autodeconstruct.lua
+++ b/features/autodeconstruct.lua
@@ -138,7 +138,7 @@ local function on_resource_depleted(event)
     for i = 1, #drills do
         local drill = drills[i]
         if is_depleted(drill, entity) then
-            Task.set_timeout_in_ticks(5, callback, drill)
+            Task.set_timeout(5, callback, drill)
         end
     end
 end


### PR DESCRIPTION
Drills that can output stacked items dont have time to drop the ore inside them before being marked for decon, so increasing time from 5 ticks to 5s should give them enough space to output the last bit of ore