### PR TITLE
Fix exchanges for values < 1

### DIFF
--- a/features/market_chest.lua
+++ b/features/market_chest.lua
@@ -68,10 +68,15 @@ local function update_entity(entity)
     return
   end
 
+  local to_remove = floor(o_count / ratio)
+  if to_remove < 1 then
+    return
+  end
+
   local removed = inv.remove {
     name = request,
     quality = request.quality,
-    count = o_count / ratio,
+    count = to_remove,
   }
   if removed > 0 then
     local inserted = inv.insert {


### PR DESCRIPTION
Trying to remove counts between 0 and 1 would raise a silent error.
If minimal count of 1 is not reached, then function early returns just like with 0 checks.