### PR TITLE
Add DO:Gridlocked

### DIFF
--- a/map_gen/maps/danger_ores/config/vanilla_ores_gridlocked.lua
+++ b/map_gen/maps/danger_ores/config/vanilla_ores_gridlocked.lua
@@ -1,0 +1,62 @@
+local b = require 'map_gen.shared.builders'
+local start_value = b.euclidean_value(50, 0.75)
+local value = b.exponential_value(50, 0.003, 2.25)
+
+return {
+    {
+        name = 'iron-ore',
+        tiles = {
+            [1] = 'landfill',
+        },
+        start = start_value,
+        weight = 10,
+        ratios = {
+            { resource = b.resource(b.full_shape, 'iron-ore',   value), weight = 75 },
+            { resource = b.resource(b.full_shape, 'copper-ore', value), weight = 13 },
+            { resource = b.resource(b.full_shape, 'stone',      value), weight =  7 },
+            { resource = b.resource(b.full_shape, 'coal',       value), weight =  5 },
+        },
+    },
+    {
+        name = 'coal',
+        tiles = {
+            [1] = 'landfill',
+        },
+        start = start_value,
+        weight = 8,
+        ratios = {
+            { resource = b.resource(b.full_shape, 'iron-ore',   value), weight = 18 },
+            { resource = b.resource(b.full_shape, 'copper-ore', value), weight =  9 },
+            { resource = b.resource(b.full_shape, 'stone',      value), weight =  8 },
+            { resource = b.resource(b.full_shape, 'coal',       value), weight = 65 },
+        },
+    },
+    {
+        name = 'copper-ore',
+        tiles = {
+            [1] = 'landfill',
+        },
+        start = start_value,
+        weight = 7,
+        ratios = {
+            { resource = b.resource(b.full_shape, 'iron-ore',   value), weight = 15 },
+            { resource = b.resource(b.full_shape, 'copper-ore', value), weight = 70 },
+            { resource = b.resource(b.full_shape, 'stone',      value), weight = 10 },
+            { resource = b.resource(b.full_shape, 'coal',       value), weight =  5 },
+        },
+    },
+    {
+        name = 'stone',
+        tiles = {
+            [1] = 'landfill',
+        },
+        start = start_value,
+        weight = 2,
+        ratios = {
+            { resource = b.resource(b.full_shape, 'iron-ore',   value), weight = 25 },
+            { resource = b.resource(b.full_shape, 'copper-ore', value), weight = 10 },
+            { resource = b.resource(b.full_shape, 'stone',      value), weight = 60 },
+            { resource = b.resource(b.full_shape, 'coal',       value), weight =  5 },
+        },
+    },
+}

--- a/map_gen/maps/danger_ores/modules/main_ores_grid_factory.lua
+++ b/map_gen/maps/danger_ores/modules/main_ores_grid_factory.lua
@@ -1,5 +1,6 @@
 local b = require 'map_gen.shared.builders'
 local gear_pic = b.decompress(require 'map_gen.data.presets.gear_64by64')
+
 return function(config)
     local main_ores = config.main_ores
     local shuffle_order = config.main_ores_shuffle_order
@@ -11,7 +12,7 @@ return function(config)
         for _, ore_data in pairs(main_ores) do
             local ore_name = ore_data.name
             local tiles = {
-                [1] = 'concrete'
+                [1] = 'concrete',
             }
             local land = tile_builder(tiles)
 
@@ -22,7 +23,9 @@ return function(config)
             local ore = ore_builder(ore_name, amount, ratios, weighted)
 
             local shape = b.apply_entity(land, ore)
-            shapes[#shapes + 1] = shape
+            for i = 1, (ore_data.weight or 1) do
+                shapes[#shapes + 1] = shape
+            end
         end
 
         local count = #shapes
@@ -72,7 +75,7 @@ return function(config)
 
         local cc_gear_shadow = b.choose(b.circle((grid_tile_size / 2) - 1), b.tile('concrete'), b.empty_shape)
         local spawn_cc_rect = b.choose(b.rectangle(grid_tile_size), concrete_ores, ores) --overlay ores
-        spawn_cc_rect =  b.any({spawn_shape, gear_shape, cc_gear_shadow, spawn_cc_rect})
+        spawn_cc_rect = b.any({ spawn_shape, gear_shape, cc_gear_shadow, spawn_cc_rect })
 
         -- walkways::
         local left_tile = b.tile('refined-hazard-concrete-left')
@@ -81,7 +84,7 @@ return function(config)
             [1] = b.tile('water'),
             [2] = b.tile('deepwater'),
             [3] = b.tile('water-shallow'),
-            [4] = b.tile('water-wube')
+            [4] = b.tile('water-wube'),
         }
         local water_tile = water_tiles[random_gen(#water_tiles)]
         local walk_pattern = {}
@@ -96,26 +99,26 @@ return function(config)
                     walk_pattern[i][j] = water_tile
                 end
             end
-          end
+        end
         -- middle x
         -- top
-        walk_pattern[ 1][32] = right_tile -- b.tile('red-refined-concrete')
-        walk_pattern[ 1][33] = left_tile  -- b.tile('green-refined-concrete')
+        walk_pattern[1][32] = right_tile -- b.tile('red-refined-concrete')
+        walk_pattern[1][33] = left_tile -- b.tile('green-refined-concrete')
         -- bottom
-        walk_pattern[64][32] = left_tile  -- b.tile('blue-refined-concrete')
+        walk_pattern[64][32] = left_tile -- b.tile('blue-refined-concrete')
         walk_pattern[64][33] = right_tile -- b.tile('yellow-refined-concrete')
         -- middle y
         -- left
-        walk_pattern[32][ 1] = right_tile -- b.tile('orange-refined-concrete')
-        walk_pattern[33][ 1] = left_tile  -- b.tile('pink-refined-concrete')
+        walk_pattern[32][1] = right_tile -- b.tile('orange-refined-concrete')
+        walk_pattern[33][1] = left_tile -- b.tile('pink-refined-concrete')
         -- right
-        walk_pattern[32][64] = left_tile  -- b.tile('purple-refined-concrete')
+        walk_pattern[32][64] = left_tile -- b.tile('purple-refined-concrete')
         walk_pattern[33][64] = right_tile -- b.tile('cyan-refined-concrete')
 
-        local hazard_grid =  b.grid_pattern_no_offset(walk_pattern, 64, 64, 1, 1)
+        local hazard_grid = b.grid_pattern_no_offset(walk_pattern, 64, 64, 1, 1)
         hazard_grid = b.translate(hazard_grid, 33, 33)
 
-        local map = b.any {hazard_grid, spawn_cc_rect, ores}
+        local map = b.any { hazard_grid, spawn_cc_rect, ores }
         return b.set_hidden_tile(map, 'sand-1') -- tile below concrete
     end
 end

--- a/map_gen/maps/danger_ores/modules/map_poll.lua
+++ b/map_gen/maps/danger_ores/modules/map_poll.lua
@@ -29,6 +29,7 @@ local mod_packs = {
     danger_ore_scrap      = 'danger_ore_scrap',
     danger_ore_space_age  = 'danger_ore_space_age',
     danger_ore_collapse   = 'danger_ore_collapse',
+    danger_ore_gridlocked = 'danger_ore_gridlocked',
 }
 
 local maps = {
@@ -47,6 +48,7 @@ local maps = {
     { name = 'danger-ore-for-the-swarm', display_name = 'Honeycomb-gradient (smooth ore ratios)', mod_pack = mod_packs.danger_ore_normal },
     { name = 'danger-ore-gradient', display_name = 'Gradient (smooth ore ratios)', mod_pack = mod_packs.danger_ore_normal },
     { name = 'danger-ore-grid-factory', display_name = 'Grid Factory (squares)', mod_pack = mod_packs.danger_ore_normal },
+    { name = 'danger-ore-gridlocked', display_name = 'Gridlocked (buy chunks)', mod_pack = mod_packs.danger_ore_gridlocked },
     { name = 'danger-ore-hub-spiral', display_name = 'Hub-spiral (with void)', mod_pack = mod_packs.danger_ore_normal },
     --{ name = 'danger-ore-industrial-revolution-3', display_name = 'Industrial Revolution 3 (default)', mod_pack = mod_packs.danger_ore_ir3 },
     --{ name = 'danger-ore-industrial-revolution-3-grid-factory', display_name = 'Industrial Revolution 3 Grid Factory (squares)', mod_pack = mod_packs.danger_ore_ir3 },

--- a/map_gen/maps/danger_ores/presets/danger_ore_grid_factory.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_grid_factory.lua
@@ -1,3 +1,4 @@
+local B = require 'map_gen.shared.builders'
 local DOC = require 'map_gen.maps.danger_ores.configuration'
 local Scenario = require 'map_gen.maps.danger_ores.scenario'
 local ScenarioInfo = require 'features.gui.info'
@@ -12,5 +13,8 @@ DOC.scenario_name = 'danger-ore-grid-factory'
 DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_grid_factory'
 DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.config.vanilla_ores_landfill'
 DOC.map_config.spawn_tile = 'orange-refined-concrete'
+DOC.map_config.spawn_shape = B.circle(20)
+DOC.map_config.start_ore_shape = B.circle(40)
+DOC.map_config.no_resource_patch_shape = B.circle(80)
 
 return Scenario.register(DOC)

--- a/map_gen/maps/danger_ores/presets/danger_ore_gridlocked.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_gridlocked.lua
@@ -1,0 +1,27 @@
+local B = require 'map_gen.shared.builders'
+local DOC = require 'map_gen.maps.danger_ores.configuration'
+local Scenario = require 'map_gen.maps.danger_ores.scenario'
+local ScenarioInfo = require 'features.gui.info'
+
+ScenarioInfo.set_map_name('Danger Ores - Gridlocked')
+ScenarioInfo.add_map_extra_info([[
+  This map is divided in quadrants of [item=iron-ore] [item=copper-ore] [item=coal] [item=stone].
+  Each sector has a main resource and the other resources at a lower ratio.
+
+  Unlock new chunks via [font=default-bold]Chunk claim tool (Alt + K)[/font].
+  Chunk purchases can be reverted within 30s from purchase.
+  Chunk points are awarded by completing [technology=gl-additional-chunk-space-science-pack] Technology: Additional chunks.
+  Chunk cost is computed based on adjacient chunks.
+]])
+
+DOC.scenario_name = 'danger-ore-gridlocked'
+DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.main_ores_grid_factory'
+DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.config.vanilla_ores_gridlocked'
+DOC.map_config.spawn_tile = 'orange-refined-concrete'
+DOC.map_config.spawn_shape = B.circle(20)
+DOC.map_config.start_ore_shape = B.circle(40)
+DOC.map_config.no_resource_patch_shape = B.circle(80)
+DOC.terraforming.enabled = false
+DOC.game.technology_price_multiplier = 10
+
+return Scenario.register(DOC)

--- a/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
+++ b/map_gen/maps/danger_ores/presets/danger_ore_industrial_revolution_3_grid_factory.lua
@@ -1,3 +1,4 @@
+local B = require 'map_gen.shared.builders'
 local H = require 'map_gen.maps.danger_ores.modules.helper'
 local DOC = require 'map_gen.maps.danger_ores.configuration'
 local Config = require 'config'
@@ -32,6 +33,9 @@ DOC.map_config.main_ores_builder = require 'map_gen.maps.danger_ores.modules.mai
 DOC.map_config.main_ores = require 'map_gen.maps.danger_ores.compatibility.industrial_revolution_3.ores_grid_factory'
 DOC.map_config.resource_patches_config = require 'map_gen.maps.danger_ores.compatibility.industrial_revolution_3.resource_patches'
 DOC.map_config.spawn_tile = 'tarmac'
+DOC.map_config.spawn_shape = B.circle(20)
+DOC.map_config.start_ore_shape = B.circle(40)
+DOC.map_config.no_resource_patch_shape = B.circle(80)
 DOC.map_gen_settings.settings = H.empty_map_settings{
   -- point patches
   'crude-oil',

--- a/scenario_templates/danger-ore-gridlocked/map_selection.lua
+++ b/scenario_templates/danger-ore-gridlocked/map_selection.lua
@@ -1,0 +1,1 @@
+return require 'map_gen.maps.danger_ores.presets.danger_ore_gridlocked'


### PR DESCRIPTION
# Changes
1. fixed grid factory preset having a starting area too big
2. fixed grid factory builder not accounting for sector weights when building the weighted array from main ores
3. added DO:Gridlocked map to DO rotation list


This map uses [Gridlocked mod](https://mods.factorio.com/mod/gridlocked) as "terraforming" tool to limit map size, chunks are claimed & unlocked via research so ore density has been modified to increase a lot quicker for this particular map (`DO/config/vanilla_ores_gridlocked.lua`)

<img width="2432" height="1368" alt="screenshot-tick-10429" src="https://github.com/user-attachments/assets/f3fff59c-7a44-49bf-89a5-d543d7849cba" />
