### PR TITLE
Show pass counts in test runner module rows

### DIFF
--- a/utils/test/module_store.lua
+++ b/utils/test/module_store.lua
@@ -19,6 +19,7 @@ local function new_module(module_name)
         is_open = false,
         depth = nil,
         count = nil,
+        pass_count = nil,
         passed = nil
     }
 end

--- a/utils/test/runner.lua
+++ b/utils/test/runner.lua
@@ -20,16 +20,26 @@ end
 local function mark_module_for_passed(module)
     local any_fails = false
     local all_ran = true
+    local pass_count = 0
+    local ran_count = 0
 
     for _, child in pairs(module.children) do
-        local module_any_fails, module_all_ran = mark_module_for_passed(child)
+        local module_any_fails, module_all_ran, module_pass_count, module_ran_count = mark_module_for_passed(child)
         any_fails = any_fails or module_any_fails
         all_ran = all_ran and module_all_ran
+        pass_count = pass_count + module_pass_count
+        ran_count = ran_count + module_ran_count
     end
 
     for _, test in pairs(module.tests) do
         any_fails = any_fails or (test.passed == false)
         all_ran = all_ran and (test.passed ~= nil)
+        if test.passed == true then
+            pass_count = pass_count + 1
+        end
+        if test.passed ~= nil then
+            ran_count = ran_count + 1
+        end
     end
 
     if any_fails then
@@ -40,7 +50,10 @@ local function mark_module_for_passed(module)
         module.passed = nil
     end
 
-    return any_fails, all_ran
+    -- Only show a pass count for modules that have results.
+    module.pass_count = ran_count > 0 and pass_count or nil
+
+    return any_fails, all_ran, pass_count, ran_count
 end
 
 local function mark_modules_for_passed()

--- a/utils/test/viewer.lua
+++ b/utils/test/viewer.lua
@@ -149,8 +149,12 @@ local function draw_tests_test(container, test, depth)
 end
 
 local function draw_tests_module(container, module)
-    local caption = {module.name or 'All Tests', ' (', module.count, ')'}
-    caption = table.concat(caption)
+    local caption
+    if module.pass_count then
+        caption = table.concat({module.name or 'All Tests', ' (', module.pass_count, '/', module.count, ')'})
+    else
+        caption = table.concat({module.name or 'All Tests', ' (', module.count, ')'})
+    end
 
     local flow = container.add {type = 'flow'}
     local arrow =


### PR DESCRIPTION
Module rows in the in-game test viewer showed only the total test count, so a module with a single failure read the same as one that failed entirely — e.g. a red `Gui (17)` where 12 of the 17 actually passed.

After a run, module rows now show `passed/total`, e.g. `Gui (12/17)`. Modules with no results yet keep the plain total, so an unrun module doesn't misleadingly read as `0/17`.

Implementation: `mark_module_for_passed` in the runner already walks the module tree after every run to set the pass/fail colouring, so it now also tallies passed and ran tests per module in the same pass. The viewer uses the tally when present.

## Before

<img width="633" height="468" alt="Screenshot 2026-07-10 at 23 07 49" src="https://github.com/user-attachments/assets/9df4dd72-f339-4f42-b648-3a0bda797f51" />

## After

<img width="619" height="425" alt="Screenshot 2026-07-10 at 23 08 27" src="https://github.com/user-attachments/assets/5e9c93ca-61e0-49d4-8657-d93a3bdacb58" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)