### PR TITLE
Address exploit of container dump module

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -590,11 +590,11 @@ storage.config = {
         market_provides_chests = true,
         -- What market provides
         offers = {
-            ['coal'] = 2,
-            ['copper-ore'] = 2,
-            ['iron-ore'] = 2,
-            ['stone'] = 2,
-            ['uranium-ore'] = 10,
+            ['coal'] = 5,
+            ['copper-ore'] = 5,
+            ['iron-ore'] = 5,
+            ['stone'] = 5,
+            ['uranium-ore'] = 25,
         },
         -- What market requests
         requests = {

--- a/features/gui/experience.lua
+++ b/features/gui/experience.lua
@@ -483,7 +483,7 @@ local function on_entity_died(event)
 
         -- stuff killed by the player force, but not the player
         if force and force.name == 'player' then
-            if cause and (cause.name == 'artillery-turret' or cause.name == 'gun-turret' or cause.name == 'laser-turret' or cause.name == 'flamethrower-turret') then
+            if cause and cause.valid and (cause.name == 'artillery-turret' or cause.name == 'gun-turret' or cause.name == 'laser-turret' or cause.name == 'flamethrower-turret') then
                 exp = config.XP['enemy_killed'] * (config.alien_experience_modifiers[entity_name] or 1)
                 floating_text_position = cause.position
             else

--- a/map_gen/maps/danger_ores/modules/container_dump.lua
+++ b/map_gen/maps/danger_ores/modules/container_dump.lua
@@ -1,11 +1,14 @@
 local Event = require 'utils.event'
 local Global = require 'utils.global'
 local math = require 'utils.math'
+local Token = require 'utils.token'
+local Task = require 'utils.task'
 
 local floor = math.floor
 local max = math.max
 
 local chest = defines.inventory.chest
+local stun_sticker_duration = 3 -- seconds
 
 local died_entities = {}
 
@@ -43,108 +46,135 @@ local cause_by_type = {
     end,
 }
 
+local stun_player_callback
+stun_player_callback = Token.register(function(data)
+    local entity = data.entity
+    if not entity.valid then
+        return
+    end
+
+    local time_to_live = data.time_to_live
+    if time_to_live <= 0 then
+        return
+    end
+
+    data.time_to_live = time_to_live - stun_sticker_duration
+    entity.surface.create_entity {
+        name = 'stun-sticker',
+        target = entity,
+        position = entity.position,
+    }
+    Task.set_timeout(stun_sticker_duration, stun_player_callback, data)
+end)
+
+---@param config table
+---@field entity_name? string, resource to be spawned (default: coal)
+---@field time_penalty? number, time lost by the player when misbehaving (default: 18s, 0 to apply none)
 Public.register = function(config)
     local entity_name = config.entity_name or 'coal'
-    Event.add(
-        defines.events.on_entity_died,
-        function(event)
-            local entity = event.entity
+    local time_penalty = config.time_penalty or 18
 
-            if not entity.valid then
-                return
-            end
+    Event.add(defines.events.on_entity_died, function(event)
+        local entity = event.entity
 
-            local type = entity.type
-            if type ~= 'container' and type ~= 'logistic-container' then
-                return
-            end
-
-            local inventory = entity.get_inventory(chest)
-            if not inventory or not inventory.valid then
-                return
-            end
-
-            local count = 0
-            local deadlock_stack_size = (settings.startup['deadlock-stack-size'] or {}).value or 1
-            local contents = inventory.get_contents()
-            for _, item_stack in pairs(contents) do
-                local real_count
-                if item_stack.name:sub(1, #'deadlock-stack') == 'deadlock-stack' then
-                    real_count = item_stack.count * deadlock_stack_size
-                else
-                    real_count = item_stack.count
-                end
-
-                count = count + real_count
-            end
-
-            if count == 0 then
-                return
-            end
-
-            local area = entity.bounding_box
-            local left_top, right_bottom = area.left_top, area.right_bottom
-            local x1, y1 = floor(left_top.x), floor(left_top.y)
-            local x2, y2 = floor(right_bottom.x), floor(right_bottom.y)
-
-            local size_x = x2 - x1 + 1
-            local size_y = y2 - y1 + 1
-            local amount = floor(count / (size_x * size_y))
-            amount = max(amount, 1)
-
-            local create_entity = entity.surface.create_entity
-
-            for x = x1, x2 do
-                for y = y1, y2 do
-                    create_entity({name = entity_name, position = {x, y}, amount = amount})
-                end
-            end
-
-            died_entities[entity.unit_number] = true
-
-            local cause = event.cause
-            if not (cause and cause.valid and cause.force and cause.force.name == 'player') then
-                return
-            end
-
-            local handler = cause_by_type[cause.type]
-            local actor = handler and handler(cause)
-            if not (actor and actor.valid) then
-                return
-            end
-
-            local character = actor.character
-            if not (character and character.valid) then
-                return
-            end
-
-            actor.print('The ore fights back!', { color = { 255, 128, 0 } })
-            character.die(game.forces.neutral)
+        if not entity.valid then
+            return
         end
-    )
 
-    Event.add(
-        defines.events.on_post_entity_died,
-        function(event)
-            local unit_number = event.unit_number
-            if not unit_number then
-                return
-            end
-
-            if not died_entities[unit_number] then
-                return
-            end
-
-            died_entities[unit_number] = nil
-
-            local ghost = event.ghost
-            if not ghost or not ghost.valid then
-                return
-            end
-
-            ghost.destroy()
+        local type = entity.type
+        if type ~= 'container' and type ~= 'logistic-container' then
+            return
         end
-    )
+
+        local inventory = entity.get_inventory(chest)
+        if not inventory or not inventory.valid then
+            return
+        end
+
+        local count = 0
+        local deadlock_stack_size = (settings.startup['deadlock-stack-size'] or {}).value or 1
+        local contents = inventory.get_contents()
+        for _, item_stack in pairs(contents) do
+            local real_count
+            if item_stack.name:sub(1, #'deadlock-stack') == 'deadlock-stack' then
+                real_count = item_stack.count * deadlock_stack_size
+            else
+                real_count = item_stack.count
+            end
+
+            count = count + real_count
+        end
+
+        if count == 0 then
+            return
+        end
+
+        local area = entity.bounding_box
+        local left_top, right_bottom = area.left_top, area.right_bottom
+        local x1, y1 = floor(left_top.x), floor(left_top.y)
+        local x2, y2 = floor(right_bottom.x), floor(right_bottom.y)
+
+        local size_x = x2 - x1 + 1
+        local size_y = y2 - y1 + 1
+        local amount = floor(count / (size_x * size_y))
+        amount = max(amount, 1)
+
+        local create_entity = entity.surface.create_entity
+
+        for x = x1, x2 do
+            for y = y1, y2 do
+                create_entity({name = entity_name, position = {x, y}, amount = amount})
+            end
+        end
+
+        died_entities[entity.unit_number] = true
+
+        local cause = event.cause
+        if not (cause and cause.valid and cause.force and cause.force.name == 'player') then
+            return
+        end
+
+        local handler = cause_by_type[cause.type]
+        local actor = handler and handler(cause)
+        if not (actor and actor.valid) then
+            return
+        end
+
+        local character = actor.character
+        if not (character and character.valid) then
+            return
+        end
+
+        actor.print('The ore fights back!', { color = { 255, 128, 0 } })
+        Task.set_timeout_in_ticks(1, stun_player_callback, {
+            entity = character,
+            time_to_live = time_penalty,
+        })
+
+        if cause.type == 'car' or cause.type == 'spider-vehicle' then
+            cause.die('neutral')
+        end
+    end)
+
+    Event.add(defines.events.on_post_entity_died, function(event)
+        local unit_number = event.unit_number
+        if not unit_number then
+            return
+        end
+
+        if not died_entities[unit_number] then
+            return
+        end
+
+        died_entities[unit_number] = nil
+
+        local ghost = event.ghost
+        if not ghost or not ghost.valid then
+            return
+        end
+
+        ghost.destroy()
+    end)
 end
 
 return Public

--- a/map_gen/maps/danger_ores/modules/container_dump.lua
+++ b/map_gen/maps/danger_ores/modules/container_dump.lua
@@ -18,6 +18,31 @@ Global.register(
 
 local Public = {}
 
+local cause_by_type = {
+    ['character'] = function(cause)
+        return cause.player
+    end,
+    ['car'] = function(cause)
+        local d = cause.get_driver()
+        if d then
+            return (d.object_name == 'LuaEntity') and d.player or d
+        else
+            return cause.last_user
+        end
+    end,
+    ['spider-vehicle'] = function(cause)
+        local d = cause.get_driver()
+        if d then
+            return (d.object_name == 'LuaEntity') and d.player or d
+        else
+            return cause.last_user
+        end
+    end,
+    ['land-mine'] = function(cause)
+        return cause.last_user
+    end,
+}
+
 Public.register = function(config)
     local entity_name = config.entity_name or 'coal'
     Event.add(
@@ -76,6 +101,25 @@ Public.register = function(config)
             end
 
             died_entities[entity.unit_number] = true
+
+            local cause = event.cause
+            if not (cause and cause.valid and cause.force and cause.force.name == 'player') then
+                return
+            end
+
+            local handler = cause_by_type[cause.type]
+            local actor = handler and handler(cause)
+            if not (actor and actor.valid) then
+                return
+            end
+
+            local character = actor.character
+            if not (character and character.valid) then
+                return
+            end
+
+            actor.print('The ore fights back!', { color = { 255, 128, 0 } })
+            character.die(game.forces.neutral)
         end
     )
 

--- a/map_gen/maps/danger_ores/modules/container_dump.lua
+++ b/map_gen/maps/danger_ores/modules/container_dump.lua
@@ -74,7 +74,7 @@ end)
 Public.register = function(config)
     local entity_name = config.entity_name or 'coal'
     local time_penalty = config.time_penalty or 18
-    local spare_vehicle = config.spare_vehicle or true
+    local spare_vehicle = config.spare_vehicle or false
 
     Event.add(defines.events.on_entity_died, function(event)
         local entity = event.entity

--- a/map_gen/maps/danger_ores/modules/container_dump.lua
+++ b/map_gen/maps/danger_ores/modules/container_dump.lua
@@ -70,9 +70,11 @@ end)
 ---@param config table
 ---@field entity_name? string, resource to be spawned (default: coal)
 ---@field time_penalty? number, time lost by the player when misbehaving (default: 18s, 0 to apply none)
+---@field spare_vehicle? boolean, saves the involved vehicle, if any (default: false)
 Public.register = function(config)
     local entity_name = config.entity_name or 'coal'
     local time_penalty = config.time_penalty or 18
+    local spare_vehicle = config.spare_vehicle or true
 
     Event.add(defines.events.on_entity_died, function(event)
         local entity = event.entity
@@ -151,7 +153,7 @@ Public.register = function(config)
             time_to_live = time_penalty,
         })
 
-        if cause.type == 'car' or cause.type == 'spider-vehicle' then
+        if (not spare_vehicle) and (cause.type == 'car' or cause.type == 'spider-vehicle') then
             cause.die('neutral')
         end
     end)


### PR DESCRIPTION
### Issue: 

Container dump module of Danger Ores can lead to endgame exploit to generate infinite resources from nothing by:
- killing a full chest of copper cables (i.e. running over it with tank)
- (module turns into coal)
- coal is mined with Prod3s
- coal is exchanged with copper-ore at 2:1 ratio
- copper is smelted + crafted into cables with double prod3s bonus
- fill chest back and repeat

<img width="1315" height="939" alt="Screenshot from 2026-02-20 11-55-12" src="https://github.com/user-attachments/assets/ebab1452-e0e1-4516-bc8b-689a97b67310" />

### Solution:

1. Destroying a chest to clear space and void items now also kills the player, making the automation of infinite loop resources very tedious to automate as chests would need to be killed 1 by 1 with respawn cooldowns in between
2. Market offers decreased from 2:1 to 5:1 ratio