### PR TITLE
Diggy: add blueprint tools

### DIFF
--- a/features/gui/experience.lua
+++ b/features/gui/experience.lua
@@ -268,7 +268,7 @@ Public.get_main_frame = function(player)
 
     local data = {}
     frame = Gui.add_left_element(player, { name = main_frame_name, type = 'frame', direction = 'vertical' })
-    Gui.set_style(frame, { maximal_width = 360 })
+    Gui.set_style(frame, { maximal_width = 332 })
 
     local canvas = frame
         .add { type = 'flow', direction = 'vertical', style = 'vertical_flow' }
@@ -358,6 +358,7 @@ Public.get_main_frame = function(player)
     end
     Gui.set_data(frame, data)
     Public.update_main_frame(player)
+    return frame
 end
 
 Public.toggle_main_button = function(player)

--- a/locale/en/redmew_command_text.cfg
+++ b/locale/en/redmew_command_text.cfg
@@ -134,6 +134,7 @@ frontier_log_global=Logs the global table
 moderator=Gives a player the moderator rank
 moderator_remove=Demotes a player from moderator to the next lowest rank
 regular_all=Gives everyone online the regular rank, if not in probation
+blueprint_tools=Open the Blueprint Tools manager GUI
 
 [command_custom_help]
 tp=<blank|mode|player> 3 different uses: "/tp" to tp to selected entity. "/tp mode" to toggle tp mode. "/tp Newcott" to tp to Newcott.

--- a/locale/en/redmew_maps.cfg
+++ b/locale/en/redmew_maps.cfg
@@ -36,7 +36,7 @@ cutscene_case7_line1=This concludes the introduction
 cutscene_case7_line3=Have fun and keep digging!
 replay_cutscene=To replay the introduction, use the __1__ command
 
-blueprint_qol_tooltip=Show blueprint tools
+blueprint_tools_tooltip=Show blueprint tools
 
 # locale linked to the crashsite scenario
 [crashsite]

--- a/locale/en/redmew_maps.cfg
+++ b/locale/en/redmew_maps.cfg
@@ -36,6 +36,8 @@ cutscene_case7_line1=This concludes the introduction
 cutscene_case7_line3=Have fun and keep digging!
 replay_cutscene=To replay the introduction, use the __1__ command
 
+blueprint_qol_tooltip=Show blueprint tools
+
 # locale linked to the crashsite scenario
 [crashsite]
 auto_play_cutscene=Auto play Crashsite cutscene

--- a/map_gen/maps/diggy/feature/blueprint_qol.lua
+++ b/map_gen/maps/diggy/feature/blueprint_qol.lua
@@ -1,0 +1,363 @@
+--[[
+    Blueprint tools for Diggy
+
+    Support beams (tiles and special entities) cannot be marked for deconstruction by default (antigrief/safety feature)
+    Regulars and above will have access to this feature to turn On/Off the safety measure however they prefer.
+    The feature will automatically popup whener the player is about to perform a "blueprint action", which is:
+    - using a blueprint record
+    - using a blueprint book
+    - setting up a blueprint from map
+    - holding a blueprintable item-entity in hand
+
+    Players can:
+    - turn On/Off the safety measure all toghether
+    - turn On/Off tiles in bulk
+    - Show/Hide the popupw window (from this window or RedMew "Settings > Show blueprint tools")
+    - turn On/Off individual entities
+]]
+
+local Event = require 'utils.event'
+local Global = require 'utils.global'
+local Gui = require 'utils.gui'
+local Rank = require 'features.rank_system'
+local Ranks = require 'resources.ranks'
+local Settings = require 'utils.redmew_settings'
+local Template = require 'map_gen.maps.diggy.template'
+
+local is_support_beam = Template.is_support_beam
+local required_rank = Ranks.regular
+local ENTITIES = prototypes.entity
+local ITEMS = prototypes.item
+local TILES = prototypes.tile
+
+local main_frame_name = Gui.uid_name()
+local feature_switch_name = Gui.uid_name()
+local entity_button_name = Gui.uid_name()
+local tiles_checkbox_name = Gui.uid_name()
+local show_window_checkbox_name = Gui.uid_name()
+
+local Public = {
+    setting_name = 'diggy_blueprint_qol',
+    setting_tooltip = 'diggy.blueprint_qol_tooltip'
+}
+
+---@class PlayerSettingsData
+---@field enabled boolean
+---@field include_tiles boolean
+---@field entities table[string --> boolean]
+
+local player_settings = {} --[[@as [player_index] --> PlayerSettingsData]]
+Global.register(player_settings, function(tbl) player_settings = tbl end)
+
+local switch_state_map = {
+    [true] = 'left',
+    [false] = 'right',
+    ['left'] = true,
+    ['right'] = false,
+}
+
+local hidden_entities = {
+    ['out-of-map'] = true,
+    ['market'] = true,
+    ['hazard-concrete'] = true, -- right/left
+    ['refined-hazard-concrete'] = true, -- left/right
+    ['stone-brick'] = true, -- stone-path
+}
+do
+    -- populate hidden_entities with template rocks
+    for _, rock in pairs(Template.diggy_rocks) do
+        hidden_entities[rock] = true
+    end
+end
+
+local cursor_stack_triggers = {
+    ['blueprint'] = true,
+    ['deconstruction-item'] = true,
+}
+
+local is_hidden_entity = function(name)
+    return hidden_entities[name] ~= nil
+end
+
+local function get_player_settings(player_index)
+    local ps = player_settings[player_index]
+    if not ps then
+        local entities = {}
+        for name in pairs(Template.support_beam_entities) do
+            if not is_hidden_entity(name) then
+                entities[name] = true
+            end
+        end
+        ps = {
+            enabled = true,
+            include_tiles = true,
+            entities = entities,
+        }
+        player_settings[player_index] = ps
+    end
+    return ps
+end
+
+local function get_sprite_from_name(name)
+    if TILES[name] then
+        return 'tile.'..name
+    elseif ITEMS[name] then
+        return 'item.'..name
+    elseif ENTITIES[name] then
+        return 'entity.'..name
+    end
+    return 'virtual-signal.signal-deny'
+end
+
+local function get_tooltip_from_name(name)
+    if TILES[name] then
+        return TILES[name].localised_name
+    elseif ITEMS[name] then
+        return ITEMS[name].localised_name
+    elseif ENTITIES[name] then
+        return ENTITIES[name].localised_name
+    end
+    return name
+end
+
+local function on_player_cursor_stack_changed(event)
+    local player = game.get_player(event.player_index)
+    if not player then
+        return
+    end
+
+    -- Regulars+ feature only
+    if Rank.less_than(player.name, required_rank) then
+        return
+    end
+
+    -- Player has hidden the window
+    if not Settings.get(player.index, Public.setting_name) then
+        return Public.toggle_main_frame(player, false)
+    end
+
+    -- Player has empty cursor
+    if player.is_cursor_empty() then
+        return Public.toggle_main_frame(player, false)
+    end
+
+    -- Player is currently using a blueprint record
+    if player.is_cursor_blueprint() then
+        return Public.toggle_main_frame(player, true)
+    end
+
+    -- Player is holding the ghost of an entity
+    -- NOTE: LuaPlayer::cursor_ghost::name returns a LuaItemPrototype when read
+    local ghost_prototype = player.cursor_ghost and player.cursor_ghost.name
+    if ghost_prototype ~= nil then
+        if ENTITIES[ghost_prototype.name] ~= nil then
+            return Public.toggle_main_frame(player, true)
+        end
+    end
+
+    local cursor_stack = player.cursor_stack
+
+    -- Player has invalid cursor
+    if not (cursor_stack and cursor_stack.valid_for_read) then
+        return Public.toggle_main_frame(player, false)
+    end
+
+    -- Player is holding blueprint/decon planner
+    if cursor_stack_triggers[cursor_stack.type] then
+        return Public.toggle_main_frame(player, true)
+    end
+
+    -- Player is holding an entity prototype
+    if ENTITIES[cursor_stack.name] ~= nil then
+        return Public.toggle_main_frame(player, true)
+    end
+end
+
+local function on_marked_for_deconstruction(event)
+    local ps = get_player_settings(event.player_index)
+    if not ps.enabled then
+        return
+    end
+
+    local entity = event.entity
+    local name = entity.name
+
+    if name == 'deconstructible-tile-proxy' then
+        name = entity.surface.get_tile(entity.position.x, entity.position.y).name
+    end
+
+    if is_support_beam(name) and ps.entities[name] then
+        entity.cancel_deconstruction(game.get_player(event.player_index).force)
+    end
+end
+
+local function on_setting_set(event)
+    if event.setting_name ~= Public.setting_name then
+        return
+    end
+
+    if not event.value_changed then
+        return
+    end
+
+    local player = game.get_player(event.player_index)
+    if not player then
+        return
+    end
+
+    Public.toggle_main_frame(player, event.new_value)
+
+    local frame = Gui.get_left_element(player, main_frame_name)
+    Gui.get_data(frame).show_window_checkbox.state = event.new_value
+end
+
+---@param player LuaPlayer
+---@return LuaGuiElement
+Public.get_main_frame = function(player)
+    local frame = Gui.get_left_element(player, main_frame_name)
+    if frame and frame.valid then
+        return frame
+    end
+
+    local data = {}
+    local ps = get_player_settings(player.index)
+    local should_show_gui = Rank.equal_or_greater_than(player.name, required_rank)
+
+    frame = Gui.add_left_element(player, {
+        name = main_frame_name,
+        type = 'frame',
+        direction = 'vertical',
+        caption = 'Blueprint tools',
+        tooltip = 'You can enable/disable this window from RedMew Settings > Show blueprint tools'
+    })
+    Gui.set_style(frame, { maximal_width = 228 })
+
+    local inner = frame
+        .add { type = 'frame', style = 'inside_shallow_frame', direction = 'vertical' }
+        .add { type = 'flow', direction = 'vertical' }
+    Gui.set_style(inner, { padding = 8, vertical_spacing = 4 })
+
+    data.enabled_switch = inner.add {
+        type = 'switch',
+        name = feature_switch_name,
+        caption = 'Feature caption',
+        state = switch_state_map[ps.enabled],
+        left_label_caption = 'On',
+        right_label_caption = 'Off',
+        left_label_tooltip = 'Use safe deconstruction mode',
+        right_label_tooltip = 'Ignore safe deconstruction mode',
+    }
+    Gui.set_data(data.enabled_switch, data)
+
+    data.tiles_checkbox = inner.add {
+        type = 'checkbox',
+        name = tiles_checkbox_name,
+        caption = 'Include tiles',
+        state = ps.include_tiles,
+    }
+    Gui.set_data(data.tiles_checkbox, data)
+
+    data.show_window_checkbox = inner.add {
+        type = 'checkbox',
+        name = show_window_checkbox_name,
+        caption = { 'diggy.blueprint_qol_tooltip' },
+        state = should_show_gui
+    }
+    Gui.set_data(data.show_window_checkbox, data)
+
+    inner.add {
+        type = 'label',
+        style = 'bold_label',
+        caption = 'Protected entities:',
+        tooltip = 'Selected entities will never be marked for deconstruction'
+    }
+
+    data.grid = inner
+        .add { type = 'scroll-pane', style = 'deep_slots_scroll_pane' }
+        .add { type = 'table', column_count = 5, style = 'filter_slot_table' }
+
+    for name, status in pairs(ps.entities) do
+        data.grid.add{ type = 'flow' }.add{
+            type = 'sprite-button',
+            name = entity_button_name,
+            style = 'slot_button',
+            auto_toggle = true,
+            toggled = status,
+            sprite = get_sprite_from_name(name),
+            tags = { name = name },
+            tooltip = get_tooltip_from_name(name),
+        }
+    end
+
+    Gui.set_data(frame, data)
+    frame.visible = should_show_gui
+
+    -- must be set after the frame/inner-frame have been created
+    Settings.set(player.index, Public.setting_name, should_show_gui)
+
+    return frame
+end
+
+---@param player LuaPlayer
+---@param state? boolean
+Public.toggle_main_frame = function(player, state)
+    local frame = Public.get_main_frame(player, main_frame_name)
+    if state == nil then
+        state = not frame.visible
+    end
+    if frame.visible == state then
+        return
+    end
+
+    frame.visible = state
+    if frame.visible then
+        -- faster to swap children order rather that redrawing gui on every cursor change event
+        local parent = frame.parent
+        parent.swap_children(frame.get_index_in_parent(), #parent.children)
+    end
+end
+
+Public.register = function()
+    Settings.register(Public.setting_name, Settings.types.boolean, true, Public.setting_tooltip)
+    Event.add(Settings.events.on_setting_set, on_setting_set)
+
+    Event.add(defines.events.on_player_cursor_stack_changed, on_player_cursor_stack_changed)
+    Event.add(defines.events.on_marked_for_deconstruction, on_marked_for_deconstruction)
+
+    Gui.on_switch_state_changed(feature_switch_name, function(event)
+        local state = switch_state_map[event.element.switch_state]
+        get_player_settings(event.player_index).enabled = state
+
+        local grid = Gui.get_data(event.element).grid
+        for _, child in pairs(grid.children) do
+            child.children[1].enabled = state
+        end
+    end)
+
+    Gui.on_checked_state_changed(tiles_checkbox_name, function(event)
+        local state = event.element.state
+        local entities = get_player_settings(event.player_index).entities
+
+        for name in pairs(entities) do
+            if prototypes.tile[name] then
+                entities[name] = state
+            end
+        end
+
+        local grid = Gui.get_data(event.element).grid
+        for _, child in pairs(grid.children) do
+            local elem = child.children[1]
+            elem.toggled = entities[elem.tags.name]
+        end
+    end)
+
+    Gui.on_checked_state_changed(show_window_checkbox_name, function(event)
+        Settings.set(event.player_index, Public.setting_name, event.element.state)
+    end)
+
+    Gui.on_click(entity_button_name, function(event)
+        get_player_settings(event.player_index).entities[event.element.tags.name] = event.element.toggled
+    end)
+end
+
+return Public

--- a/map_gen/maps/diggy/feature/blueprint_tools.lua
+++ b/map_gen/maps/diggy/feature/blueprint_tools.lua
@@ -277,7 +277,7 @@ local function get_admin_main_frame(_, player)
         Gui.set_style(online.parent, { horizontally_stretchable = true })
 
         local grid = inner
-            .add { type = 'scroll-pane' }
+            .add { type = 'scroll-pane', style = 'naked_scroll_pane' }
             .add { type = 'table', style = 'table_with_selection', column_count = 4 }
 
         local function make_rank(name)
@@ -305,6 +305,7 @@ local function get_admin_main_frame(_, player)
             local list = grid
                 .add { type = 'scroll-pane', style = 'naked_scroll_pane' }
                 .add { type = 'table', column_count = 10, style = 'filter_slot_table' }
+            list.parent.horizontal_scroll_policy = 'never'
 
             for name, status in pairs(ps.entities) do
                 list.add{ type = 'flow' }.add{

--- a/map_gen/maps/diggy/feature/blueprint_tools.lua
+++ b/map_gen/maps/diggy/feature/blueprint_tools.lua
@@ -16,6 +16,7 @@
     - turn On/Off individual entities
 ]]
 
+local Command = require 'utils.command'
 local Event = require 'utils.event'
 local Global = require 'utils.global'
 local Gui = require 'utils.gui'
@@ -35,6 +36,11 @@ local feature_switch_name = Gui.uid_name()
 local entity_button_name = Gui.uid_name()
 local tiles_checkbox_name = Gui.uid_name()
 local show_window_checkbox_name = Gui.uid_name()
+
+local admin_main_frame_name = Gui.uid_name()
+local admin_feature_switch_name = Gui.uid_name()
+local admin_entity_button_name = Gui.uid_name()
+local admin_close_button_name = Gui.uid_name()
 
 local Public = {
     setting_name = 'diggy_blueprint_tools',
@@ -128,7 +134,7 @@ local function on_player_cursor_stack_changed(event)
 
     -- Regulars+ feature only
     if Rank.less_than(player.name, required_rank) then
-        return
+        return Public.toggle_main_frame(player, false)
     end
 
     -- Player has hidden the window
@@ -171,14 +177,11 @@ local function on_player_cursor_stack_changed(event)
     if ENTITIES[cursor_stack.name] ~= nil then
         return Public.toggle_main_frame(player, true)
     end
+
+    Public.toggle_main_frame(player, false)
 end
 
 local function on_marked_for_deconstruction(event)
-    local ps = get_player_settings(event.player_index)
-    if not ps.enabled then
-        return
-    end
-
     local entity = event.entity
     local name = entity.name
 
@@ -186,17 +189,8 @@ local function on_marked_for_deconstruction(event)
         name = entity.surface.get_tile(entity.position.x, entity.position.y).name
     end
 
-    if is_support_beam(name) and ps.entities[name] then
-        entity.cancel_deconstruction(game.get_player(event.player_index).force)
-    end
-end
-
-local function on_setting_set(event)
-    if event.setting_name ~= Public.setting_name then
-        return
-    end
-
-    if not event.value_changed then
+    -- Entity is not a support
+    if not is_support_beam(name) then
         return
     end
 
@@ -205,10 +199,142 @@ local function on_setting_set(event)
         return
     end
 
-    Public.toggle_main_frame(player, event.new_value)
+    -- Regular+ feature only
+    if Rank.less_than(player.name, required_rank) then
+        return entity.cancel_deconstruction(player.force)
+    end
+
+    local ps = get_player_settings(player.index)
+    if not ps.enabled then
+        return
+    end
+
+    -- Entity is not marked to keep safe
+    if not ps.entities[name] then
+        return
+    end
+
+    entity.cancel_deconstruction(player.force)
+end
+
+local function on_setting_set(event)
+    if event.setting_name ~= Public.setting_name then
+        return
+    end
+
+    local player = game.get_player(event.player_index)
+    if not player then
+        return
+    end
+
+    local should_show_gui = Rank.equal_or_greater_than(player.name, required_rank) and event.new_value and event.value_changed
+    Public.toggle_main_frame(player, should_show_gui)
 
     local frame = Gui.get_left_element(player, main_frame_name)
-    Gui.get_data(frame).show_window_checkbox.state = event.new_value
+    Gui.get_data(frame).show_window_checkbox.state = should_show_gui
+end
+
+local function get_admin_main_frame(_, player)
+    local frame = player.gui.screen[admin_main_frame_name]
+    if frame and frame.valid then
+        Gui.destroy(frame)
+    end
+
+    frame = player.gui.screen.add {
+        type = 'frame',
+        name = admin_main_frame_name,
+        direction = 'vertical',
+    }
+    Gui.set_style(frame, { maximal_height = 930 })
+
+    do -- Header
+        local header = frame.add { type = 'flow', direction = 'horizontal' }
+        Gui.set_style(header, { horizontal_spacing = 8, vertical_align = 'center', bottom_padding = 4 })
+
+        local label = header.add { type = 'label', caption = 'Blueprint tools management', style = 'frame_title' }
+        label.drag_target = frame
+
+        local dragger = header.add { type = 'empty-widget', style = 'draggable_space_header' }
+        dragger.drag_target = frame
+        Gui.set_style(dragger, { height = 24, horizontally_stretchable = true })
+
+        local button = header.add {
+            type = 'sprite-button',
+            name = admin_close_button_name,
+            sprite = 'utility/close',
+            clicked_sprite = 'utility/close_black',
+            style = 'close_button',
+            tooltip = {'gui.close-instruction'}
+        }
+        Gui.set_data(button, frame)
+    end
+
+    do -- Content
+        local inner = frame.add { type = 'frame', style = 'inside_deep_frame', direction = 'vertical' }
+        local online = inner
+            .add { type = 'frame', style = 'subheader_frame'}
+            .add { type = 'label', caption = ('Online: %d/%d'):format(#game.connected_players, #game.players), style = 'subheader_label' }
+        Gui.set_style(online.parent, { horizontally_stretchable = true })
+
+        local grid = inner
+            .add { type = 'scroll-pane' }
+            .add { type = 'table', style = 'table_with_selection', column_count = 4 }
+
+        local function make_rank(name)
+            local label = grid.add { type = 'label', caption = Rank.get_player_rank_name(name) }
+            Gui.set_style(label, { font_color = Rank.get_player_rank_color(name) })
+        end
+
+        local function make_switch(index)
+            local ps = get_player_settings(index)
+            grid.add { type = 'flow' }.add {
+                type = 'switch',
+                name = admin_feature_switch_name,
+                switch_state = switch_state_map[ps.enabled],
+                left_label_caption = 'On',
+                right_label_caption = 'Off',
+                left_label_tooltip = 'Use safe deconstruction mode',
+                right_label_tooltip = 'Ignore safe deconstruction mode',
+                tags = { index = index },
+            }
+        end
+
+        local function make_list(index)
+            local ps = get_player_settings(index)
+
+            local list = grid
+                .add { type = 'scroll-pane', style = 'naked_scroll_pane' }
+                .add { type = 'table', column_count = 10, style = 'filter_slot_table' }
+
+            for name, status in pairs(ps.entities) do
+                list.add{ type = 'flow' }.add{
+                    type = 'sprite-button',
+                    name = admin_entity_button_name,
+                    style = 'slot_button',
+                    auto_toggle = true,
+                    toggled = status,
+                    sprite = get_sprite_from_name(name),
+                    tags = { name = name, index = index },
+                    tooltip = get_tooltip_from_name(name),
+                }
+            end
+        end
+
+        grid.add { type = 'label', caption = 'Name' }
+        grid.add { type = 'label', caption = 'Rank' }
+        grid.add { type = 'label', caption = 'Status' }
+        grid.add { type = 'label', caption = 'Entities' }
+
+        for index, p in pairs(game.players) do
+            grid.add { type = 'label', caption = p.name }
+            make_rank(p.name)
+            make_switch(index)
+            make_list(index)
+        end
+    end
+
+    frame.force_auto_center()
+    player.opened = frame
 end
 
 ---@param player LuaPlayer
@@ -227,10 +353,15 @@ Public.get_main_frame = function(player)
         name = main_frame_name,
         type = 'frame',
         direction = 'vertical',
-        caption = 'Blueprint tools',
-        tooltip = 'You can enable/disable this window from RedMew Settings > Show blueprint tools'
     })
     Gui.set_style(frame, { maximal_width = 228 })
+
+    frame.add {
+        type = 'label',
+        style = 'frame_title',
+        caption = 'Blueprint tools [img=info]',
+        tooltip = 'You can enable/disable this window from \nRedMew Settings > Show blueprint tools'
+    }
 
     local inner = frame
         .add { type = 'frame', style = 'inside_shallow_frame', direction = 'vertical' }
@@ -241,7 +372,7 @@ Public.get_main_frame = function(player)
         type = 'switch',
         name = feature_switch_name,
         caption = 'Feature caption',
-        state = switch_state_map[ps.enabled],
+        switch_state = switch_state_map[ps.enabled],
         left_label_caption = 'On',
         right_label_caption = 'Off',
         left_label_tooltip = 'Use safe deconstruction mode',
@@ -261,7 +392,7 @@ Public.get_main_frame = function(player)
         type = 'checkbox',
         name = show_window_checkbox_name,
         caption = { 'diggy.blueprint_tools_tooltip' },
-        state = should_show_gui
+        state = Settings.get(player.index, Public.setting_name)
     }
     Gui.set_data(data.show_window_checkbox, data)
 
@@ -286,14 +417,12 @@ Public.get_main_frame = function(player)
             sprite = get_sprite_from_name(name),
             tags = { name = name },
             tooltip = get_tooltip_from_name(name),
+            enabled = ps.enabled,
         }
     end
 
     Gui.set_data(frame, data)
     frame.visible = should_show_gui
-
-    -- must be set after the frame/inner-frame have been created
-    Settings.set(player.index, Public.setting_name, should_show_gui)
 
     return frame
 end
@@ -357,6 +486,53 @@ Public.register = function()
 
     Gui.on_click(entity_button_name, function(event)
         get_player_settings(event.player_index).entities[event.element.tags.name] = event.element.toggled
+    end)
+
+    Command.add(
+        'blueprint-tools',
+        {
+            description = { 'command_description.blueprint_tools' },
+            required_rank = Ranks.moderator,
+            allowed_by_server = false,
+        },
+        get_admin_main_frame
+    )
+
+    Gui.on_click(admin_close_button_name, function(event)
+        Gui.destroy(Gui.get_data(event.element))
+    end)
+
+    Gui.on_custom_close(admin_main_frame_name, function(event)
+        Gui.destroy(event.element)
+    end)
+
+    Gui.on_switch_state_changed(admin_feature_switch_name, function(event)
+        local state = switch_state_map[event.element.switch_state]
+        local player_index = event.element.tags.index
+        get_player_settings(player_index).enabled = state
+
+        local target = game.get_player(player_index)
+        if not target then
+            return
+        end
+        local frame = Gui.get_left_element(target, main_frame_name)
+        if frame then
+            Gui.destroy(frame)
+        end
+    end)
+
+    Gui.on_click(admin_entity_button_name, function(event)
+        local player_index = event.element.tags.index
+        get_player_settings(player_index).entities[event.element.tags.name] = event.element.toggled
+
+        local target = game.get_player(player_index)
+        if not target then
+            return
+        end
+        local frame = Gui.get_left_element(target, main_frame_name)
+        if frame then
+            Gui.destroy(frame)
+        end
     end)
 end
 

--- a/map_gen/maps/diggy/feature/blueprint_tools.lua
+++ b/map_gen/maps/diggy/feature/blueprint_tools.lua
@@ -194,7 +194,9 @@ local function on_marked_for_deconstruction(event)
         return
     end
 
-    local player = game.get_player(event.player_index)
+    local player = event.player_index and game.get_player(event.player_index)
+    -- NOTE: The only case when a support beam is marked for deconstruction AND there's no player_index
+    -- is when player bots-mine rocks and bots have to re-iterate over the rock to fully mine it
     if not player then
         return
     end

--- a/map_gen/maps/diggy/feature/blueprint_tools.lua
+++ b/map_gen/maps/diggy/feature/blueprint_tools.lua
@@ -37,8 +37,8 @@ local tiles_checkbox_name = Gui.uid_name()
 local show_window_checkbox_name = Gui.uid_name()
 
 local Public = {
-    setting_name = 'diggy_blueprint_qol',
-    setting_tooltip = 'diggy.blueprint_qol_tooltip'
+    setting_name = 'diggy_blueprint_tools',
+    setting_tooltip = 'diggy.blueprint_tools_tooltip'
 }
 
 ---@class PlayerSettingsData
@@ -260,7 +260,7 @@ Public.get_main_frame = function(player)
     data.show_window_checkbox = inner.add {
         type = 'checkbox',
         name = show_window_checkbox_name,
-        caption = { 'diggy.blueprint_qol_tooltip' },
+        caption = { 'diggy.blueprint_tools_tooltip' },
         state = should_show_gui
     }
     Gui.set_data(data.show_window_checkbox, data)

--- a/map_gen/maps/diggy/feature/blueprint_tools.lua
+++ b/map_gen/maps/diggy/feature/blueprint_tools.lua
@@ -1,18 +1,18 @@
 --[[
     Blueprint tools for Diggy
 
-    Support beams (tiles and special entities) cannot be marked for deconstruction by default (antigrief/safety feature)
-    Regulars and above will have access to this feature to turn On/Off the safety measure however they prefer.
-    The feature will automatically popup whener the player is about to perform a "blueprint action", which is:
+    Support beams (tiles and special entities) cannot be marked for deconstruction by default (antigrief/safety feature).
+    Regulars and above will have access to this tool to turn On/Off the safety measure however they prefer.
+    The feature will automatically popup whenever the player is about to perform a "blueprint action", which is:
     - using a blueprint record
     - using a blueprint book
     - setting up a blueprint from map
     - holding a blueprintable item-entity in hand
 
     Players can:
-    - turn On/Off the safety measure all toghether
+    - turn On/Off the safety measure all together
     - turn On/Off tiles in bulk
-    - Show/Hide the popupw window (from this window or RedMew "Settings > Show blueprint tools")
+    - Show/Hide the popup window (from this window or RedMew "Settings > Show blueprint tools")
     - turn On/Off individual entities
 ]]
 

--- a/map_gen/maps/diggy/feature/diggy_cave_collapse.lua
+++ b/map_gen/maps/diggy/feature/diggy_cave_collapse.lua
@@ -28,6 +28,8 @@ local clear_table = table.clear_table
 local collapse_rocks = Template.diggy_rocks
 local collapse_rocks_size = #collapse_rocks
 local cave_collapses_name = 'cave-collapses'
+local support_beam_entities = Template.support_beam_entities
+local is_support_beam = Template.is_support_beam
 
 -- this
 local DiggyCaveCollapse = {}
@@ -55,7 +57,6 @@ local stress_map_add
 local mask_disc_blur
 local mask_init
 local stress_map_check_stress_in_threshold
-local support_beam_entities
 local on_surface_created
 
 local stress_threshold_causing_collapse = 3.57
@@ -114,7 +115,7 @@ local function create_collapse_template(positions, surface)
         for _, entity in pairs(find_entities_filtered({area = {position, {x + 1, y + 1}}})) do
             pcall(
                 function()
-                    local strength = support_beam_entities[entity.name]
+                    local strength = is_support_beam(entity.name)
                     if strength then
                         do_insert = false
                     else
@@ -365,28 +366,10 @@ function DiggyCaveCollapse.register(cfg)
     global_to_show[#global_to_show + 1] = cave_collapses_name
 
     config = cfg
-    support_beam_entities = config.support_beam_entities
 
-    if support_beam_entities['stone-path'] then
-        support_beam_entities['stone-brick'] = support_beam_entities['stone-path']
-    else
-        support_beam_entities['stone-brick'] = nil
-    end
-
-    if support_beam_entities['hazard-concrete'] then
-        support_beam_entities['hazard-concrete-left'] = support_beam_entities['hazard-concrete']
-        support_beam_entities['hazard-concrete-right'] = support_beam_entities['hazard-concrete']
-    else
-        support_beam_entities['hazard-concrete-left'] = nil
-        support_beam_entities['hazard-concrete-right'] = nil
-    end
-
-    if support_beam_entities['refined-hazard-concrete'] then
-        support_beam_entities['refined-hazard-concrete-left'] = support_beam_entities['refined-hazard-concrete']
-        support_beam_entities['refined-hazard-concrete-right'] = support_beam_entities['refined-hazard-concrete']
-    else
-        support_beam_entities['refined-hazard-concrete-left'] = nil
-        support_beam_entities['refined-hazard-concrete-right'] = nil
+    -- override custom support beam entities from scenario
+    for k, v in pairs(cfg.support_beam_entities) do
+        support_beam_entities[k] = v
     end
 
     Event.add(DiggyCaveCollapse.events.on_collapse_triggered, on_collapse_triggered)
@@ -410,18 +393,6 @@ function DiggyCaveCollapse.register(cfg)
     Event.add(Template.events.on_void_removed, on_void_removed)
     Event.add(defines.events.on_surface_created, on_surface_created)
 
-    Event.add(defines.events.on_marked_for_deconstruction, function(event)
-        local entity = event.entity
-        local name = entity.name
-        if is_diggy_rock(name) then
-            return
-        end
-
-        if name == 'deconstructible-tile-proxy' or nil ~= support_beam_entities[name] then
-            entity.cancel_deconstruction(game.get_player(event.player_index).force)
-        end
-    end)
-
     Event.add(defines.events.on_player_created, function(event)
         show_deconstruction_alert_message[event.player_index] = true
     end)
@@ -436,7 +407,7 @@ function DiggyCaveCollapse.register(cfg)
             return
         end
 
-        if (nil ~= support_beam_entities[event.entity.name]) then
+        if is_support_beam(event.entity.name) then
             Popup.player(game.get_player(player_index), {'diggy.cave_collapse_warning'})
             show_deconstruction_alert_message[player_index] = nil
         end

--- a/map_gen/maps/diggy/presets/danger_ores.lua
+++ b/map_gen/maps/diggy/presets/danger_ores.lua
@@ -99,9 +99,9 @@ local config = {
             }
         },
         -- adds some QoL helpers for trusted user to use blueprints withing Diggy's fragile contraints
-        blueprint_qol = {
+        blueprint_tools = {
             enabled = true,
-            load = function() return require('map_gen.maps.diggy.feature.blueprint_qol') end,
+            load = function() return require('map_gen.maps.diggy.feature.blueprint_tools') end,
         },
         -- Adds the ability to drop coins and track how many are sent into space
         coin_gathering = {

--- a/map_gen/maps/diggy/presets/danger_ores.lua
+++ b/map_gen/maps/diggy/presets/danger_ores.lua
@@ -92,23 +92,16 @@ local config = {
             collapse_delay = 2.5,
             -- the threshold that will be applied to all neighbors on a collapse via a mask
             collapse_threshold_total_strength = 16,
-            support_beam_entities = {
-                ['market'] = 9,
-                ['nuclear-reactor'] = 4,
-                ['stone-wall'] = 3,
-                ['big-rock'] = 2,
-                ['huge-rock'] = 2.5,
-                ['out-of-map'] = 1,
-                ['stone-path'] = 0.03,
-                ['concrete'] = 0.04,
-                ['hazard-concrete'] = 0.04,
-                ['refined-concrete'] = 0.06,
-                ['refined-hazard-concrete'] = 0.06
-            },
+            support_beam_entities = {},
             cracking_sounds = {
                 {'diggy.cracking_sound_1'},
                 {'diggy.cracking_sound_2'}
             }
+        },
+        -- adds some QoL helpers for trusted user to use blueprints withing Diggy's fragile contraints
+        blueprint_qol = {
+            enabled = true,
+            load = function() return require('map_gen.maps.diggy.feature.blueprint_qol') end,
         },
         -- Adds the ability to drop coins and track how many are sent into space
         coin_gathering = {

--- a/map_gen/maps/diggy/presets/danger_ores_BnB.lua
+++ b/map_gen/maps/diggy/presets/danger_ores_BnB.lua
@@ -99,9 +99,9 @@ local config = {
             }
         },
         -- adds some QoL helpers for trusted user to use blueprints withing Diggy's fragile contraints
-        blueprint_qol = {
+        blueprint_tools = {
             enabled = true,
-            load = function() return require('map_gen.maps.diggy.feature.blueprint_qol') end,
+            load = function() return require('map_gen.maps.diggy.feature.blueprint_tools') end,
         },
         -- Adds the ability to drop coins and track how many are sent into space
         coin_gathering = {

--- a/map_gen/maps/diggy/presets/danger_ores_BnB.lua
+++ b/map_gen/maps/diggy/presets/danger_ores_BnB.lua
@@ -92,23 +92,16 @@ local config = {
             collapse_delay = 2.5,
             -- the threshold that will be applied to all neighbors on a collapse via a mask
             collapse_threshold_total_strength = 16,
-            support_beam_entities = {
-                ['market'] = 9,
-                ['nuclear-reactor'] = 4,
-                ['stone-wall'] = 3,
-                ['big-rock'] = 2,
-                ['huge-rock'] = 2.5,
-                ['out-of-map'] = 1,
-                ['stone-path'] = 0.03,
-                ['concrete'] = 0.04,
-                ['hazard-concrete'] = 0.04,
-                ['refined-concrete'] = 0.06,
-                ['refined-hazard-concrete'] = 0.06
-            },
+            support_beam_entities = {},
             cracking_sounds = {
                 {'diggy.cracking_sound_1'},
                 {'diggy.cracking_sound_2'}
             }
+        },
+        -- adds some QoL helpers for trusted user to use blueprints withing Diggy's fragile contraints
+        blueprint_qol = {
+            enabled = true,
+            load = function() return require('map_gen.maps.diggy.feature.blueprint_qol') end,
         },
         -- Adds the ability to drop coins and track how many are sent into space
         coin_gathering = {

--- a/map_gen/maps/diggy/presets/normal.lua
+++ b/map_gen/maps/diggy/presets/normal.lua
@@ -99,9 +99,9 @@ local config = {
             }
         },
         -- adds some QoL helpers for trusted user to use blueprints withing Diggy's fragile contraints
-        blueprint_qol = {
+        blueprint_tools = {
             enabled = true,
-            load = function() return require('map_gen.maps.diggy.feature.blueprint_qol') end,
+            load = function() return require('map_gen.maps.diggy.feature.blueprint_tools') end,
         },
         -- Adds the ability to drop coins and track how many are sent into space
         coin_gathering = {

--- a/map_gen/maps/diggy/presets/normal.lua
+++ b/map_gen/maps/diggy/presets/normal.lua
@@ -92,23 +92,16 @@ local config = {
             collapse_delay = 2.5,
             -- the threshold that will be applied to all neighbors on a collapse via a mask
             collapse_threshold_total_strength = 16,
-            support_beam_entities = {
-                ['market'] = 9,
-                ['nuclear-reactor'] = 4,
-                ['stone-wall'] = 3,
-                ['big-rock'] = 2,
-                ['huge-rock'] = 2.5,
-                ['out-of-map'] = 1,
-                ['stone-path'] = 0.03,
-                ['concrete'] = 0.04,
-                ['hazard-concrete'] = 0.04,
-                ['refined-concrete'] = 0.06,
-                ['refined-hazard-concrete'] = 0.06
-            },
+            support_beam_entities = {},
             cracking_sounds = {
                 {'diggy.cracking_sound_1'},
                 {'diggy.cracking_sound_2'}
             }
+        },
+        -- adds some QoL helpers for trusted user to use blueprints withing Diggy's fragile contraints
+        blueprint_qol = {
+            enabled = true,
+            load = function() return require('map_gen.maps.diggy.feature.blueprint_qol') end,
         },
         -- Adds the ability to drop coins and track how many are sent into space
         coin_gathering = {

--- a/map_gen/maps/diggy/template.lua
+++ b/map_gen/maps/diggy/template.lua
@@ -190,4 +190,49 @@ function Template.is_diggy_rock(entity_name)
     return (entity_name == 'big-rock') or (entity_name == 'huge-rock')
 end
 
+
+local support_beam_entities = {
+    ['market'] = 9,
+    ['nuclear-reactor'] = 4,
+    ['stone-wall'] = 3,
+    ['big-rock'] = 2,
+    ['huge-rock'] = 2.5,
+    ['out-of-map'] = 1,
+    ['stone-path'] = 0.03,
+    ['concrete'] = 0.04,
+    ['hazard-concrete'] = 0.04,
+    ['refined-concrete'] = 0.06,
+    ['refined-hazard-concrete'] = 0.06
+}
+
+do
+    if support_beam_entities['stone-path'] then
+        support_beam_entities['stone-brick'] = support_beam_entities['stone-path']
+    else
+        support_beam_entities['stone-brick'] = nil
+    end
+
+    if support_beam_entities['hazard-concrete'] then
+        support_beam_entities['hazard-concrete-left'] = support_beam_entities['hazard-concrete']
+        support_beam_entities['hazard-concrete-right'] = support_beam_entities['hazard-concrete']
+    else
+        support_beam_entities['hazard-concrete-left'] = nil
+        support_beam_entities['hazard-concrete-right'] = nil
+    end
+
+    if support_beam_entities['refined-hazard-concrete'] then
+        support_beam_entities['refined-hazard-concrete-left'] = support_beam_entities['refined-hazard-concrete']
+        support_beam_entities['refined-hazard-concrete-right'] = support_beam_entities['refined-hazard-concrete']
+    else
+        support_beam_entities['refined-hazard-concrete-left'] = nil
+        support_beam_entities['refined-hazard-concrete-right'] = nil
+    end
+end
+
+Template.support_beam_entities = support_beam_entities
+
+function Template.is_support_beam(name)
+    return support_beam_entities[name] ~= nil
+end
+
 return Template


### PR DESCRIPTION
This PR adds Blueprint tools for Diggy scenario.

## Context & feature explanation
Support beams (tiles and special entities) cannot be marked for deconstruction by default (antigrief/safety feature)
Regulars and above will have access to this new feature to turn On/Off the safety measure however they prefer.
The feature will automatically popup whenever the player is about to perform a "blueprint action", which is:
- using a blueprint record
- using a blueprint book
- setting up a blueprint from map
- holding a blueprintable item-entity in hand

Players can:
- turn On/Off the safety measure all together
- turn On/Off tiles in bulk
- Show/Hide the popup window (from this window or RedMew "Settings > Show blueprint tools")
- turn On/Off individual entities

Here's a quick demo that goes through the various settings/cases:

![Demo video](https://github.com/user-attachments/assets/8de85585-f299-4f8f-ab7e-0cf6bf22d608)

# Changes:
- moved support beams definition from presets to template
- moved `on_marked_for_deconstruction` handler from `diggy_cave_collapse` to BP Tool module
- BP Tool is now responsible for the antigrief feature all together

Arguably, `diggy_cave_collapse` module could force require this module or I could have included this logic in `diggy_cave_collapse` to begin with, but I thought if would have been cleaner to detach the antigrief/tool logic on its own module as it handles a lot of Gui events rather than game actions.