### PR TITLE
Frontier fixes

### DIFF
--- a/map_gen/maps/frontier/modules/restart.lua
+++ b/map_gen/maps/frontier/modules/restart.lua
@@ -542,9 +542,8 @@ function Restart.print_endgame_statistics()
     local resource_prototypes = prototypes.get_entity_filtered({{ filter = 'type', type = 'resource' }})
     local ore_products = {}
     for _, ore_prototype in pairs(resource_prototypes) do
-      local mineable_properties = ore_prototype.mineable_properties
-      if mineable_properties.minable_flag and ore_prototype.resource_category == 'basic-solid' then
-        for _, product in pairs(mineable_properties.products) do
+      if ore_prototype.resource_category == 'basic-solid' then
+        for _, product in pairs(ore_prototype.mineable_properties.products) do
           ore_products[product.name] = true
         end
       end

--- a/map_gen/maps/frontier/modules/spawn_shop.lua
+++ b/map_gen/maps/frontier/modules/spawn_shop.lua
@@ -387,7 +387,6 @@ function SpawnShop.on_player_purchase(player, id)
     inv.remove(item_stack)
   end
 
-  data.level = data.level + 1
   SpawnShop.upgrade_perk(id)
   SpawnShop.refresh_price(id)
   SpawnShop.update_all_guis()

--- a/map_gen/maps/frontier/modules/terrain.lua
+++ b/map_gen/maps/frontier/modules/terrain.lua
@@ -521,7 +521,14 @@ function Terrain.prepare_next_surface()
   game.print({'frontier.map_setup'})
 
   local surface = Public.surface()
+
+  -- Surface clear up
   surface.clear(true)
+  for _, tag in pairs(game.forces.player.find_chart_tags(surface)) do
+    tag.destroy()
+  end
+
+  -- Seed update
   local mgs = table.deepcopy(surface.map_gen_settings)
   mgs.seed = mgs.seed + 1e4
   surface.map_gen_settings = mgs

--- a/map_gen/maps/frontier/scenario.lua
+++ b/map_gen/maps/frontier/scenario.lua
@@ -47,6 +47,14 @@ ScenarioInfo.set_map_extra_info([[
   In [font=default-bold]Frontier[/font], your wits will be tested as you evolve from a mere survivor to an engineering genius capable of taming the land and launching your final escape. Build a thriving factory, and prepare to conquer both nature and the relentless horde in a race against time. But remember, the frontier waits for no one. Will you make your mark on this alien world or become another lost tale in the void of space?
 ]])
 ScenarioInfo.set_new_info([[
+  2026-06-07:
+    - Removed landfill lock
+    - Increased crude oil frequency, size and richness
+    - Fixed map height not being applied correctly on startup
+    - Fixed map gen settings allowing water tiles
+    - Fixed endgame statistics for ore mined count
+    - Fixed surface tags not being removed on map reset
+    - Fixed purchasing in spawn shop resulting in double the levels
   2024-08-16:
     - Added random markets
     - Added spawn shop


### PR DESCRIPTION
- Fixed endgame statistics for ore mined count
- Fixed surface tags not being removed on map reset
- Fixed purchasing in spawn shop resulting in double the levels