### PR TITLE
Update CrashSite outposts

### DIFF
--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -382,11 +382,9 @@ local function draw_market_frame(player, group_name)
         Gui.set_data(button, frame)
     end
 
-    local inner = frame
-        .add { type = 'frame', style = 'entity_frame', direction = 'vertical' } -- entity_frame_filler
+    local inner = frame.add { type = 'frame', style = 'entity_frame', direction = 'vertical' }
     Gui.set_style(inner, { padding = 0 })
 
-    -- table/slot_table
     local scroll_pane = inner.add{ type = 'scroll-pane' }
     Gui.set_style(scroll_pane, { maximal_height = 600, padding = 8, top_padding = 12 })
 

--- a/features/retailer.lua
+++ b/features/retailer.lua
@@ -331,7 +331,7 @@ local function redraw_market_items(data)
             number = stack_count,
             tooltip = tooltip,
         })
-        button.style = 'slot_button'
+        button.style = 'slot_button_in_shallow_frame'
 
         Gui.set_data(button, {index = i, data = data, stack_count = stack_count})
 
@@ -353,21 +353,42 @@ local function redraw_market_items(data)
 end
 
 local function do_coin_label(coin_count, label)
-    label.caption = {'', coin_count, ' ', currency_item_name, ' ', {'common.available'}}
-    label.style.font = 'default-bold'
+    label.caption = { '', coin_count, ' ', currency_item_name, ' ', { 'common.available' } }
 end
 
 local function draw_market_frame(player, group_name)
     local frame = player.gui.center.add({
         type = 'frame',
         name = market_frame_name,
-        caption = Retailer.get_market_group_label(group_name),
         direction = 'vertical',
+        style = 'non_draggable_frame'
     })
 
-    local scroll_pane = frame.add({type = 'scroll-pane'})
-    local scroll_style = scroll_pane.style
-    scroll_style.maximal_height = 600
+    do -- Header
+        local header = frame.add { type = 'flow', direction = 'horizontal' }
+        Gui.set_style(header, { horizontal_spacing = 8, vertical_align = 'center', bottom_padding = 4 })
+
+        header.add { type = 'label', caption = Retailer.get_market_group_label(group_name), style = 'frame_title' }
+        Gui.add_pusher(header)
+
+        local button = header.add {
+            type = 'sprite-button',
+            name = market_frame_close_button_name,
+            sprite = 'utility/close',
+            clicked_sprite = 'utility/close_black',
+            style = 'close_button',
+            tooltip = {'gui.close-instruction'}
+        }
+        Gui.set_data(button, frame)
+    end
+
+    local inner = frame
+        .add { type = 'frame', style = 'entity_frame', direction = 'vertical' } -- entity_frame_filler
+    Gui.set_style(inner, { padding = 0 })
+
+    -- table/slot_table
+    local scroll_pane = inner.add{ type = 'scroll-pane' }
+    Gui.set_style(scroll_pane, { maximal_height = 600, padding = 8, top_padding = 12 })
 
     local grid = scroll_pane.add({type = 'table', column_count = 10})
 
@@ -381,34 +402,41 @@ local function draw_market_frame(player, group_name)
         player_index = player.index,
     }
 
-    local coin_label = frame.add({type = 'label'})
+    local footer = inner.add { type = 'frame', style = 'subheader_frame' }.add { type = 'flow', direction = 'horizontal' }
+    Gui.set_style(footer, { vertical_align = 'center', padding = 4, horizontal_spacing = 8 })
+
+    local coin_label = footer.add { type = 'label', style = 'bold_label' }
     do_coin_label(player_coins, coin_label)
     data.coin_label = coin_label
+    Gui.add_pusher(footer)
 
     redraw_market_items(data)
 
-    local bottom_grid = frame.add({type = 'table', column_count = 2})
+    footer.add{ type = 'label', caption = { '', {'common.quantity'}, ': ' }, style = 'caption_label' }
 
-    bottom_grid.add({type = 'label', caption = {'', {'common.quantity'}, ': '}}).style.font = 'default-bold'
-
-    local count_text = bottom_grid.add({
-        type = 'text-box',
+    local count_text = footer.add {
+        type = 'textfield',
         name = count_text_name,
         text = '1',
-    })
+        numeric = true,
+        allow_decimal = false,
+        allow_negative = false,
+    }
+    Gui.set_style(count_text, { width = 45 })
 
-    local count_slider = frame.add({
+    local count_slider = footer.add {
         type = 'slider',
         name = count_slider_name,
         minimum_value = 1,
         maximum_value = 7,
         value = 1,
-    })
+        style = 'notched_slider',
+    }
+    Gui.set_style(count_slider, { width = 115 })
 
-    frame.add({name = market_frame_close_button_name, type = 'button', caption = 'Close'})
-
-    count_slider.style.width = 115
-    count_text.style.width = 45
+    Gui.add_pusher(footer)
+    local padding = footer.add { type = 'empty-widget' }
+    Gui.set_style(padding, { width = 100 })
 
     data.slider = count_slider
     data.text = count_text

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -686,12 +686,13 @@ local function to_shape(blocks, part_size, on_init)
             top_left = {nil, nil},
             bottom_right = {nil, nil},
             level = 1,
+            maximum_level = nil,
             upgrade_rate = nil,
             upgrade_base_cost = nil,
             upgrade_cost_base = nil,
             artillery_area = nil,
             artillery_turrets = nil,
-            last_fire_tick = nil
+            last_fire_tick = nil,
         }
     end
 
@@ -988,8 +989,12 @@ local function update_market_upgrade_description(outpost_data)
 
     prototype.description = tooltip_str
     prototype.disabled = false
-
     prototype.mapview_description = mapview_str
+
+    if outpost_data.maximum_level and (outpost_data.level >= outpost_data.maximum_level) then
+        prototype.disabled = true
+        prototype.disabled_reason = 'Max level reached.'
+    end
 
     Retailer.set_item(outpost_id, prototype)
 end
@@ -1736,6 +1741,13 @@ Public.market_set_items_callback =
         outpost_data.upgrade_rate = callback_data.upgrade_rate
         outpost_data.upgrade_base_cost = upgrade_base_cost
         outpost_data.upgrade_cost_base = callback_data.upgrade_cost_base
+        if callback_data.maximum_level_count then
+            outpost_data.maximum_level = callback_data.maximum_level
+        end
+        if callback_data.maximum_level_formula then
+            local formula = Token.get(callback_data.maximum_level_formula)
+            outpost_data.maximum_level = formula(callback_data)
+        end
 
         Retailer.add_market(market_id, entity)
         Retailer.set_market_group_label(market_id, callback_data.market_name)

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -1958,8 +1958,10 @@ local function market_selected(event)
 
     local args = {
         text = nil,
-        target = selected,
-        target_offset = nil,
+        target = {
+            entity = selected,
+            offset = nil,
+        },
         alignment = 'center',
         surface = selected.surface,
         color = {1, 1, 1},
@@ -1970,15 +1972,15 @@ local function market_selected(event)
     }
 
     args.text = prototype.name_label
-    args.target_offset = {0, -6.5}
+    args.target.offset = {0, -6.5}
     draw_text(args)
 
     args.text = 'Price: ' .. prototype.price
-    args.target_offset = {0, -5}
+    args.target.offset = {0, -5}
     draw_text(args)
 
     args.text = prototype.mapview_description
-    args.target_offset = {0, -3.5}
+    args.target.offset = {0, -3.5}
     draw_text(args)
 end
 

--- a/map_gen/maps/crash_site/outpost_builder.lua
+++ b/map_gen/maps/crash_site/outpost_builder.lua
@@ -89,6 +89,38 @@ Global.register(
     end
 )
 
+---@class MagicCrafter
+---@field base_rate number
+---@field entity LuaEntity
+---@field item string
+---@field last_tick number
+---@field rate number
+
+---@class MagicFluidCrafter
+---@field base_rate number
+---@field entity LuaEntity
+---@field item string
+---@field last_tick number
+---@field rate number
+---@field fluidbox_index
+
+---@class OutpostData
+---@field outpost_id number, unique identifier for the outpost
+---@field area BoundingBox, area covered by the outpost
+---@field artillery_area? BoundingBox, area covered by artillery
+---@field artillery_turrets? LuaEntity[], table of artillery turrets
+---@field base_outputs table<string, number>, outputs produced by the outpost for upgrades
+---@field last_fire_tick? number, last tick when artillery fired
+---@field level number, current level of the outpost
+---@field magic_crafters MagicCrafter[], table of magic crafters
+---@field magic_fluid_crafters? MagicFluidCrafter[], table of magic fluid crafters
+---@field market LuaEntity, reference to the market entity
+---@field maximum_level? number, maximum level
+---@field turret_count number, number of turrets attached to the outpost
+---@field upgrade_base_cost number, base cost for upgrading
+---@field upgrade_cost_base number, cost multiplier for upgrades
+---@field upgrade_rate number, rate at which the outpost upgrades
+
 --[[ local function get_direction(part)
     local dir = bit32.band(part, direction_bit_mask)
     return bit32.rshift(dir, direction_bit_shift - 1)
@@ -683,8 +715,7 @@ local function to_shape(blocks, part_size, on_init)
             --magic_fluid_crafters = {},
             market = nil,
             turret_count = 0,
-            top_left = {nil, nil},
-            bottom_right = {nil, nil},
+            area = nil,
             level = 1,
             maximum_level = nil,
             upgrade_rate = nil,
@@ -1013,7 +1044,6 @@ local function do_outpost_upgrade(event)
     local level = outpost_data.level + 1
     outpost_data.level = level
 
-
     local player_name = event.player.name
     local outpost_name = Retailer.get_market_group_label(outpost_id)
     local message = concat {player_name, ' has upgraded ', outpost_name, ' to level ', level}
@@ -1085,7 +1115,7 @@ local function find_nearest_player(position)
 end
 
 local function do_capture_outpost(outpost_data)
-    local area = {top_left = outpost_data.top_left, bottom_right = outpost_data.bottom_right}
+    local area = outpost_data.area
     local walls = RS.get_surface().find_entities_filtered {area = area, force = 'enemy', name = 'stone-wall'}
 
     for i = 1, #walls do
@@ -1648,8 +1678,13 @@ Public.wall_callback =
 
         local outpost_id = data.outpost_id
         local outpost_data = outposts[outpost_id]
-        local top_left = outpost_data.top_left
-        local bottom_right = outpost_data.bottom_right
+        local area = outpost_data.area
+        if not area then
+            area = { top_left = {}, bottom_right = {} }
+            outpost_data.area = area
+        end
+        local top_left = area.top_left
+        local bottom_right = area.bottom_right
         local tx, ty = top_left.x, top_left.y
         local bx, by = bottom_right.x, bottom_right.y
 
@@ -1741,10 +1776,9 @@ Public.market_set_items_callback =
         outpost_data.upgrade_rate = callback_data.upgrade_rate
         outpost_data.upgrade_base_cost = upgrade_base_cost
         outpost_data.upgrade_cost_base = callback_data.upgrade_cost_base
-        if callback_data.maximum_level_count then
-            outpost_data.maximum_level = callback_data.maximum_level
-        end
+        outpost_data.maximum_level = callback_data.maximum_level_count
         if callback_data.maximum_level_formula then
+            assert((outpost_data.maximum_level == nil), 'maximum_level has already been defined')
             local formula = Token.get(callback_data.maximum_level_formula)
             outpost_data.maximum_level = formula(callback_data)
         end

--- a/map_gen/maps/crash_site/scenario.lua
+++ b/map_gen/maps/crash_site/scenario.lua
@@ -802,6 +802,10 @@ local function init(config)
 
     map = b.apply_entity(map, ore_grid)
 
+    local spawn_maximum_level_formula = Token.register(function()
+        return game.is_multiplayer() and 6 or nil
+    end)
+
     local market = {
         callback = spawn_callback,
         data = {
@@ -809,6 +813,8 @@ local function init(config)
             upgrade_rate = 0.5,
             upgrade_base_cost = 500,
             upgrade_cost_base = 2,
+            maximum_level_count = nil,
+            maximum_level_formula = spawn_maximum_level_formula,
             {
                 price = 0,
                 stack_limit = 1,
@@ -862,7 +868,6 @@ local function init(config)
                 name_label = {'command_description.crash_site_barrage_radius_name_label', 1},
                 sprite = 'virtual-signal/signal-B',
                 description = {'command_description.crash_site_barrage_radius', 1, 0, 25}
-
             },
             {
                 price = 1000,


### PR DESCRIPTION
# Changes

### A. Add outposts maximum level

`outpost_data` for outpost builder will now also accept 2 optional parameters:
- `maximum_level_count`: number
- `maximum_level_formula`: token id to function callback

Both will try to set `maximum_level` and if set/reached, it wont be possible to upgrade the outpost further.
I have decided to simply disable the upgrade item instead of removing it completely as this option keeps open the possibility to develop further the feature in the future, without adding/removing market item every time.

<img width="774" height="620" alt="Screenshot from 2026-02-23 12-14-23" src="https://github.com/user-attachments/assets/565e4931-3427-4728-a864-890a3c834f35" />

> Following Tigress and CrashSite veteran players feedbacks, Spawn Market in CS has been capped at Lvl.6 for multiplayer events

### B. Fixed that outposts would display rendering text incorrectly
### C. Slight GUI style update to `Retailer`