### PR TITLE
Fix raw resources not being visible in logistic tab

### DIFF
--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -969,7 +969,6 @@ Global.register_init(
         local surface = game.surfaces[1]
         surface.map_gen_settings = {width = 2, height = 2}
         surface.clear()
-        game.forces.player.lock_space_location('nauvis')
 
         local seed = RS.get_surface().map_gen_settings.seed
         tbl.outpost_seed = outpost_seed or seed


### PR DESCRIPTION
This PR fixes raw resources not being visible in logistic tabs without using the setting "show all items" in user interface (img below) in Crash Site.

I believe this line of code to be an artifact of the 2.0 porting, to hide Nauvis surface. This call is already being handled by redmew's generate/surface modules which will hide `nauvis` surface (not planet) if a custom `redmew` surface is created instead (introduced with DO's PR that moved DO scenarios from custom surfaces back to Nauvis surface).


<img width="1890" height="1009" alt="Screenshot from 2026-02-09 10-10-18" src="https://github.com/user-attachments/assets/fc910b09-3f9a-47a5-aa21-01b086211e11" />
